### PR TITLE
try to fix the errors with MPI-one-sided #47

### DIFF
--- a/src/RMPI.jl
+++ b/src/RMPI.jl
@@ -248,6 +248,16 @@ function mpi_no_exchange(data, comm = mpi_comm(), root = mpi_root)
 end
 
 """
+    register_MPI_Datatype(T)
+Register the type `T` for use as a data type with the `MPI` module. This is a workaround
+for a bug in `MPI.jl`.
+"""
+function register_MPI_Datatype(::Type{T}) where T
+      DT = MPI.Datatype(T)
+      @eval MPI.Datatype(::Type{$T}) = $DT
+end
+
+"""
     mpi_one_sided(data, comm = mpi_comm(), root = mpi_root)
 Declare `data` as mpi-distributed and set communication strategy to one-sided
 with remote memory access (RMA).
@@ -259,6 +269,8 @@ function mpi_one_sided(data, comm = mpi_comm(), root = mpi_root)
     np = MPI.Comm_size(comm)
     id = MPI.Comm_rank(comm)
     P = pairtype(data)
+
+    register_MPI_Datatype(P)
 
     # compute the required capacity for the communication buffer as a
     # fraction of the capacity of `data`


### PR DESCRIPTION
This PR seems to fix the problems with `mpi_one_sided()`, but is only a workaround. I think the real problem is the same underlying issue that we had with #9, which is that `MPI.Datatype()` is called every time we use `MPI.Put()`, and it creates a new struct for describing the custom data type in a digestible form for the MPI library. 

While #9 could be fixed by adding a finalizer, which allowed the GC to prevent memory growth, it still seems wasteful to create a new struct describing the custom data type on every call. I think this was causing the problems with our use of one-sided communication and `MPI.Put()`. The translation between the custom Julia type and the MPI data type should be made only once and then re-used thereafter. So to me it looks like a bug in MPI.jl. I will open an issue there.