### PR TITLE
Different way to do three-argument dot with MPI

### DIFF
--- a/src/RMPI/mpidata.jl
+++ b/src/RMPI/mpidata.jl
@@ -317,7 +317,6 @@ function Rimu.replica_stats(
 end
 
 function Rimu.all_overlaps(operators::Tuple, vecs::NTuple{N,MPIData}) where {N}
-    println("called")
     local_vec_i = similar(localpart(vecs[1]))
     T = promote_type((valtype(v) for v in vecs)..., eltype.(operators)...)
     names = String[]

--- a/src/RMPI/mpidata.jl
+++ b/src/RMPI/mpidata.jl
@@ -296,26 +296,6 @@ function Rimu.freeze(md::MPIData)
     return freeze(localpart(md))
 end
 
-using ..Rimu: ReplicaState, AllOverlaps
-function Rimu.replica_stats(
-    rs::AllOverlaps{2}, replicas::NTuple{2,ReplicaState{<:Any,<:MPIData}}
-)
-    local_left = copy_to_local(replicas[1])
-
-    T = promote_type((valtype(r.v) for r in replicas)..., eltype.(rs.operators)...)
-    names = String[]
-    values = T[]
-    push!(names, "c$(i)_dot_c$(j)")
-    push!(values, dot(local_left, replicas[2].v))
-    for (k, op) in enumerate(rs.operators)
-        push!(names, "c$(i)_Op$(k)_c$(j)")
-        push!(values, dot(local_left, op, replicas[2].v))
-    end
-
-    num_reports = length(rs.operators) + 1
-    return SVector{num_reports,String}(names).data, SVector{num_reports,T}(values).data
-end
-
 function Rimu.all_overlaps(operators::Tuple, vecs::NTuple{N,MPIData}) where {N}
     local_vec_i = similar(localpart(vecs[1]))
     T = promote_type((valtype(v) for v in vecs)..., eltype.(operators)...)

--- a/src/RMPI/mpidata.jl
+++ b/src/RMPI/mpidata.jl
@@ -253,10 +253,7 @@ function copy_to_local!(target, md::MPIData)
     datatype = MPI.Datatype(eltype(md))
 
     # Store all pairs to a buffer.
-    sendbuf = Vector{eltype(md)}(undef, length(localpart(md)))
-    for (i, p) in enumerate(pairs(localpart(md)))
-        sendbuf[i] = p
-    end
+    sendbuf = collect(pairs(localpart(md)))
     recbuf = eltype(md)[]
 
     # Receive from lower ranks.

--- a/test/mpi_runtests.jl
+++ b/test/mpi_runtests.jl
@@ -62,6 +62,12 @@ end
 @testset "MPI tests" begin
     @testset "MPIData" begin
         for type in (InitiatorDVec, DVec)
+            @testset "copy_to_local" begin
+                dv = MPIData(type(mpi_rank() => 1, -1 => 10))
+                loc = RMPI.copy_to_local(dv)
+                @test length(loc) == mpi_size() + 1
+                @test loc[-1] == 10 * mpi_size()
+            end
             @testset "Single component $type" begin
                 for i in 1:N_REPEATS
                     add = BoseFS((0,0,10,0,0))

--- a/test/mpi_runtests.jl
+++ b/test/mpi_runtests.jl
@@ -245,7 +245,8 @@ end
                     setup,
                     kwargs...
                 )
-                df = lomc!(H, dv; laststep=5000).df
+                s_strat = DoubleLogUpdate(targetwalkers=100)
+                df = lomc!(H, dv; laststep=5000, s_strat).df
 
                 # Shift estimate.
                 Es, _ = mean_and_se(df.shift[2000:end])


### PR DESCRIPTION
Doing the dot product this way uses way less memory. Finally closes #81 