### PR TITLE
Use new ArrowTypes interface

### DIFF
--- a/src/RimuIO.jl
+++ b/src/RimuIO.jl
@@ -9,10 +9,12 @@ module RimuIO
 
 using Arrow, DataFrames
 
-function __init__()
-    Arrow.ArrowTypes.registertype!(Complex{Int},Complex{Int})
-    Arrow.ArrowTypes.registertype!(Complex{Float64},Complex{Float64})
-end
+const COMPLEX = Symbol("JuliaLang.Complex")
+ArrowTypes.arrowname(::Type{<:Complex}) = COMPLEX
+ArrowTypes.ArrowType(::Type{Complex{T}}) where {T} = Tuple{T,T}
+ArrowTypes.JuliaType(::Val{COMPLEX}, ::Type{Tuple{T,T}}) where {T} = Complex{T}
+ArrowTypes.toarrow(a::Complex) = (a.re, a.im)
+ArrowTypes.fromarrow(::Type{Complex{T}}, t::Tuple{T,T}) where {T} = Complex{T}(t...)
 
 """
     RimuIO.save(filename, df::DataFrame)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -604,6 +604,14 @@ end
     @test_throws AssertionError growthWitness(rdfs.norm, rdfs.shift[1:end-1],rdfs.dτ[1])
 end
 
+@testset "RimuIO" begin
+    file = joinpath(@__DIR__, "tmp.arrow")
+    df = DataFrame(a=[1, 2, 3], b=Complex{Float64}[1, 2, 3+im], d=rand(Complex{Int}, 3))
+    RimuIO.save_df(file, df)
+    df2 = RimuIO.load_df(file)
+    @test df == df2
+    rm(file)
+end
 
 using Rimu.EmbarrassinglyDistributed # bring relevant function into namespace
 @testset "EmbarrassinglyDistributed" begin


### PR DESCRIPTION
Fixes annoying warning messages when loading Rimu.