### PR TITLE
Custom single-particle dispersion for `HubbardMom1D`

### DIFF
--- a/src/Hamiltonians/BoseHubbardMom1D2C.jl
+++ b/src/Hamiltonians/BoseHubbardMom1D2C.jl
@@ -1,7 +1,8 @@
 """
-    BoseHubbardMom1D2C(add::BoseFS2C; ua=1.0, ub=1.0, ta=1.0, tb=1.0, v=1.0)
+    BoseHubbardMom1D2C(add::BoseFS2C; ua=1.0, ub=1.0, ta=1.0, tb=1.0, v=1.0, kwargs...)
 
-Implements a two-component one-dimensional Bose Hubbard chain in momentum space.
+Implements a one-dimensional Bose Hubbard chain in momentum space with a two-component
+Bose gas.
 
 ```math
 \\hat{H} = \\hat{H}_a + \\hat{H}_b + \\frac{V}{M}\\sum_{kpqr} b^†_{r} a^†_{q} b_p a_k δ_{r+q,p+k}
@@ -15,10 +16,11 @@ Implements a two-component one-dimensional Bose Hubbard chain in momentum space.
 * `ta`: the `t` parameter for Hamiltonian a.
 * `tb`: the `t` parameter for Hamiltonian b.
 * `v`: the inter-species interaction parameter V.
+Further keyword arguments are passed on to the constructor of [`HubbardMom1D`](@ref).
 
 # See also
 
-* [`HubbardMom1D`](@ref)
+* [`BoseFS2C`](@ref)
 * [`BoseHubbardReal1D2C`](@ref)
 
 """
@@ -27,9 +29,9 @@ struct BoseHubbardMom1D2C{T,HA,HB,V} <: TwoComponentHamiltonian{T}
     hb::HB
 end
 
-function BoseHubbardMom1D2C(add::BoseFS2C; ua=1.0, ub=1.0, ta=1.0, tb=1.0, v=1.0)
-    ha = HubbardMom1D(add.bsa;u=ua,t=ta)
-    hb = HubbardMom1D(add.bsb;u=ub,t=tb)
+function BoseHubbardMom1D2C(add::BoseFS2C; ua=1.0, ub=1.0, ta=1.0, tb=1.0, v=1.0, args...)
+    ha = HubbardMom1D(add.bsa; u=ua, t=ta, args...)
+    hb = HubbardMom1D(add.bsb; u=ub, t=tb, args...)
     T = promote_type(eltype(ha), eltype(hb))
     return BoseHubbardMom1D2C{T,typeof(ha),typeof(hb),v}(ha, hb)
 end

--- a/src/Hamiltonians/Hamiltonians.jl
+++ b/src/Hamiltonians/Hamiltonians.jl
@@ -43,6 +43,7 @@ export MatrixHamiltonian
 export HubbardReal1D, HubbardMom1D, ExtendedHubbardReal1D, HubbardRealSpace
 export BoseHubbardMom1D2C, BoseHubbardReal1D2C
 export GutzwillerSampling, GuidingVectorSampling
+export hubbard_dispersion, continuum_dispersion
 
 export G2Correlator
 

--- a/src/Hamiltonians/HubbardMom1D.jl
+++ b/src/Hamiltonians/HubbardMom1D.jl
@@ -28,7 +28,7 @@ Implements a one-dimensional Bose Hubbard chain in momentum space.
 * `address`: the starting address, defines number of particles and sites.
 * `u`: the interaction parameter.
 * `t`: the hopping strength.
-* `dispersion`: defines ``ϵ_k``
+* `dispersion`: defines ``ϵ_k =``` t*dispersion(k)`
     - [`hubbard_dispersion`](@ref): ``ϵ_k = -2t \\cos(k)``
     - [`continuum_dispersion`](@ref): ``ϵ_k = tk^2``
 

--- a/src/Hamiltonians/HubbardMom1D.jl
+++ b/src/Hamiltonians/HubbardMom1D.jl
@@ -1,11 +1,26 @@
 """
-    HubbardMom1D(address; u=1.0, t=1.0)
+    hubbard_dispersion(k)
+Dispersion relation for [`HubbardMom1D`](@ref). Returns `-2cos(k)`.
+
+See also [`continuum_dispersion`](@ref).
+"""
+hubbard_dispersion(k) = -2cos(k)
+
+"""
+    continuum_dispersion(k)
+Dispersion relation for [`HubbardMom1D`](@ref). Returns `2k`.
+
+See also [`hubbard_dispersion`](@ref).
+"""
+continuum_dispersion(k) = k^2
+
+"""
+    HubbardMom1D(address; u=1.0, t=1.0, dispersion=hubbard_dispersion)
 
 Implements a one-dimensional Bose Hubbard chain in momentum space.
 
 ```math
-\\hat{H} =  \\sum_{k} ϵ_k n_k + \\frac{u}{M}\\sum_{kpqr} a^†_{r} a^†_{q} a_p a_k δ_{r+q,p+k}\\\\
-ϵ_k = -2t \\cos(k)
+\\hat{H} =  \\sum_{k} ϵ_k n_k + \\frac{u}{M}\\sum_{kpqr} a^†_{r} a^†_{q} a_p a_k δ_{r+q,p+k}
 ```
 
 # Arguments
@@ -13,12 +28,14 @@ Implements a one-dimensional Bose Hubbard chain in momentum space.
 * `address`: the starting address, defines number of particles and sites.
 * `u`: the interaction parameter.
 * `t`: the hopping strength.
+* `dispersion`: defines ``ϵ_k``
+    - [`hubbard_dispersion`](@ref): ``ϵ_k = -2t \\cos(k)``
+    - [`continuum_dispersion`](@ref): ``ϵ_k = tk^2``
 
 # See also
 
 * [`HubbardReal1D`](@ref)
 * [`ExtendedHubbardReal1D`](@ref)
-
 """
 struct HubbardMom1D{TT,M,AD<:AbstractFockAddress,U,T} <: AbstractHamiltonian{TT}
     add::AD # default starting address, should have N particles and M modes
@@ -26,7 +43,10 @@ struct HubbardMom1D{TT,M,AD<:AbstractFockAddress,U,T} <: AbstractHamiltonian{TT}
     kes::SVector{M,TT} # values for kinetic energy
 end
 
-function HubbardMom1D(add::BoseFS{<:Any,M}; u=1.0, t=1.0) where {M}
+function HubbardMom1D(
+    add::BoseFS{<:Any,M};
+    u=1.0, t=1.0, dispersion = hubbard_dispersion,
+) where {M}
     U, T = promote(float(u), float(t))
     step = 2π/M
     if isodd(M)
@@ -36,7 +56,8 @@ function HubbardMom1D(add::BoseFS{<:Any,M}; u=1.0, t=1.0) where {M}
     end
     kr = range(start; step = step, length = M)
     ks = SVector{M}(kr)
-    kes = SVector{M}(-2T*cos.(kr))
+    # kes = SVector{M}(-2T*cos.(kr))
+    kes = SVector{M}(T .* dispersion.(kr))
     return HubbardMom1D{typeof(U),M,typeof(add),U,T}(add, ks, kes)
 end
 

--- a/src/Hamiltonians/HubbardMom1D.jl
+++ b/src/Hamiltonians/HubbardMom1D.jl
@@ -8,7 +8,7 @@ hubbard_dispersion(k) = -2cos(k)
 
 """
     continuum_dispersion(k)
-Dispersion relation for [`HubbardMom1D`](@ref). Returns `2k`.
+Dispersion relation for [`HubbardMom1D`](@ref). Returns `k^2`.
 
 See also [`hubbard_dispersion`](@ref).
 """

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -96,6 +96,23 @@ end
     @test diagonal_element(HRu0, bs2) == 0
     @test all(iszero, e for (_, e) in offdiagonals(HMu0, bs1))
     @test all(iszero, e for (_, e) in offdiagonals(HRt0, bs2))
+
+    t = 1
+    bs3 = BoseFS((0,3,0))
+    HM3Cu0 =HubbardMom1D(bs3; u=0, t, dispersion=continuum_dispersion)
+    HM3Hu0 =HubbardMom1D(bs3; u=0, t, dispersion=hubbard_dispersion)
+    @test HubbardMom1D(bs3; u=0, t) == HM3Hu0
+    @test diagonal_element(HM3Cu0, bs3) == 0
+    @test 2t*num_particles(bs3) + diagonal_element(HM3Hu0, bs3) == 0
+
+    HM2Cu0 =HubbardMom1D(bs2; u=0, t, dispersion=continuum_dispersion)
+    HM2Hu0 =HubbardMom1D(bs2; u=0, t, dispersion=hubbard_dispersion)
+    @test diagonal_element(HM2Cu0, bs2) > 2t*num_particles(bs2)+diagonal_element(HM2Hu0,bs2)
+    @test diagonal_element(HM2Cu0, bs2) ≈ 6*t*(2pi/num_modes(bs2))^2
+
+    HM3Ct0 =HubbardMom1D(bs3; t=0, dispersion=continuum_dispersion)
+    HM3Ht0 =HubbardMom1D(bs3; t=0, dispersion=hubbard_dispersion)
+    @test offdiagonals(HM3Ht0,bs3) == offdiagonals(HM3Ht0,bs3)
 end
 
 @testset "1C model properties" begin


### PR DESCRIPTION
The single particle dispersion relation used in `HubbardMom1D` and `BoseHubbardMom1D2C` can be changed with the keyword argument `dispersion`. See the docstring of `HubbardMom1D`.