### PR TITLE
Bugfix/compatj1.5

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        julia-version: [latest]
+        julia-version: [1.5.1]
         # julia-arch: [x64, x86]
         julia-arch: [x64]
         # os: [ubuntu-latest, windows-latest, macOS-latest]

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -6,6 +6,7 @@ on:
       - master
       - develop
       - 'feature/**'
+      - 'bugfix/**'
     tags: '*'
   pull_request:
     branches:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        julia-version: [1.4.1]
+        julia-version: [latest]
         # julia-arch: [x64, x86]
         julia-arch: [x64]
         # os: [ubuntu-latest, windows-latest, macOS-latest]

--- a/src/Blocking.jl
+++ b/src/Blocking.jl
@@ -78,7 +78,7 @@ function blocking_old(v::Vector; typos = nothing)
         mean = sum(v)/n
         var = v .- mean
         sigmasq = sum(var.^2)/n # uncorrected sample variance
-        if typos == nothing
+        if typos === nothing
             gamma = sum(var[1:n-1].*var[2:n])/(n-1)
         else # typos ∈ {:FP, :Jonsson}
             gamma = sum(var[1:n-1].*var[2:n])/n
@@ -87,7 +87,7 @@ function blocking_old(v::Vector; typos = nothing)
         end
         mj = n*((n-1)*sigmasq/(n^2)+gamma)^2/(sigmasq^2)
         stddev = sqrt(sigmasq)
-        if typos == nothing || typos == :FP
+        if typos === nothing || typos == :FP
             stderr = stddev/sqrt(n-1) # [F&P] Eq. (28)
         else
             stderr = stddev/sqrt(n) # [Jonsson] Fig. 2

--- a/src/DictVectors/abstractdvec.jl
+++ b/src/DictVectors/abstractdvec.jl
@@ -321,7 +321,7 @@ end
 Base.keys(dv::AbstractDVec) = ADVKeysIterator(dv)
 function Base.iterate(ki::ADVKeysIterator, oldstate...)
     it = iterate(pairs(ki.dv), oldstate...)
-    it == nothing && return nothing
+    it === nothing && return nothing
     pair, state = it
     return (pair[1],state)
 end

--- a/src/DictVectors/dfvec.jl
+++ b/src/DictVectors/dfvec.jl
@@ -223,7 +223,7 @@ flags(dv::DFVec) = FlagsIterator(dv)
 
 @inline function Base.iterate(fi::FlagsIterator, oldstate...)
     ps = iterate(fi.dv.d, oldstate...)
-    ps == nothing && return nothing
+    ps === nothing && return nothing
     pair, state = ps
     @inbounds return pair[2][2], state
 end
@@ -250,7 +250,7 @@ function kvpairs(dv::DFVec)
 end
 @inline function Base.iterate(kvi::KVPairsIterator, oldstate...)
     ps = iterate(kvi.dv.d, oldstate...)
-    ps == nothing && return nothing
+    ps === nothing && return nothing
     pair, state = ps
     @inbounds return Pair(pair[1], pair[2][1]), state
 end
@@ -274,7 +274,7 @@ Base.IteratorSize(::Type{DFVec}) = HasLength()
 
 @inline function Base.iterate(dv::DFVec, oldstate...)
     it = iterate(pairs(dv), oldstate...)
-    it == nothing && return nothing
+    it === nothing && return nothing
     pair, state = it
     @inbounds return (pair[2][1],state)
 end

--- a/src/DictVectors/fastdvec.jl
+++ b/src/DictVectors/fastdvec.jl
@@ -210,7 +210,7 @@ end
 # iteration over the FastDVec returns values
 @inline function Base.iterate(fdv::FastDVec, state...)
     it = _pair_iterate(fdv,state...)
-    it == nothing && return nothing
+    it === nothing && return nothing
     pair, state = it
     return pair[2], state # value
 end
@@ -219,7 +219,7 @@ end
 # iteration over the keys requires  ADVKeysIterator - 3 to 4 times faster than fallback
 @inline function Base.iterate(ki::ADVKeysIterator{DV}, state...) where DV<:FastDVec
     it = _pair_iterate(ki.dv,state...)
-    it == nothing && return nothing
+    it === nothing && return nothing
     pair, state = it
     return pair[1], state # key
 end

--- a/src/fciqmc.jl
+++ b/src/fciqmc.jl
@@ -279,7 +279,7 @@ function fciqmc!(v, pa::RunTillLastStep, df::DataFrame,
     end
     # make sure that `svec` contains the current population:
     if !(v === svec)
-        copyto!(svec, v)
+        copy!(svec, v)
     end
     # pack up parameters for continuation runs
     # note that this modifes the struct pa


### PR DESCRIPTION
This PR mainly fixes compatibility of the automatic tests with Julia v1.5. The tests should now complete successfully on all Julia versions >= v1.3.

In addition there is a bug fix that could result in the passing of a wrong coefficient vector after lomc!() or fciqmc!() completed. This would affect continuation runs.

