### PR TITLE
Feature/delayed-double-log-update

### DIFF
--- a/src/Rimu.jl
+++ b/src/Rimu.jl
@@ -26,7 +26,8 @@ export MemoryStrategy, NoMemory, DeltaMemory, ShiftMemory
 export ProjectStrategy, NoProjection, ThresholdProject, ScaledThresholdProject
 export ShiftUpdateStrategy, LogUpdate, LogUpdateAfterTargetWalkers
 export DontUpdate, DelayedLogUpdate, DelayedLogUpdateAfterTargetWalkers
-export DoubleLogUpdate, DoubleLogUpdateAfterTargetWalkers
+export DoubleLogUpdate, DelayedDoubleLogUpdate, DoubleLogUpdateAfterTargetWalkers
+export DelayedDoubleLogUpdateAfterTW
 export DoubleLogUpdateAfterTargetWalkersSwitch
 export HistoryLogUpdate
 export ReportingStrategy, EveryTimeStep, EveryKthStep, ReportDFAndInfo

--- a/src/strategies_and_params.jl
+++ b/src/strategies_and_params.jl
@@ -475,7 +475,7 @@ See [`DoubleLogUpdate`](@ref).
     A::Int = 10 # delay for updating shift
 end
 @doc """
-    DoubleLogUpdate(; targetwalkers = 1000, ζ = 0.08, ξ = ζ^2/4, A=10) <: ShiftStrategy
+    DelayedDoubleLogUpdate(; targetwalkers = 1000, ζ = 0.08, ξ = ζ^2/4, A=10) <: ShiftStrategy
 Strategy for updating the shift according to the log formula with damping
 parameter `ζ` and `ξ` and delay of `A` steps.
 See [`DoubleLogUpdate`](@ref).
@@ -493,7 +493,7 @@ S^{n+A} = S^n -\\frac{ζ}{A dτ}\\ln\\left(\\frac{\\|Ψ\\|_1^{n+A}}{\\|Ψ\\|_1^n
     A::Int = 10 # delay for updating shift
 end
 @doc """
-    DoubleLogUpdate(; targetwalkers = 1000, ζ = 0.08, ξ = ζ^2/4, A=10) <: ShiftStrategy
+    DelayedDoubleLogUpdateAfterTW(; targetwalkers = 1000, ζ = 0.08, ξ = ζ^2/4, A=10) <: ShiftStrategy
 Strategy for updating the shift according to the log formula with damping
 parameter `ζ` and `ξ` and delay of `A` steps after the number of target walkers is reached.
 See [`DoubleLogUpdate`](@ref).


### PR DESCRIPTION
Two new shift update strategies are introduced:

- `DelayedDoubleLogUpdate`: updating the shift every `A` steps.
- `DelayedDoubleLogUpdateAfterTW`: updating the shift every `A` steps after the target walker number is reached to avoid slow initial growth or unwanted death.

Also fixed some typos in the file.