### PR TITLE
MPI-related fixes and improvements.

### DIFF
--- a/src/Hamiltonians/TwoBodyCorrelation.jl
+++ b/src/Hamiltonians/TwoBodyCorrelation.jl
@@ -65,5 +65,5 @@ function get_offdiagonal(g::G2Correlator, add::BoseFS2C{NA,NB,M,AA,AB}, chosen) 
     new_add = BoseFS2C(new_bsa, new_bsb)
     gamma = sqrt(onproduct_a*onproduct_b)
     gd = exp(-im*g.d*(p-q)*2π/M)*gamma
-    return new_add, ComplexF64(gd/M)
+    return new_add, ComplexF64(gd/M)::ComplexF64
 end

--- a/src/Hamiltonians/TwoBodyCorrelation.jl
+++ b/src/Hamiltonians/TwoBodyCorrelation.jl
@@ -4,8 +4,8 @@
     G2Correlator(d::Int) <: AbstractHamiltonian{ComplexF64}
 
 Two-body correlation operator representing the inter-component density-
-density correlation at distance `d` of a two component system 
-in a momentum-space Fock-state basis. 
+density correlation at distance `d` of a two component system
+in a momentum-space Fock-state basis.
 It returns a `Complex` value.
 It currently only works on [`BoseFS2C`](@ref).
 
@@ -65,5 +65,5 @@ function get_offdiagonal(g::G2Correlator, add::BoseFS2C{NA,NB,M,AA,AB}, chosen) 
     new_add = BoseFS2C(new_bsa, new_bsb)
     gamma = sqrt(onproduct_a*onproduct_b)
     gd = exp(-im*g.d*(p-q)*2π/M)*gamma
-    return new_add, gd/M
+    return new_add, ComplexF64(gd/M)
 end

--- a/src/Hamiltonians/operations.jl
+++ b/src/Hamiltonians/operations.jl
@@ -74,11 +74,13 @@ end
 Internal function evaluates the 3-argument `dot()` function in order from right
 to left.
 """
-function dot_from_right(x::AbstractDVec{K,T1}, LO::AbstractHamiltonian{T}, v::AbstractDVec{K,T2}) where {K, T,T1, T2}
-    result = zero(promote_type(T1,promote_type(T,T2)))
-    for (key,val) in pairs(v)
+function dot_from_right(
+    x::AbstractDVec{K,T}, LO::AbstractHamiltonian{U}, v::AbstractDVec{K,V}
+) where {K,T,U,V}
+    result = zero(promote_type(T, U, V))
+    for (key, val) in pairs(v)
         result += conj(x[key]) * diagonal_element(LO, key) * val
-        for (add,elem) in offdiagonals(LO, key)
+        for (add, elem) in offdiagonals(LO, key)
             result += conj(x[add]) * elem * val
         end
     end

--- a/src/Hamiltonians/operations.jl
+++ b/src/Hamiltonians/operations.jl
@@ -19,7 +19,7 @@ function Base.:*(h::AbstractHamiltonian{E}, v::AbstractDVec{K,V}) where {E, K, V
     w = empty(v, T) # allocate new vector; non-mutating version
     for (key,val) in pairs(v)
         w[key] += diagonal_element(h, key)*val
-        for (add,elem) in offdiagonals(h, key)
+        for (add, elem) in offdiagonals(h, key)
             w[add] += elem*val
         end
     end

--- a/src/RMPI/RMPI.jl
+++ b/src/RMPI/RMPI.jl
@@ -14,7 +14,7 @@ import Rimu: sort_into_targets!
 
 export MPIData
 export mpi_rank, is_mpi_root, @mpi_root, mpi_barrier
-export mpi_comm, mpi_root, mpi_size, mpi_seed_CRNGs!
+export mpi_comm, mpi_root, mpi_size, mpi_seed_CRNGs!, mpi_allprintln
 
 function __init__()
     # Initialise the MPI library once at runtime.

--- a/src/RMPI/helpers.jl
+++ b/src/RMPI/helpers.jl
@@ -157,3 +157,17 @@ function mpi_seed_CRNGs!(seed = rand(Random.RandomDevice(), UInt))
     _check_crng_independence(mpi_comm())
     return rngs
 end
+
+"""
+    mpi_allprintln(args...)
+Print a message to `stdout` from each rank separately, in order. MPI synchronizing.
+"""
+function mpi_allprintln(args...)
+    for i in 0:(mpi_size() - 1)
+        if mpi_rank() == i
+            print("[ rank ", lpad(i, length(string(mpi_size() - 1))), ": ", args...)
+            flush(stdout)
+        end
+        mpi_barrier()
+    end
+end

--- a/src/RMPI/helpers.jl
+++ b/src/RMPI/helpers.jl
@@ -63,10 +63,10 @@ The MPI barrier with optional argument. MPI syncronizing.
 mpi_barrier(comm = mpi_comm()) = MPI.Barrier(comm)
 
 """
-    targetrank(key, np, hash = hash(key))
+    targetrank(key, np)
 Compute the rank where the `key` belongs.
 """
-targetrank(key, np, hash = hash(key)) = hash%np
+targetrank(key, np) = hash(key, hash(1)) % np
 
 """
     mpi_combine_walkers!(target, source, [strategy])

--- a/src/RMPI/helpers.jl
+++ b/src/RMPI/helpers.jl
@@ -165,7 +165,7 @@ Print a message to `stdout` from each rank separately, in order. MPI synchronizi
 function mpi_allprintln(args...)
     for i in 0:(mpi_size() - 1)
         if mpi_rank() == i
-            print("[ rank ", lpad(i, length(string(mpi_size() - 1))), ": ", args...)
+            println("[ rank ", lpad(i, length(string(mpi_size() - 1))), ": ", args...)
             flush(stdout)
         end
         mpi_barrier()

--- a/src/RMPI/mpidata.jl
+++ b/src/RMPI/mpidata.jl
@@ -127,6 +127,14 @@ function Rimu.DictVectors.walkernumber(md::MPIData)
     return MPI.Allreduce(walkernumber(md.data), +, md.comm)
 end
 
+"""
+    *(lop::AbstractHamiltonian, md::MPIData)
+Allocating "Matrix"-"vector" multiplication with MPI-distributed "vector" `md`. The result is similar to 
+[`localpart(md)`](@ref) with all content having been communicated to the correct [`targetrank`](@ref).
+MPI communicating.
+
+See [`MPIData`](@ref).
+"""
 function Base.:*(lop, md::MPIData)
     T = promote_type(eltype(lop),valtype(md))
     P = Pair{keytype(md),T}

--- a/src/RMPI/mpidata.jl
+++ b/src/RMPI/mpidata.jl
@@ -127,6 +127,53 @@ function Rimu.DictVectors.walkernumber(md::MPIData)
     return MPI.Allreduce(walkernumber(md.data), +, md.comm)
 end
 
+function Base.:*(lop, md::MPIData)
+    T = promote_type(eltype(lop),valtype(md))
+    P = Pair{keytype(md),T}
+    buffers = Vector{P}[P[] for _ in 1:mpi_size()]
+    datatype = MPI.Datatype(P)
+    myrank = mpi_rank()
+    recbuf = buffers[myrank + 1]
+
+    result = similar(localpart(md), T)
+
+    # Do the multiplication into the buffers.
+    for (key,val) in pairs(localpart(md))
+        result[key] += diagonal_element(lop, key)*val
+        for (add, elem) in offdiagonals(lop, key)
+            tr = targetrank(add, mpi_size())
+            if tr == myrank
+                result[add] += elem * val
+            else
+                push!(buffers[tr + 1], add => elem * val)
+            end
+        end
+    end
+
+    # Receive from lower ranks.
+    for id in 0:(myrank - 1)
+        resize!(recbuf, MPI.Get_count(MPI.Probe(id, 0, md.comm), datatype))
+        MPI.Recv!(recbuf, id, 0, md.comm)
+        for (add, value) in recbuf
+            result[add] += value
+        end
+    end
+    # Perform sends.
+    for id in 0:(mpi_size() - 1)
+        id == myrank && continue
+        MPI.Send(buffers[id + 1], id, 0, md.comm)
+    end
+    # Receive from lower ranks.
+    for id in (myrank + 1):(mpi_size() - 1)
+        resize!(recbuf, MPI.Get_count(MPI.Probe(id, 0, md.comm), datatype))
+        MPI.Recv!(recbuf, id, 0, md.comm)
+        for (add, value) in recbuf
+            result[add] += value
+        end
+    end
+    return result
+end
+
 function LinearAlgebra.dot(x, md::MPIData)
     return MPI.Allreduce(localpart(x)⋅localpart(md), +, md.comm)
 end
@@ -134,10 +181,7 @@ function LinearAlgebra.dot(x, lop, md::MPIData)
     return MPI.Allreduce(dot(x, lop, localpart(md)), +, md.comm)
 end
 function LinearAlgebra.dot(md_left::MPIData, lop, md_right::MPIData)
-    temp_1 = lop * localpart(md_right)
-    # Construct a new MPIData instance and use it to communicate walkers that were supposed
-    # to be on a different rank.
-    temp_2 = MPIData(empty(temp_1))
-    mpi_combine_walkers!(temp_2, temp_1)
-    return dot(localpart(md_left), temp_2)
+    # Arguments are swapped since lop * md_right is not an MPIData and MPIData should be on
+    # the right hand side.
+    return conj(dot(lop * md_right, md_left))
 end

--- a/src/strategies_and_params/replicastrategy.jl
+++ b/src/strategies_and_params/replicastrategy.jl
@@ -70,7 +70,7 @@ function replica_stats(rs::AllOverlaps{N}, replicas) where {N}
     values = T[]
     for i in 1:N, j in i+1:N
         push!(names, "c$(i)_dot_c$(j)")
-        push!(values, dot(localpart(replicas[i].v), localpart(replicas[j].v)))
+        push!(values, dot(replicas[i].v, replicas[j].v))
         for (k, op) in enumerate(rs.operators)
             push!(names, "c$(i)_Op$(k)_c$(j)")
             push!(values, dot(replicas[i].v, op, replicas[j].v))


### PR DESCRIPTION
This PR does _not_ fix #81, but it does implement the following fixes:
* Make `*(::AbstractHamiltonian, ::MPIData)` (also three-argument `dot`) type-stable and faster.
* Change hashing function in `targetrank` for better distribution among ranks.
* Fix dot product bug in `AllOverlaps`.
* Add `mpi_allprintln` for nicer printing with MPI.