### PR TITLE
Feature/deltanoise

### DIFF
--- a/src/BitStringAddresses.jl
+++ b/src/BitStringAddresses.jl
@@ -714,6 +714,16 @@ end
   return BoseFS{N,M,BSAdd128}(BSAdd128(bs))
 end
 
+@inline function BoseFS{BitAdd{I,B}}(onr::T,::Val{N},::Val{M},::Val{B}) where {I,N,M,B,T<:Union{AbstractVector,Tuple}}
+  @boundscheck  ((N + M - 1 == B) && (I == (B-1) ÷ 64 + 1)) || @error "Inconsistency in constructor BoseFS"
+  bs = BitAdd{B}(0) # empty bitstring
+  for on in reverse(onr)
+    bs <<= on+1
+    bs |= BitAdd{B}()>>(B-on)
+  end
+  return BoseFS{N,M,BitAdd{I,B}}(bs)
+end
+
 @inline function BoseFS{BitAdd}(onr::T,::Val{N},::Val{M},::Val{B}) where {N,M,B,T<:Union{AbstractVector,Tuple}}
   @boundscheck  N + M - 1 == B || @error "Inconsistency in constructor BoseFS"
   bs = BitAdd{B}(0) # empty bitstring

--- a/src/BitStringAddresses.jl
+++ b/src/BitStringAddresses.jl
@@ -631,7 +631,7 @@ struct BoseFS{N,M,A} <: BosonicFockStateAddress
   bs::A
 end
 
-BoseFS{N,M}(bs::A) where {N,M,A} = BoseFS{N,M,A}(bs) # slow - not sure why
+BoseFS{N,M}(bs::A) where {N,M,A} = BoseFS{N,M,A}(bs) 
 
 function BoseFS(bs::A, b::Integer) where A <: BitStringAddressType
   n = count_ones(bs)

--- a/src/Blocking.jl
+++ b/src/Blocking.jl
@@ -13,6 +13,7 @@ using DataFrames, Statistics
 export autocovariance, covariance
 export blocker, blocking, blockingErrorEstimation, mtest
 export autoblock, blockAndMTest
+export growthWitness
 
 # """
 # Calculate the variance of the dataset v
@@ -444,5 +445,36 @@ function autoblock(dftup::Tuple; start = 1, stop = size(dftup[1])[1], corrected:
         ēH = df_var_H.mean_f[1], σeH = df_var_H.SE_f[ks], k = ks)
 
 end
+
+#G_b^{(n)} = \\bar{S}^{(n)} - \\frac{\\log\\vert\\mathbf{c}^{(n+b)}\\vert - \\log\\vert\\mathbf{c}^{(n)}\\vert}{b d\\tau},
+"""
+    growthWitness(norm::AbstractArray, shift::AbstractArray, dt; b = 30, pad = :true) -> g
+    growthWitness(df::DataFrame; b = 30, pad = :true) -> g
+Compute the growth witness 
+```math
+G_b^{(n)} = S̄^{(n)} - \\frac{\\log\\vert\\mathbf{c}^{(n+b)}\\vert - \\log\\vert\\mathbf{c}^{(n)}\\vert}{b d\\tau},
+```
+where `S̄` is an average of the `shift` over `b` time steps and \$\\vert\\mathbf{c}^{(n)}\\vert =\$ `norm[n]`. 
+The parameter `b ≥ 1` averages the derivative quantity over `b` time steps and helps suppress noise.
+
+If `pad` is set to `:false` then the returned array `g` has the length `length(norm) - b`.
+If set to `:true` then `g` will be padded up to the same length as `norm` and `shift`.
+"""
+function growthWitness(norm::AbstractArray, shift::AbstractArray, dt; b = 30, pad = :true)
+    l = length(norm)
+    @assert length(shift) == l "`norm` and `shift` arrays need to have the same length."
+    n = l - b
+    g = Vector{Float64}(undef, pad ? l : n)
+    offset = pad ? b÷2 : 0 # use offset only if pad == :true
+    for i in 1:n
+        g[i + offset] = -(1/(b*dt) * log(norm[i+b]/norm[i]) - 1/(b+1) * sum(shift[i:i+b]))
+    end
+    if pad # pad the vector g at both ends
+        g[1:offset] .= g[offset]
+        g[offset+n+1 : end] .= g[offset+n]
+    end
+    return g
+end
+growthWitness(df::DataFrame; b = 30, pad = :true) = growthWitness(df.norm, df.shift, df.dτ[1]; b=b, pad=pad)
 
 end # module Blocking

--- a/src/Blocking.jl
+++ b/src/Blocking.jl
@@ -454,7 +454,7 @@ Compute the growth witness
 ```math
 G_b^{(n)} = S̄^{(n)} - \\frac{\\log\\vert\\mathbf{c}^{(n+b)}\\vert - \\log\\vert\\mathbf{c}^{(n)}\\vert}{b d\\tau},
 ```
-where `S̄` is an average of the `shift` over `b` time steps and \$\\vert\\mathbf{c}^{(n)}\\vert =\$ `norm[n]`. 
+where `S̄` is an average of the `shift` over `b` time steps and \$\\vert\\mathbf{c}^{(n)}\\vert ==\$ `norm[n]`. 
 The parameter `b ≥ 1` averages the derivative quantity over `b` time steps and helps suppress noise.
 
 If `pad` is set to `:false` then the returned array `g` has the length `length(norm) - b`.

--- a/src/DictVectors/abstractdvec.jl
+++ b/src/DictVectors/abstractdvec.jl
@@ -22,7 +22,7 @@ haskey, empty!, isempty`) and, in addition:
 - `capacity(dv)`: holding capacity
 - `similar(dv [,Type])`
 - `iterate()`: should return values of type `V`
-- `pairs()`: should return an iterator over `key::K => content` pairs. If `content ≠ value::V` the provide `values()` iterator as well!
+- `pairs()`: should return an iterator over `key::K => content` pairs. If `content ≠ value::V` then provide `values()` iterator as well!
 """
 abstract type AbstractDVec{K,V} end
 
@@ -450,6 +450,5 @@ of projectors in FCIQMC.
 struct Norm2Projector end
 
 LinearAlgebra.dot(::Norm2Projector, y::DVecOrVec) = norm(y,2)
-# NOTE that this returns a `Float64` opposite to the convention for 
+# NOTE that this returns a `Float64` opposite to the convention for
 # dot to return the promote_type of the arguments.
-

--- a/src/DictVectors/dfvec.jl
+++ b/src/DictVectors/dfvec.jl
@@ -1,17 +1,21 @@
 """
     DFVec{K,V,F}(capacity) <: AbstractDVec{K,V <: Number}
+    DFVec(key => (value, flag); capacity)
+    DFVec(args...; capacity)
     DFVec(d::Dict [, capacity])
     DFVec(v::Vector{V} [, capacity])
-Construct a wrapped dictionary with minimum capacity `capacity` to
-represent a vector-like object with `valtype(dv) == V`. The value of the
-`Dict` are of type `Tuple{V,F}`, which allows for storing a flag of type `F`
-for each entry. Indexing is done with an
-arbitrary (in general non-integer) `keytype(dv) == K`.
+Dictionary-based vector-like data structure with minimum capacity `capacity`
+for storing values and flags with keys.
+The values have type `eltype(dv) == V` and the flags have `flagtype(dv) == F`.
+Indexing is done with an
+arbitrary (in general non-integer) key with `keytype(dv) == K`.
+If the keyword argument `capacity` is passed then args are parsed as for `Dict`.
 When constructed from a `Vector{V}`,
 the keys will be integers `∈ [1, length(v)]` and the flag `zero(UInt16)`.
 See [`AbstractDVec`](@ref). The
 method [`capacity()`](@ref) is defined but not a strict upper limit as `Dict`
 objects can expand.
+
 """
 struct DFVec{K,V,F} <: AbstractDVec{K,V}
     d::Dict{K,Tuple{V,F}}
@@ -34,6 +38,9 @@ end
 function DFVec{K,V,F}(capacity::Int) where {K, V <: Number, F}
     return DFVec(Dict{K,Tuple{V,F}}(), capacity)
 end
+
+# like Dict with mandatory keyword argument capacity
+DFVec(args...; capacity) = DFVec(Dict(args...), capacity)
 
 # from Vector
 function DFVec(t::Vector{V}, capacity = length(t), F = UInt16) where V <: Number

--- a/src/DictVectors/dvec.jl
+++ b/src/DictVectors/dvec.jl
@@ -1,13 +1,17 @@
 """
-    DVec{K,T}(capacity) <: AbstractDVec{K,T}
+    DVec{K,V}(capacity) <: AbstractDVec{K,V}
+    DVec(key => value; capacity)
+    DVec(args...; capacity)
     DVec(d::Dict [, capacity])
-    DVec(v::Vector{T} [, capacity])
-Construct a wrapped dictionary with minimum capacity `capacity` to
-represent a vector-like object with `eltype(dv) == T`,
-which corresponds to the values of the `Dict`. Indexing is done with an
-arbitrary (in general non-integer) `keytype(dv) == K`.
+    DVec(v::Vector{V} [, capacity])
+Dictionary-based vector-like data structure with minimum capacity `capacity`
+for storing values with keys.
+The type of the values is `eltype(dv) == V`.
+Indexing is done with an
+arbitrary (in general non-integer) key with `keytype(dv) == K`.
+If the keyword argument `capacity` is passed then args are parsed as for `Dict`.
 When constructed from a `Vector`,
-the keys will be integers ∈ `[0, length(v)]`. See [`AbstractDVec`](@ref). The
+the keys will be integers ∈ `[1, length(v)]`. See [`AbstractDVec`](@ref). The
 method [`capacity()`](@ref) is defined but not a strict upper limit as `Dict`
 objects can expand.
 """
@@ -22,6 +26,8 @@ end
 # default constructor from `Dict` just wraps the dict, no copying or allocation:
 # dv = DVec(Dict(k => v, ...))
 
+# constructor like Dict with mandatory keyword capacity
+DVec(args...; capacity) = DVec(Dict(args...), capacity)
 
 function DVec(dict::D, capacity::Int) where D <: Dict
     if capacity*3 ≥ length(dict.keys)*2

--- a/src/DictVectors/fastdvec.jl
+++ b/src/DictVectors/fastdvec.jl
@@ -8,6 +8,9 @@ Create a dictionary-like array indexed by keys of type `K` and values of type
     FastDVec(d::AbstractDict{K,V}, [capacity = length(d)])
     FastDVec(d::AbstractDVec{K,V}, [capacity = length(d)])
 Construct a `FastDVec` object from an existing array or dictionary.
+
+    FastDVec(args...; capacity)
+If the keyword argument `capacity` is passed then args are parsed as for `Dict`.
 """
 mutable struct FastDVec{K,V} <: AbstractDVec{K,V}
     # V = value, e.g. a walker type like W3
@@ -29,6 +32,14 @@ function FastDVec{K,V}(capacity::Int) where V <: Number where K
     emptyslots = FastBuf{Int}(capacity)
     FastDVec{K,V}(vals, emptyslots, capacity, hashrange, hashtable)
 end
+
+function FastDVec(p::Pair{K,V}; capacity) where {K,V}
+    fdv = FastDVec{K,V}(capacity)
+    fdv[p.first] = p.second
+    return fdv
+end
+
+FastDVec(args...; capacity) = FastDVec(Dict(args...), capacity)
 
 # convenience constructors
 function FastDVec(a::AbstractVector, capacity = length(a))

--- a/src/Rimu.jl
+++ b/src/Rimu.jl
@@ -35,7 +35,7 @@ export TimeStepStrategy, ConstantTimeStep, OvershootControl
 export StochasticStyle, IsStochastic, IsDeterministic
 # export IsSemistochastic # is not yet ready
 export IsStochasticNonlinear, IsStochasticWithThreshold
-export @setThreshold, @setDeterministic
+export @setThreshold, @setDeterministic, setThreshold
 export threadedWorkingMemory, localpart
 
 # exports for MPI functionality

--- a/src/Rimu.jl
+++ b/src/Rimu.jl
@@ -35,6 +35,7 @@ export TimeStepStrategy, ConstantTimeStep, OvershootControl
 export StochasticStyle, IsStochastic, IsDeterministic
 # export IsSemistochastic # is not yet ready
 export IsStochasticNonlinear, IsStochasticWithThreshold
+export @setThreshold, @setDeterministic
 export threadedWorkingMemory, localpart
 
 # exports for MPI functionality

--- a/src/fciqmc.jl
+++ b/src/fciqmc.jl
@@ -77,7 +77,7 @@ function lomc!(ham, v;
         @unpack step, laststep, shiftMode, shift, dτ = params
         len = length(v) # MPIsync
         nor = norm(v, 1) # MPIsync
-        v_proj, h_proj = energy_project(v, ham, r_strat) # MPIsync
+        v_proj, h_proj = compute_proj_observables(v, ham, r_strat) # MPIsync
 
         # prepare df for recording data
         df = DataFrame(steps=Int[], dτ=Float64[], shift=Float64[],
@@ -185,7 +185,7 @@ function fciqmc!(svec, pa::FciqmcRunStrategy,
     @unpack step, laststep, shiftMode, shift, dτ = pa
     len = length(svec) # MPIsync
     nor = norm(svec, 1) # MPIsync
-    v_proj, h_proj = energy_project(svec, ham, r_strat) # MPIsync
+    v_proj, h_proj = compute_proj_observables(svec, ham, r_strat) # MPIsync
 
     # prepare df for recording data
     df = DataFrame(steps=Int[], dτ=Float64[], shift=Float64[],
@@ -251,7 +251,7 @@ function fciqmc!(v, pa::RunTillLastStep, df::DataFrame,
         tnorm = norm_project!(v, p_strat)  # MPIsync
         # project coefficients of `w` to threshold
 
-        v_proj, h_proj = energy_project(v, ham, r_strat)  # MPIsync
+        v_proj, h_proj = compute_proj_observables(v, ham, r_strat)  # MPIsync
 
         # update shift and mode if necessary
         shift, shiftMode, pnorm = update_shift(s_strat,

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -30,3 +30,12 @@ function sort_into_targets!(target, ws::NTuple{NT,W}, statss) where {NT,W}
     return target, ws, sum(statss)
 end
 # three argument version for MPIData to be found in mpi_helpers.jl
+
+# function setup_lomc(H::Type; n =6, m = 6, targetwalkers = )
+
+# function ini_state_vector(address, nwalkers, capacity, Style)
+#     if Style ∈ Union{IsDeterministic,IsStochasticWithThreshold,IsSemistochastic}
+#         nwalkers /= 1 # make it floating point
+#     end
+#     dv = DVec(Dict(address=>nwalkers), capacity)
+#     StochasticStyle(::Type{typeof(dv)}) = Style(1.0)

--- a/src/strategies_and_params.jl
+++ b/src/strategies_and_params.jl
@@ -252,7 +252,7 @@ DeltaMemory2(Δ::Int) = DeltaMemory2(Δ, NaN, DataStructures.CircularBuffer{Floa
 
 """
     DeltaMemory3(Δ::Int, level::Float64) <: MemoryStrategy
-Before updating the shift, apply multiplicative memory noise with a 
+Before updating the shift, apply multiplicative memory noise with a
 memory length of `Δ` at level `level`,
 where `Δ = 1` means no memory noise.
 
@@ -711,12 +711,12 @@ propagation with real walker numbers and cutoff `threshold`.
 During stochastic propagation, walker numbers small than `threshold` will be
 stochastically projected to either zero or `threshold`.
 
-The trait can be conveniently defined on an instance of a generalised vector with the macro 
+The trait can be conveniently defined on an instance of a generalised vector with the macro
 [`@setThreshold`](@ref). Example:
-```julia
-> dv = DVec(Dict(nearUniform(BoseFS{3,3})=>3.0))
-> @setThreshold dv 0.6
-> StochasticStyle(dv)
+```julia-repl
+julia> dv = DVec(Dict(nearUniform(BoseFS{3,3})=>3.0))
+julia> @setThreshold dv 0.6
+julia> StochasticStyle(dv)
 IsStochasticWithThreshold(0.6f0)
 ```
 """
@@ -726,37 +726,58 @@ end
 
 """
     @setThreshold dv threshold
-A macro to set a threshold for non-integer walker number FCIQMC. Technically, the macro sets the 
-trait [`StochasticStyle`](@ref) of the generalised vector `dv` to 
-[`IsStochasticWithThreshold(threshold)`](@ref), where `dv` must be a type that supports floating 
-point walker numbers.
+A macro to set a threshold for non-integer walker number FCIQMC. Technically, the macro sets the
+trait [`StochasticStyle`](@ref) of the generalised vector `dv` to
+[`IsStochasticWithThreshold(threshold)`](@ref), where `dv` must be a type that supports floating
+point walker numbers. Also available as function, see [`setThreshold`](@ref).
 
 Example usage:
-```julia
-> dv = DVec(Dict(nearUniform(BoseFS{3,3})=>3.0))
-> @setThreshold dv 0.6
-> StochasticStyle(dv)
+```julia-repl
+julia> dv = DVec(Dict(nearUniform(BoseFS{3,3})=>3.0))
+julia> @setThreshold dv 0.6
 IsStochasticWithThreshold(0.6f0)
 ```
 """
 macro setThreshold(dv, threshold)
     return esc(quote
-        StochasticStyle(::Type{typeof($dv)}) = IsStochasticWithThreshold($threshold)
+        @assert !(valtype($dv) <:Integer) "`valtype(dv)` must not be integer."
+        Rimu.StochasticStyle(::Type{typeof($dv)}) = IsStochasticWithThreshold($threshold)
+        Rimu.StochasticStyle($dv)
     end)
-    nothing
+end
+
+"""
+    setThreshold(dv, threshold)
+Set a threshold for non-integer walker number FCIQMC. Technically, the function sets the
+trait [`StochasticStyle`](@ref) of the generalised vector `dv` to
+[`IsStochasticWithThreshold(threshold)`](@ref), where `dv` must be a type that supports floating
+point walker numbers. Also available as macro, see [`@setThreshold`](@ref).
+
+Example usage:
+```julia-repl
+julia> dv = DVec(Dict(nearUniform(BoseFS{3,3})=>3.0))
+julia> setThreshold(dv, 0.6)
+IsStochasticWithThreshold(0.6f0)
+```
+"""
+function setThreshold(dv, threshold)
+    @assert !(valtype(dv) <:Integer) "`valtype(dv)` must not be integer."
+    @eval Rimu.StochasticStyle(::Type{typeof($dv)}) = IsStochasticWithThreshold($threshold)
+    return Rimu.StochasticStyle(dv)
 end
 
 """
     @setDeterministic dv
-A macro to undo the effect of [`@setThreshold`] and set the 
-trait [`StochasticStyle`](@ref) of the generalised vector `dv` to 
+A macro to undo the effect of [`@setThreshold`] and set the
+trait [`StochasticStyle`](@ref) of the generalised vector `dv` to
 [`IsDeterministic()`](@ref).
 """
 macro setDeterministic(dv)
     return esc(quote
-        StochasticStyle(::Type{typeof($dv)}) = IsDeterministic()
+        @assert !(valtype($dv) <:Integer) "`valtype(dv)` must not be integer."
+        Rimu.StochasticStyle(::Type{typeof($dv)}) = IsDeterministic()
+        Rimu.StochasticStyle($dv)
     end)
-    nothing
 end
 
 """

--- a/src/strategies_and_params.jl
+++ b/src/strategies_and_params.jl
@@ -251,6 +251,26 @@ end
 DeltaMemory2(Δ::Int) = DeltaMemory2(Δ, NaN, DataStructures.CircularBuffer{Float64}(Δ))
 
 """
+    DeltaMemory3(Δ::Int, level::Float64) <: MemoryStrategy
+Before updating the shift, apply multiplicative memory noise with a 
+memory length of `Δ` at level `level`,
+where `Δ = 1` means no memory noise.
+
+```
+r̃ = (pnorm - tnorm)/pnorm + dτ*shift
+r = r̃ - <r̃>
+w .*= 1 + level*r
+```
+"""
+mutable struct DeltaMemory3 <: MemoryStrategy
+    Δ::Int # length of memory noise buffer
+    level::Float64 # previous norm
+    noiseBuffer::DataStructures.CircularBuffer{Float64} # buffer for memory noise
+end
+DeltaMemory3(Δ::Int,level::Float64) = DeltaMemory3(Δ, level, DataStructures.CircularBuffer{Float64}(Δ))
+
+
+"""
     ShiftMemory(Δ::Int) <: MemoryStrategy
 Effectively replaces the fluctuating `shift` update procedure for the
 coefficient vector by an averaged `shift` over `Δ` timesteps,

--- a/src/strategies_and_params.jl
+++ b/src/strategies_and_params.jl
@@ -710,9 +710,53 @@ propagation with real walker numbers and cutoff `threshold`.
 ```
 During stochastic propagation, walker numbers small than `threshold` will be
 stochastically projected to either zero or `threshold`.
+
+The trait can be conveniently defined on an instance of a generalised vector with the macro 
+[`@setThreshold`](@ref). Example:
+```julia
+> dv = DVec(Dict(nearUniform(BoseFS{3,3})=>3.0))
+> @setThreshold dv 0.6
+> StochasticStyle(dv)
+IsStochasticWithThreshold(0.6f0)
+```
 """
 struct IsStochasticWithThreshold <: StochasticStyle
     threshold::Float32
+end
+
+"""
+    @setThreshold dv threshold
+A macro to set a threshold for non-integer walker number FCIQMC. Technically, the macro sets the 
+trait [`StochasticStyle`](@ref) of the generalised vector `dv` to 
+[`IsStochasticWithThreshold(threshold)`](@ref), where `dv` must be a type that supports floating 
+point walker numbers.
+
+Example usage:
+```julia
+> dv = DVec(Dict(nearUniform(BoseFS{3,3})=>3.0))
+> @setThreshold dv 0.6
+> StochasticStyle(dv)
+IsStochasticWithThreshold(0.6f0)
+```
+"""
+macro setThreshold(dv, threshold)
+    return esc(quote
+        StochasticStyle(::Type{typeof($dv)}) = IsStochasticWithThreshold($threshold)
+    end)
+    nothing
+end
+
+"""
+    @setDeterministic dv
+A macro to undo the effect of [`@setThreshold`] and set the 
+trait [`StochasticStyle`](@ref) of the generalised vector `dv` to 
+[`IsDeterministic()`](@ref).
+"""
+macro setDeterministic(dv)
+    return esc(quote
+        StochasticStyle(::Type{typeof($dv)}) = IsDeterministic()
+    end)
+    nothing
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -66,7 +66,11 @@ using Statistics
         @test reduce(&, Tuple(r).≈(-5.714600548611788, 0.21631081209341332, -5.884807394477632, 0.3849918114544903, 6))
     end
     g = growthWitness(rdfs, b=50)
-    @test sum(g) ≈ -5725.3936298329545
+    # @test sum(g) ≈ -5725.3936298329545
+    @test length(g) == nrow(rdfs)
+    g = growthWitness(rdfs, b=50, pad = :false)
+    @test length(g) == nrow(rdfs) - 50
+    @test_throws AssertionError growthWitness(rdfs.norm, rdfs.shift[1:end-1],rdfs.dτ[1])
 end
 
 using Rimu.BitStringAddresses

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -133,10 +133,13 @@ using Rimu.FastBufs
 end
 
 @testset "DictVectors.jl" begin
+    @test FastDVec(i => i^2 for i in 1:10; capacity = 30)|> length == 10
+    myfda = FastDVec("a" => 42; capacity = 40)
     myda2 = FastDVec{String,Int}(40)
     myda2["a"] = 42
     @test haskey(myda2,"a")
     @test !haskey(myda2,"b")
+    @test myfda == myda2
     myda2["c"] = 422
     myda2["d"] = 45
     myda2["f"] = 412
@@ -182,6 +185,13 @@ end
     ys = Tuple(empty(dv) for i in 1:Threads.nthreads())
     axpy!(2.0, dv, ys, batchsize=100)
     @test sum(norm.(ys, 1)) ≈ norm(dv,1)*2
+
+    mdv = DVec(:a => 2; capacity = 10)
+    @test mdv[:a] == 2
+    @test mdv[:b] == 0
+    @test length(mdv) == 1
+
+    @test DFVec(:a => (2,3); capacity = 10) == DFVec(Dict(:a => (2,3)))
 end
 
 using Rimu.ConsistentRNG

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using Rimu
 using Test
 using LinearAlgebra
+using Statistics, DataFrames
 
 # the following is needed because random numbers of collections are computed
 # differently after version 1.5, and thus the results of many tests change
@@ -12,7 +13,6 @@ const OV = VERSION<v"1.5"
     @test 3==3
 end
 
-using Statistics
 @testset "Blocking.jl" begin
     n=10
     a = rand(n)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -442,8 +442,13 @@ end
     # IsStochasticWithThreshold
     s = DoubleLogUpdate(targetwalkers = 100)
     svec = DVec(Dict(aIni => 2.0), ham(:dim))
-    Rimu.StochasticStyle(::Type{typeof(svec)}) = IsStochasticWithThreshold(1.0)
-    StochasticStyle(svec)
+    # Rimu.StochasticStyle(::Type{typeof(svec)}) = IsStochasticWithThreshold(1.0)
+    @setThreshold svec 0.621
+    @test StochasticStyle(svec) == IsStochasticWithThreshold(0.621)
+    @setDeterministic svec
+    @test StochasticStyle(svec) == IsDeterministic()
+    setThreshold(svec, 1.0)
+    @test StochasticStyle(svec) == IsStochasticWithThreshold(1.0)
     vs = copy(svec)
     pa = RunTillLastStep(laststep = 100)
     seedCRNG!(12345) # uses RandomNumbers.Xorshifts.Xoroshiro128Plus()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -65,6 +65,8 @@ using Statistics
     else
         @test reduce(&, Tuple(r).≈(-5.714600548611788, 0.21631081209341332, -5.884807394477632, 0.3849918114544903, 6))
     end
+    g = growthWitness(rdfs, b=50)
+    @test sum(g) ≈ -5725.3936298329545
 end
 
 using Rimu.BitStringAddresses


### PR DESCRIPTION
## Service Update
#### New features:

- new macros `@setThreshold` and `@setDetermnistic` and function `setThreshold` to modify `StochasticStyle` traits
- new unexported strategy `DeltaMemory3`
- new constructors for `DVec`, `DFVec` and `FastDVec` with mandatory keyword argument `capacity`
- new function `growthWitness()` in module `Blocking` to calculate the growth witness
 
#### Changed behaviour:

- `NormProjector` and `Norm2Projector` now trigger only computation of the norm of `v` and not of `dot(ham,v)` in order to run faster

#### Additional changes:

Improved tests, documentation updates, renamed internal function `energy_project()` into `compute_proj_observables()`
