### PR TITLE
Bugfix/GitHub actions

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -15,8 +15,10 @@ on:
       - feature/github-actions
 
 jobs:
-  testNewVersion: 
+  testNewVersion:
     runs-on: ${{ matrix.os }}
+    env:
+      ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
     strategy:
       matrix:
         julia-version: [1.5.2]
@@ -52,8 +54,10 @@ jobs:
           julia --project=@. -e "using Pkg; Pkg.instantiate(); Pkg.build()"
           julia --project=@. -e "using Pkg; Pkg.test(\"Rimu\");"
 
-  testOldVersion: 
+  testOldVersion:
     runs-on: ${{ matrix.os }}
+    env:
+      ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
     strategy:
       matrix:
         julia-version: [1.4.2]
@@ -87,4 +91,4 @@ jobs:
           mpirun echo "hello"
           julia --project=@. -e "using InteractiveUtils; versioninfo(verbose=true)"
           julia --project=@. -e "using Pkg; Pkg.instantiate(); Pkg.build()"
-          julia --project=@. -e "using Pkg; Pkg.test(\"Rimu\");"        
+          julia --project=@. -e "using Pkg; Pkg.test(\"Rimu\");"

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -17,8 +17,8 @@ on:
 jobs:
   testNewVersion:
     runs-on: ${{ matrix.os }}
-    env:
-      ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
+    # env:
+    #   ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
     strategy:
       matrix:
         julia-version: [1.5.2]
@@ -32,9 +32,9 @@ jobs:
         #     julia-arch: x86
 
     steps:
-      - uses: actions/checkout@v1.0.0
+      - uses: actions/checkout@latest
       - name: "Set up Julia"
-        uses: julia-actions/setup-julia@v0.2
+        uses: julia-actions/setup-julia@latest
         with:
           version: ${{ matrix.julia-version }}
           arch: ${{ matrix.julia-arch }}
@@ -56,8 +56,8 @@ jobs:
 
   testOldVersion:
     runs-on: ${{ matrix.os }}
-    env:
-      ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
+    # env:
+    #   ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
     strategy:
       matrix:
         julia-version: [1.4.2]
@@ -71,9 +71,9 @@ jobs:
         #     julia-arch: x86
 
     steps:
-      - uses: actions/checkout@v1.0.0
+      - uses: actions/checkout@latest
       - name: "Set up Julia"
-        uses: julia-actions/setup-julia@v0.2
+        uses: julia-actions/setup-julia@latest
         with:
           version: ${{ matrix.julia-version }}
           arch: ${{ matrix.julia-arch }}

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -32,9 +32,9 @@ jobs:
         #     julia-arch: x86
 
     steps:
-      - uses: actions/checkout@latest
+      - uses: actions/checkout@v2
       - name: "Set up Julia"
-        uses: julia-actions/setup-julia@latest
+        uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.julia-version }}
           arch: ${{ matrix.julia-arch }}
@@ -71,9 +71,9 @@ jobs:
         #     julia-arch: x86
 
     steps:
-      - uses: actions/checkout@latest
+      - uses: actions/checkout@v2
       - name: "Set up Julia"
-        uses: julia-actions/setup-julia@latest
+        uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.julia-version }}
           arch: ${{ matrix.julia-arch }}


### PR DESCRIPTION
The actions/setup-julia package version used in the Actions is outdated, which causes Actions to fail. Now it's specified as v1, solving the Action issue without adding env variables. Also updated actions/checkout to v2.