### PR TITLE
Bugfix/annihilation stochastic threshold

### DIFF
--- a/src/fciqmc.jl
+++ b/src/fciqmc.jl
@@ -1014,9 +1014,10 @@ function fciqmc_col!(s::IsStochasticWithThreshold, w, ham::AbstractHamiltonian,
     # projection to threshold should be applied after all colums are evaluated
     new_val = (1 + dτ*(shift - diagME(ham,add)))*val
     # apply threshold if necessary
-    if new_val < s.threshold
+    if abs(new_val) < s.threshold
         # project stochastically to threshold
-        w[add] += (new_val/s.threshold > cRand()) ? s.threshold : 0
+        # w[add] += (abs(new_val)/s.threshold > cRand()) ? sign(new_val)*s.threshold : 0
+        w[add] += ifelse(cRand() < abs(new_val)/s.threshold, sign(new_val)*s.threshold, 0)
     else
         w[add] += new_val
     end

--- a/src/strategies_and_params.jl
+++ b/src/strategies_and_params.jl
@@ -271,7 +271,7 @@ Averaging over `Δ` time steps is applied, where `Δ = 1` means no memory noise
 is applied. Use `pp` to initialise the value of the projection or pass `v` in
 order to initialise the projection with `pp = projector.v`.
 ```
-r̃ = (projector⋅w - projector⋅v)/(dτ*projector⋅v) + shift
+r̃ = (projector⋅v - projector⋅w)/projector⋅v + dτ*shift
 r = r̃ - <r̃>
 ```
 where `v` is the coefficient vector before and `w` after applying a regular
@@ -734,7 +734,7 @@ abstract type ProjectStrategy end
 struct NoProjection <: ProjectStrategy end
 
 """
-Do not project the walker amplitudes. Use two-norm to 
+Do not project the walker amplitudes. Use two-norm to
 calculate walker numbers. This affects reported "norm" but also the shift update procedures.
 See [`norm_project`](@ref).
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -252,7 +252,7 @@ end
     @test rayleigh_quotient(momentum, v) ≈ -1.5707963267948966
 
     fs = BoseFS((1,2,1,0)) # should be zero momentum
-    ham = BoseHubbardMom1D(fs,t=1.0) 
+    ham = BoseHubbardMom1D(fs,t=1.0)
     m=Momentum(ham) # define momentum operator
     mom_fs = diagME(m, fs) # get momentum value as diagonal matrix element of operator
     @test isapprox(mom_fs, 0.0, atol = sqrt(eps())) # check whether momentum is zero
@@ -386,10 +386,10 @@ end
     # single step
     ṽ, w̃, stats = Rimu.fciqmc_step!(ham, copy(vs), pa.shift, pa.dτ, 1.0, similar(vs))
     if Threads.nthreads() == 1 # I'm not sure why this is necessary, but there
-        # seems to be a difference 
+        # seems to be a difference
         @test sum(stats) == (OV ? 436 : 479)
     elseif Threads.nthreads() == 4
-        @test sum(stats) == (OV ? 643 : 707)
+        @test sum(stats) == (OV ? 643 : 479)
     end
 
     # single step multi threading
@@ -470,14 +470,14 @@ end
     seedCRNG!(12345) # uses RandomNumbers.Xorshifts.Xoroshiro128Plus()
     pa = RunTillLastStep(laststep = 100)
     @time rdfs = fciqmc!(vs, pa, ham, s, EveryTimeStep(), ConstantTimeStep(), copy(vs), m_strat = DeltaMemory(10), p_strat = p)
-    @test sum(rdfs[:,:norm]) ≈ (OV ? 3593.0881344844074 : 2683.334567725324)
-    @test sum(rdfs.shiftnoise) ≈ (OV ? 0.2800051045189369 : 0.282574064213998)
+    @test sum(rdfs[:,:norm]) ≈ (OV ? 2841.683858917014 : 2683.334567725324)
+    @test sum(rdfs.shiftnoise) ≈ (OV ? 0.456062023263646 : 0.282574064213998)
     # DeltaMemory2
     vs = copy(svec)
     seedCRNG!(12345) # uses RandomNumbers.Xorshifts.Xoroshiro128Plus()
     pa = RunTillLastStep(laststep = 100)
     @time rdfs = fciqmc!(vs, pa, ham, s, EveryTimeStep(), ConstantTimeStep(), copy(vs), m_strat = Rimu.DeltaMemory2(10), p_strat = p)
-    @test sum(rdfs[:,:norm]) ≈ (OV ? 2868.443452947778 : 3114.518739252482)
+    @test sum(rdfs[:,:norm]) ≈ (OV ? 3407.75528796349 : 3114.518739252482)
 
     # ScaledThresholdProject
     vs = copy(svec)
@@ -485,16 +485,16 @@ end
     pa = RunTillLastStep(laststep = 100)
     p_strat = ScaledThresholdProject(1.0)
     @time rdfs = fciqmc!(vs, pa, ham, s, EveryTimeStep(), ConstantTimeStep(), copy(vs), m_strat = DeltaMemory(10), p_strat = p_strat)
-    @test sum(rdfs[:,:norm]) ≈ (OV ? 2479.8235792152586 : 3122.817384314045)
+    @test sum(rdfs[:,:norm]) ≈ (OV ? 3174.5195839788425 : 3122.817384314045)
 
     # ProjectedMemory
     vs = copy(svec)
     seedCRNG!(12345) # uses RandomNumbers.Xorshifts.Xoroshiro128Plus()
     pa = RunTillLastStep(laststep = 100)
     p_strat = NoProjection() # ScaledThresholdProject(1.0)
-    m_strat = Rimu.ProjectedMemory(10,UniformProjector(), vs)
+    m_strat = Rimu.ProjectedMemory(5,UniformProjector(), vs)
     @time rdfs = fciqmc!(vs, pa, ham, s, EveryTimeStep(), ConstantTimeStep(), copy(vs), m_strat = m_strat, p_strat = p_strat)
-    @test sum(rdfs[:,:norm]) ≈ (OV ? 3007.216076256354 : 3055.346795977555)
+    @test sum(rdfs[:,:norm]) ≈ (OV ? 3256.8110011126214 : 3054.5448859688427)
 
     # ShiftMemory
     vs = copy(svec)
@@ -502,7 +502,7 @@ end
     pa = RunTillLastStep(laststep = 100)
     p_strat = NoProjection() #ScaledThresholdProject(1.0)
     @time rdfs = fciqmc!(vs, pa, ham, s, EveryTimeStep(), ConstantTimeStep(), copy(vs), m_strat = ShiftMemory(10), p_strat = p_strat)
-    @test sum(rdfs[:,:norm]) ≈ (OV ? 3575.6243544500435 : 3320.0700864646715)
+    @test sum(rdfs[:,:norm]) ≈ (OV ? 3231.4229026099574 : 3298.7124102559173)
 
     # applyMemoryNoise
     v2=DVec(Dict(aIni => 2))
@@ -521,7 +521,7 @@ end
     pa = RunTillLastStep(laststep = 100)
     seedCRNG!(12345) # uses RandomNumbers.Xorshifts.Xoroshiro128Plus()
     @time rdfs = fciqmc!(vs, pa, ham, s, EveryTimeStep(), ConstantTimeStep(), copy(vs))
-    @test sum(rdfs[:,:norm]) ≈ (OV ? 3250.375173192328 : 3687.674720780682)
+    @test sum(rdfs[:,:norm]) ≈ (OV ? 3939.3835802371677 : 3687.674720780682)
 end
 
 @testset "dfvec.jl" begin
@@ -641,9 +641,9 @@ end
     ham2 = BoseHubbardMom1D(aIni2; u = 1.0, t=1.0)
     sv2 = DVec(Dict(aIni2 => 2), 2000)
     seedCRNG!(12345) # uses RandomNumbers.Xorshifts.Xoroshiro128Plus()
-    nt = lomc!(ham2, sv2, laststep = 30, threading = false, 
+    nt = lomc!(ham2, sv2, laststep = 30, threading = false,
                 r_strat = EveryTimeStep(projector = copy(sv2)),
-                s_strat = DoubleLogUpdate(targetwalkers = 100)) 
+                s_strat = DoubleLogUpdate(targetwalkers = 100))
     # need to analyse this - looks fishy
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -470,14 +470,14 @@ end
     seedCRNG!(12345) # uses RandomNumbers.Xorshifts.Xoroshiro128Plus()
     pa = RunTillLastStep(laststep = 100)
     @time rdfs = fciqmc!(vs, pa, ham, s, EveryTimeStep(), ConstantTimeStep(), copy(vs), m_strat = DeltaMemory(10), p_strat = p)
-    @test sum(rdfs[:,:norm]) ≈ (OV ? 3593.0881344844074 : 3404.8587715385115)
-    @test sum(rdfs.shiftnoise) ≈ (OV ? 0.2800051045189369 : 0.20053422394595116)
+    @test sum(rdfs[:,:norm]) ≈ (OV ? 3593.0881344844074 : 2683.334567725324)
+    @test sum(rdfs.shiftnoise) ≈ (OV ? 0.2800051045189369 : 0.282574064213998)
     # DeltaMemory2
     vs = copy(svec)
     seedCRNG!(12345) # uses RandomNumbers.Xorshifts.Xoroshiro128Plus()
     pa = RunTillLastStep(laststep = 100)
     @time rdfs = fciqmc!(vs, pa, ham, s, EveryTimeStep(), ConstantTimeStep(), copy(vs), m_strat = Rimu.DeltaMemory2(10), p_strat = p)
-    @test sum(rdfs[:,:norm]) ≈ (OV ? 2868.443452947778 : 3191.954261752702)
+    @test sum(rdfs[:,:norm]) ≈ (OV ? 2868.443452947778 : 3114.518739252482)
 
     # ScaledThresholdProject
     vs = copy(svec)
@@ -485,7 +485,7 @@ end
     pa = RunTillLastStep(laststep = 100)
     p_strat = ScaledThresholdProject(1.0)
     @time rdfs = fciqmc!(vs, pa, ham, s, EveryTimeStep(), ConstantTimeStep(), copy(vs), m_strat = DeltaMemory(10), p_strat = p_strat)
-    @test sum(rdfs[:,:norm]) ≈ (OV ? 2479.8235792152586 : 3353.557855050109)
+    @test sum(rdfs[:,:norm]) ≈ (OV ? 2479.8235792152586 : 3122.817384314045)
 
     # ProjectedMemory
     vs = copy(svec)
@@ -509,6 +509,19 @@ end
     StochasticStyle(v2) # IsStochastic() is not suitable for DeltaMemory()
     @test_throws ErrorException Rimu.applyMemoryNoise!(v2, v2, 0.0, 0.1, 20, DeltaMemory(3))
     @test 0 == Rimu.applyMemoryNoise!(svec, copy(svec), 0.0, 0.1, 20, DeltaMemory(3))
+
+    # momentum space - tests annihilation
+    aIni = BoseFS((0,0,6,0,0,0))
+    ham = BoseHubbardMom1D(aIni, u=6.0)
+    s = DoubleLogUpdate(targetwalkers = 100)
+    svec = DVec(Dict(aIni => 2.0), ham(:dim))
+    Rimu.StochasticStyle(::Type{typeof(svec)}) = IsStochasticWithThreshold(1.0)
+    StochasticStyle(svec)
+    vs = copy(svec)
+    pa = RunTillLastStep(laststep = 100)
+    seedCRNG!(12345) # uses RandomNumbers.Xorshifts.Xoroshiro128Plus()
+    @time rdfs = fciqmc!(vs, pa, ham, s, EveryTimeStep(), ConstantTimeStep(), copy(vs))
+    @test sum(rdfs[:,:norm]) ≈ (OV ? 3250.375173192328 : 3687.674720780682)
 end
 
 @testset "dfvec.jl" begin


### PR DESCRIPTION
This PR fixes a bug in the walker annihilation for non-integer walker number calculations using `IsStochasticWithThreshold()`.