### PR TITLE
Feature/two norm

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -15,11 +15,48 @@ on:
       - feature/github-actions
 
 jobs:
-  test:
+  test: Julia v1.5
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         julia-version: [1.5.1]
+        # julia-arch: [x64, x86]
+        julia-arch: [x64]
+        # os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest]
+        # 32-bit Julia binaries are not available on macOS
+        # exclude:
+        #   - os: macOS-latest
+        #     julia-arch: x86
+
+    steps:
+      - uses: actions/checkout@v1.0.0
+      - name: "Set up Julia"
+        uses: julia-actions/setup-julia@v0.2
+        with:
+          version: ${{ matrix.julia-version }}
+          arch: ${{ matrix.julia-arch }}
+      - name: "Install MPI"
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y openmpi-bin libopenmpi-dev
+      - name: "Run tests"
+        run: |
+          export JULIA_PROJECT=@.
+          export JULIA_MPIEXEC=/tmp/mpiexecwrapper
+          echo -e '#!/bin/bash\nmpiexec --allow-run-as-root $@' > $JULIA_MPIEXEC
+          chmod +x $JULIA_MPIEXEC
+          export JULIA_NUM_THREADS=1
+          mpirun echo "hello"
+          julia --project=@. -e "using InteractiveUtils; versioninfo(verbose=true)"
+          julia --project=@. -e "using Pkg; Pkg.instantiate(); Pkg.build()"
+          julia --project=@. -e "using Pkg; Pkg.test(\"Rimu\");"
+
+  test: Julia v1.4
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        julia-version: [1.4.2]
         # julia-arch: [x64, x86]
         julia-arch: [x64]
         # os: [ubuntu-latest, windows-latest, macOS-latest]

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -7,7 +7,7 @@ on:
       - develop
       - 'feature/**'
       - 'bugfix/**'
-    tags: '*'
+    # tags: '*'
   pull_request:
     branches:
       - master
@@ -15,7 +15,7 @@ on:
       - feature/github-actions
 
 jobs:
-  test: Julia v1.5
+  testNewVersion: 
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -52,7 +52,7 @@ jobs:
           julia --project=@. -e "using Pkg; Pkg.instantiate(); Pkg.build()"
           julia --project=@. -e "using Pkg; Pkg.test(\"Rimu\");"
 
-  test: Julia v1.4
+  testOldVersion: 
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -87,4 +87,4 @@ jobs:
           mpirun echo "hello"
           julia --project=@. -e "using InteractiveUtils; versioninfo(verbose=true)"
           julia --project=@. -e "using Pkg; Pkg.instantiate(); Pkg.build()"
-          julia --project=@. -e "using Pkg; Pkg.test(\"Rimu\");"
+          julia --project=@. -e "using Pkg; Pkg.test(\"Rimu\");"        

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        julia-version: [1.5.1]
+        julia-version: [1.5.2]
         # julia-arch: [x64, x86]
         julia-arch: [x64]
         # os: [ubuntu-latest, windows-latest, macOS-latest]

--- a/src/DictVectors/DictVectors.jl
+++ b/src/DictVectors/DictVectors.jl
@@ -33,7 +33,7 @@ import Base: length, iterate, getindex, setindex, setindex!, get, get!, haskey,
 using ..FastBufs
 
 export AbstractDVec, capacity, zero!, kvpairs, pairtype, add!
-export NormProjector, UniformProjector
+export NormProjector, Norm2Projector, UniformProjector
 export DVec
 export DFVec, tuples, gettuple, flagtype, flags
 export FastDVec

--- a/src/DictVectors/abstractdvec.jl
+++ b/src/DictVectors/abstractdvec.jl
@@ -435,3 +435,21 @@ LinearAlgebra.dot(::NormProjector, y::DVecOrVec) = convert(valtype(y),norm(y,1))
 # dot returns the promote_type of the arguments.
 # NOTE that this can be different from the return type of norm()->Float64
 # NOTE: This operation should work for `MPIData` and is MPI synchronizing
+
+"""
+    Norm2Projector()
+Results in computing the two-norm when used in `dot()`. E.g.
+```julia
+dot(NormProjector(),x)
+-> norm(x,2) # with type Float64
+```
+
+See also [`ReportingStrategy`](@ref) for use
+of projectors in FCIQMC.
+"""
+struct Norm2Projector end
+
+LinearAlgebra.dot(::Norm2Projector, y::DVecOrVec) = norm(y,2)
+# NOTE that this returns a `Float64` opposite to the convention for 
+# dot to return the promote_type of the arguments.
+

--- a/src/Rimu.jl
+++ b/src/Rimu.jl
@@ -23,7 +23,7 @@ include("Blocking.jl")
 export lomc!
 export fciqmc!, FciqmcRunStrategy, RunTillLastStep
 export MemoryStrategy, NoMemory, DeltaMemory, ShiftMemory
-export ProjectStrategy, NoProjection, ThresholdProject, ScaledThresholdProject
+export ProjectStrategy, NoProjection, NoProjectionTwoNorm, ThresholdProject, ScaledThresholdProject
 export ShiftUpdateStrategy, LogUpdate, LogUpdateAfterTargetWalkers
 export DontUpdate, DelayedLogUpdate, DelayedLogUpdateAfterTargetWalkers
 export DoubleLogUpdate, DoubleLogUpdateAfterTargetWalkers

--- a/src/fciqmc.jl
+++ b/src/fciqmc.jl
@@ -482,6 +482,9 @@ norm_project!(::StochasticStyle, w, p) = norm(w, 1) # MPIsync
 # default, compute 1-norm
 # e.g. triggered with the `NoProjection` strategy
 
+norm_project!(::StochasticStyle, w, p::NoProjectionTwoNorm) = norm(w, 2) # MPIsync
+# compute 2-norm but do not perform projection
+
 function norm_project!(s::S, w, p::ThresholdProject) where S<:Union{IsStochasticWithThreshold}
     return norm_project_threshold!(w, p.threshold) # MPIsync
 end

--- a/src/strategies_and_params.jl
+++ b/src/strategies_and_params.jl
@@ -59,7 +59,8 @@ respectively. Possible values for `projector` are
 * `missing` - no projections are computed (default)
 * `dv::AbstractDVec` - compute projection onto coefficient vector `dv`
 * [`UniformProjector()`](@ref) - projection onto vector of all ones
-* [`NormProjector()`](@ref) - compute norm instead of projection
+* [`NormProjector()`](@ref) - compute 1-norm instead of projection
+* [`Norm2Projector()`](@ref) - compute 2-norm instead of projection
 
 # Examples
 ```julia

--- a/src/strategies_and_params.jl
+++ b/src/strategies_and_params.jl
@@ -723,6 +723,7 @@ floating point walker number with [`norm_project`](@ref).
 Implemented stategies:
 
    * [`NoProjection`](@ref)
+   * [`NoProjectionTwoNorm`](@ref)
    * [`ThresholdProject`](@ref)
    * [`ScaledThresholdProject`](@ref)
 """
@@ -730,6 +731,10 @@ abstract type ProjectStrategy end
 
 "Do not project the walker amplitudes. See [`norm_project`](@ref)."
 struct NoProjection <: ProjectStrategy end
+
+"Do not project the walker amplitudes. Use two-norm to 
+calculate walker numbers. See [`norm_project`](@ref)."
+struct NoProjectionTwoNorm <: ProjectStrategy end
 
 
 @with_kw struct ThresholdProject <: ProjectStrategy

--- a/src/strategies_and_params.jl
+++ b/src/strategies_and_params.jl
@@ -733,8 +733,11 @@ abstract type ProjectStrategy end
 "Do not project the walker amplitudes. See [`norm_project`](@ref)."
 struct NoProjection <: ProjectStrategy end
 
-"Do not project the walker amplitudes. Use two-norm to 
-calculate walker numbers. See [`norm_project`](@ref)."
+"""
+Do not project the walker amplitudes. Use two-norm to 
+calculate walker numbers. This affects reported "norm" but also the shift update procedures.
+See [`norm_project`](@ref).
+"""
 struct NoProjectionTwoNorm <: ProjectStrategy end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -225,6 +225,7 @@ end
     @test v2 == ham*svec
     @test dot(v2,ham,svec) == v2⋅(ham*svec) ≈ 144
     @test -⋅(UniformProjector(),ham,svec)≈⋅(NormProjector(),ham,svec)≈norm(v2,1)
+    @test dot(Norm2Projector(),v2) ≈ norm(v2,2)
     @test Hamiltonians.LOStructure(ham) == Hamiltonians.HermitianLO()
     aIni2 = nearUniform(BoseFS{9,9})
     hamc = BoseHubbardReal1D(aIni2, u=6.0+0im, t=1.0+0im) # formally a complex operator

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -443,6 +443,13 @@ end
     @time rdfs = fciqmc!(vs, pa, ham, s, EveryTimeStep(), ConstantTimeStep(), copy(vs), p_strat = p)
     @test sum(rdfs[:,:norm]) ≈ (OV ? 3250.3751731923294 : 3012.564012011806)
 
+    # NoProjectionTwoNorm
+    vs = copy(svec)
+    pa = RunTillLastStep(laststep = 100)
+    seedCRNG!(12345) # uses RandomNumbers.Xorshifts.Xoroshiro128Plus()
+    @time rdfs = fciqmc!(vs, pa, ham, s, EveryTimeStep(), ConstantTimeStep(), copy(vs), p_strat = NoProjectionTwoNorm())
+    @test sum(rdfs[:,:norm]) ≈ (OV ? 3250.3751731923294 : 3467.388948546654)
+
     # NoMemory
     vs = copy(svec)
     seedCRNG!(12345) # uses RandomNumbers.Xorshifts.Xoroshiro128Plus()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -386,7 +386,7 @@ end
     ṽ, w̃, stats = Rimu.fciqmc_step!(ham, copy(vs), pa.shift, pa.dτ, 1.0, similar(vs))
     if Threads.nthreads() == 1 # I'm not sure why this is necessary, but there
         # seems to be a difference 
-        @test sum(stats) == (OV ? 643 : 479)
+        @test sum(stats) == (OV ? 436 : 479)
     elseif Threads.nthreads() == 4
         @test sum(stats) == (OV ? 643 : 707)
     end
@@ -397,14 +397,14 @@ end
     ṽ, w̃, stats = Rimu.fciqmc_step!(ham, copy(vs), pa.shift, pa.dτ, 1.0, ws;
                     batchsize = length(vs)÷4+1)
     if Threads.nthreads() == 1
-        @test sum(stats) == (OV ? 642 : 475) # test assuming nthreads() == 1
+        @test sum(stats) == (OV ? 428 : 475) # test assuming nthreads() == 1
     end
 
     # run 100 steps with multi
     pa.laststep = 200
     @time rdfs = fciqmc!(vs, pa, rdfs, ham, s, r_strat, τ_strat, ws)
     if Threads.nthreads() == 1
-        @test sum(rdfs[:,:spawns]) == (OV ? 141757 : 136905) # test assuming nthreads() == 1
+        @test sum(rdfs[:,:spawns]) == (OV ? 136992 : 136905) # test assuming nthreads() == 1
     end
 
     # threaded version of standard fciqmc!
@@ -441,14 +441,14 @@ end
     pa = RunTillLastStep(laststep = 100)
     seedCRNG!(12345) # uses RandomNumbers.Xorshifts.Xoroshiro128Plus()
     @time rdfs = fciqmc!(vs, pa, ham, s, EveryTimeStep(), ConstantTimeStep(), copy(vs), p_strat = p)
-    @test sum(rdfs[:,:norm]) ≈ (OV ? 3250.3751731923294 : 3012.564012011806)
+    @test sum(rdfs[:,:norm]) ≈ (OV ? 3250.375173192328 : 3012.564012011806)
 
     # NoProjectionTwoNorm
     vs = copy(svec)
     pa = RunTillLastStep(laststep = 100)
     seedCRNG!(12345) # uses RandomNumbers.Xorshifts.Xoroshiro128Plus()
     @time rdfs = fciqmc!(vs, pa, ham, s, EveryTimeStep(), ConstantTimeStep(), copy(vs), p_strat = NoProjectionTwoNorm())
-    @test sum(rdfs[:,:norm]) ≈ (OV ? 3250.3751731923294 : 3467.388948546654)
+    @test sum(rdfs[:,:norm]) ≈ (OV ? 3518.9649297547053 : 3467.388948546654)
 
     # NoMemory
     vs = copy(svec)


### PR DESCRIPTION
This PR adds features for computing the two-norm via the projector mechanism inside the reporting strategy. E.g. 
`r_strat = EveryTimeStep(projector = Norm2Projector())`

The other added feature is a new projection strategy `p_strat = NoProjection2Norm()`. If used, all walker numbers are calculated with the two-norm. In particular that means the two-norm is used for shift updates.

Finally, the workfows/action.yml file was modified to test both with the newest Julia version and the old version 1.4.2.