### PR TITLE
Bugfix/g2correlator wrong momenta

### DIFF
--- a/src/Hamiltonians/BoseHubbardMom1D2C.jl
+++ b/src/Hamiltonians/BoseHubbardMom1D2C.jl
@@ -140,7 +140,7 @@ addresses and products of occupation numbers for computing off-diagonal elements
     # if mod(q+r,M)-mod(s+p,M) != 0 # sanity check for momentum conservation
     #     error("Momentum is not conserved!")
     # end
-    return BoseFS{NA,M}(onrep_a), BoseFS{NB,M}(onrep_b), onproduct_a, onproduct_b, p, q
+    return BoseFS{NA,M}(onrep_a), BoseFS{NB,M}(onrep_b), onproduct_a, onproduct_b, s, q
 end
 
 function get_offdiagonal(ham::BoseHubbardMom1D2C, add::BoseFS2C, chosen)

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -380,8 +380,8 @@ end
     @test imag(dot(v0,g0,v0)) == 0 # should be strictly real
     @test abs(imag(dot(v0,g3,v0))) < 1e-10
     @test dot(v0,g0,v0) ≈ 0.6519750102294596
-    @test dot(v0,g1,v0) ≈ 0.6740721867996825
-    @test dot(v0,g2,v0) ≈ 0.6740721867996825
+    @test dot(v0,g1,v0) ≈ 0.6740124948852698
+    @test dot(v0,g2,v0) ≈ 0.6740124948852698
     @test dot(v0,g3,v0) ≈ 0.6519750102294596
     @test num_offdiagonals(g0,aIni) == 2
 end


### PR DESCRIPTION
Function `hop_across_two_addresses()` returns incorrect momenta due to different way of indexing operators in `HubbardMom1D2C` where `s` is the index for `b†`, but in `G2Correlator` is labelled as `p`. 