### PR TITLE
Momentum space offdiagonal allocations

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -13,8 +13,6 @@ jobs:
       - uses: julia-actions/julia-buildpkg@latest
       - name: Install dependencies
         run: julia -e 'using Pkg; pkg"add PkgBenchmark BenchmarkTools BenchmarkCI@0.1"'
-      - name: Run benchmarks
-        run: julia -e 'using BenchmarkCI; BenchmarkCI.judge(baseline="origin/develop"); BenchmarkCI.displayjudgement()'
 
       # generate result markdown
       - name: generate benchmark result
@@ -23,7 +21,7 @@ jobs:
           body=$(julia -e '
           using BenchmarkCI
           let
-              judgement = BenchmarkCI._loadjudge(BenchmarkCI.DEFAULT_WORKSPACE)
+              judgement = BenchmarkCI.judge(target="origin/develop")
               title = "Benchmark result"
               ciresult = BenchmarkCI.CIResult(; judgement, title)
               BenchmarkCI.printcommentmd(stdout::IO, ciresult)

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -13,6 +13,8 @@ jobs:
       - uses: julia-actions/julia-buildpkg@latest
       - name: Install dependencies
         run: julia -e 'using Pkg; pkg"add PkgBenchmark BenchmarkTools BenchmarkCI@0.1"'
+      - name: Run benchmarks
+        run: julia -e 'using BenchmarkCI; BenchmarkCI.judge(baseline="origin/develop"); BenchmarkCI.displayjudgement()'
 
       # generate result markdown
       - name: generate benchmark result
@@ -21,7 +23,7 @@ jobs:
           body=$(julia -e '
           using BenchmarkCI
           let
-              judgement = BenchmarkCI.judge(baseline="origin/develop")
+              judgement = BenchmarkCI._loadjudge(BenchmarkCI.DEFAULT_WORKSPACE)
               title = "Benchmark result"
               ciresult = BenchmarkCI.CIResult(; judgement, title)
               BenchmarkCI.printcommentmd(stdout::IO, ciresult)

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -21,7 +21,7 @@ jobs:
           body=$(julia -e '
           using BenchmarkCI
           let
-              judgement = BenchmarkCI.judge(target="origin/develop")
+              judgement = BenchmarkCI.judge(baseline="origin/develop")
               title = "Benchmark result"
               ciresult = BenchmarkCI.CIResult(; judgement, title)
               BenchmarkCI.printcommentmd(stdout::IO, ciresult)

--- a/src/Hamiltonians/HubbardMom1D.jl
+++ b/src/Hamiltonians/HubbardMom1D.jl
@@ -169,76 +169,94 @@ and the change in momentum.
 """
 @inline function momentum_transfer_excitation(add, chosen, singlies, doublies)
     M = num_modes(add)
-    onrep = BitStringAddresses.m_onr(add)
-    # get occupation number representation as a static array
-    onproduct = 1
-    k = p = q = 0
-    double = chosen - singlies*(singlies-1)*(M - 2)
-    # start by making holes as the action of two annihilation operators
-    if double > 0 # need to choose doubly occupied site for double hole
-        # c_p c_p
-        double, q = fldmod1(double, M-1)
-        # double is location of double
-        # q is momentum transfer
-        for (i, occ) in enumerate(onrep)
-            if occ > 1
-                double -= 1
-                if double == 0
-                    onproduct *= occ*(occ-1)
-                    @inbounds onrep[i] = occ-2
-                    # annihilate two particles in onrep
-                    p = k = i # remember where we make the holes
-                    break # should break out of the for loop
-                end
-            end
-        end
-    else # need to punch two single holes
-        # c_k c_p
-        pair, q = fldmod1(chosen, M-2) # floored integer division and modulus in ranges 1:(m-1)
-        first, second = fldmod1(pair, singlies-1) # where the holes are to be made
-        if second < first # put them in ascending order
-            f_hole = second
-            s_hole = first
-        else
-            f_hole = first
-            s_hole = second + 1 # as we are counting through all singlies
-        end
-        counter = 0
-        for (i, occ) in enumerate(onrep)
-            if occ > 0
-                counter += 1
-                if counter == f_hole
-                    onproduct *= occ
-                    @inbounds onrep[i] = occ-1
-                    # punch first hole
-                    p = i # location of first hole
-                elseif counter == s_hole
-                    onproduct *= occ
-                    @inbounds onrep[i] = occ-1
-                    # punch second hole
-                    k = i # location of second hole
-                    break
-                end
-            end
-        end
-        # we have p<k and 1 < q < ham.m - 2
-        if q ≥ k-p
-            q += 1 # to avoid putting particles back into the holes
-        end
-    end # if double > 0 # we're done punching holes
+    onrep = onr(add)
+    double = chosen - singlies * (singlies - 1) * (M - 2)
+    # Start by making holes as the action of two annihilation operators.
+    if double > 0
+        # Need to choose doubly occupied site for double hole.
+        onrep, onproduct, p, q, k = double_hole(onrep, double)
+    else
+        # Need to punch two single holes.
+        onrep, onproduct, p, q, k = single_hole(onrep, chosen, singlies)
+    end
 
-    # now it is time to deal with two creation operators
-    # c^†_k-q
-    kmq = mod1(k-q, M) # in 1:m # use mod1() to implement periodic boundaries
-    @inbounds occ = onrep[kmq]
-    onproduct *= occ + 1
-    @inbounds onrep[kmq] = occ + 1
-    # c^†_p+q
-    ppq = mod1(p+q, M) # in 1:m # use mod1() to implement periodic boundaries
-    @inbounds occ = onrep[ppq]
-    onproduct *= occ + 1
-    @inbounds onrep[ppq] = occ + 1
+    onrep, onproduct = creation_operators(onrep, onproduct, p, q, k)
     return SVector(onrep), onproduct, -q
+end
+function double_hole(onrep::SVector{M}, double) where {M}
+    m_onrep = MVector(onrep...)
+    double, q = fldmod1(double, M - 1)
+    p = k = 0
+    onproduct = 1
+    # q is momentum transfer
+    for (i, occ) in enumerate(onrep)
+        if occ > 1
+            double -= 1
+            if double == 0
+                onproduct *= occ * (occ - 1)
+                @inbounds m_onrep[i] = occ - 2
+                # annihilate two particles in onrep
+                p = k = i # remember where we make the holes
+                break
+            end
+        end
+    end
+    return SVector(m_onrep), onproduct, p, q, k
+end
+function single_hole(onrep::SVector{M}, chosen, singlies) where {M}
+    m_onrep = MVector(onrep...)
+    # c_k c_p
+    pair, q = fldmod1(chosen, M - 2)
+    p = k = 0
+    onproduct = 1
+
+    first, second = fldmod1(pair, singlies - 1) # where the holes are to be made
+    if second < first # put them in ascending order
+        f_hole = second
+        s_hole = first
+    else
+        f_hole = first
+        s_hole = second + 1 # as we are counting through all singlies
+    end
+
+    counter = 0
+    for (i, occ) in enumerate(onrep)
+        if occ > 0
+            counter += 1
+            if counter == f_hole
+                onproduct *= occ
+                @inbounds m_onrep[i] = occ - 1
+                # punch first hole
+                p = i # location of first hole
+            elseif counter == s_hole
+                onproduct *= occ
+                @inbounds m_onrep[i] = occ - 1
+                # punch second hole
+                k = i # location of second hole
+                break
+            end
+        end
+    end
+    # we have p<k and 1 < q < ham.m - 2
+    if q ≥ k-p
+        q += 1 # to avoid putting particles back into the holes
+    end
+    return SVector(m_onrep), onproduct, p, q, k
+end
+function creation_operators(onrep::SVector{M}, onproduct, p, q, k) where {M}
+    m_onrep = MVector(onrep...)
+    # c^†_k-q
+    kmq = mod1(k - q, M)
+    @inbounds occ = m_onrep[kmq]
+    onproduct *= occ + 1
+    @inbounds m_onrep[kmq] = occ + 1
+    # c^†_p+q
+    ppq = mod1(p + q, M)
+    @inbounds occ = m_onrep[ppq]
+    onproduct *= occ + 1
+    @inbounds m_onrep[ppq] = occ + 1
+
+    return SVector(m_onrep), onproduct
 end
 
 @inline function get_offdiagonal(


### PR DESCRIPTION
Offdiagonals for the momentum space models were allocating. This PR fixes that.

The problem only appears on the `master` branch of Julia, which is why the benchmarks don't show any improvement. There, allocations go from tens GiB to tens of MiB per run.