### PR TITLE
Fixing type parameter for HubbardMom1D

### DIFF
--- a/src/Hamiltonians.jl
+++ b/src/Hamiltonians.jl
@@ -889,7 +889,7 @@ diagME(mom::Momentum, add) = mod1(onr(add)⋅ks(mom.ham) + π, 2π) - π # fold 
 
 ###############################################
 
-struct HubbardMom1D{TT,U,T,N,M,AD} <: AbstractHamiltonian{T}
+struct HubbardMom1D{TT,U,T,N,M,AD} <: AbstractHamiltonian{TT}
     add::AD # default starting address, should have N particles and M modes
     ks::SVector{M,TT} # values for k
     kes::SVector{M,TT} # values for kinetic energy


### PR DESCRIPTION
Error encountered when calculating projected energy with `HubbardMom1D`:
```
ERROR: MethodError: no method matching promote_type(::Float64, ::Type{Int64})
Closest candidates are:
  promote_type(::Any, ::Any, ::Any, ::Any...) at promotion.jl:209
  promote_type(::Type{Union{}}, ::Type{T}) where T at promotion.jl:214
  promote_type(::Type{T}, ::Type{T}) where T at promotion.jl:212
  ...
Stacktrace:
 [1] *(::HubbardMom1D{Float64,6.0,1.0,8,4,BoseFS{8,4,BSAdd64}}, ::DVec{BoseFS{8,4,BSAdd64},Int64})
 ```
Identified the bug as 
```
struct HubbardMom1D{TT,U,T,N,M,AD} <: AbstractHamiltonian{T}
    add::AD # default starting address, should have N particles and M modes
    ks::SVector{M,TT} # values for k
    kes::SVector{M,TT} # values for kinetic energy
end
```
where `T` is no longer the type for the Hamiltonian property but the parameter to represent the hopping strength. `TT` is the correct type parameter for  `AbstractHamiltonian` in this case.

The bug was not introduced by recent changes in the BoseFS2C branch.