### PR TITLE
Harmonic trap for Hubbard model in 1D real space

### DIFF
--- a/src/Hamiltonians/Hamiltonians.jl
+++ b/src/Hamiltonians/Hamiltonians.jl
@@ -41,7 +41,7 @@ export dimension, rayleigh_quotient, momentum
 
 export MatrixHamiltonian
 export HubbardReal1D, HubbardMom1D, ExtendedHubbardReal1D, HubbardRealSpace
-export HubbardReal1DEP
+export HubbardReal1DEP, shift_lattice, shift_lattice_inv
 export BoseHubbardMom1D2C, BoseHubbardReal1D2C
 export GutzwillerSampling, GuidingVectorSampling
 export hubbard_dispersion, continuum_dispersion

--- a/src/Hamiltonians/Hamiltonians.jl
+++ b/src/Hamiltonians/Hamiltonians.jl
@@ -41,6 +41,7 @@ export dimension, rayleigh_quotient, momentum
 
 export MatrixHamiltonian
 export HubbardReal1D, HubbardMom1D, ExtendedHubbardReal1D, HubbardRealSpace
+export HubbardReal1DEP
 export BoseHubbardMom1D2C, BoseHubbardReal1D2C
 export GutzwillerSampling, GuidingVectorSampling
 export hubbard_dispersion, continuum_dispersion
@@ -58,6 +59,7 @@ include("geometry.jl")
 include("MatrixHamiltonian.jl")
 
 include("HubbardReal1D.jl")
+include("HubbardReal1DEP.jl")
 include("HubbardMom1D.jl")
 include("HubbardRealSpace.jl")
 include("ExtendedHubbardReal1D.jl")

--- a/src/Hamiltonians/HubbardReal1DEP.jl
+++ b/src/Hamiltonians/HubbardReal1DEP.jl
@@ -1,4 +1,22 @@
 """
+    shift_lattice(is)
+Circular shift contiguous indices `is` in interval `[M÷2, M÷2)` such that set starts with 0,
+where `M=length(is)`.
+
+Inverse operation: [`shift_lattice_inv`](@ref).
+"""
+shift_lattice(is) = circshift(is, cld(length(is),2))
+
+"""
+    shift_lattice_inv(js)
+Circular shift indices starting with 0 into a contiguous set in interval `[M÷2, M÷2)`,
+where `M=length(js)`.
+
+Inverse operation of [`shift_lattice`](@ref).
+"""
+shift_lattice_inv(js) = circshift(js, fld(length(js),2))
+
+"""
     HubbardReal1DEP(address; u=1.0, t=1.0, v_ho=1.0)
 
 Implements a one-dimensional Bose Hubbard chain in real space with external potential.
@@ -13,7 +31,9 @@ Implements a one-dimensional Bose Hubbard chain in real space with external pote
 * `address`: the starting address, defines number of particles and sites.
 * `u`: the interaction parameter.
 * `t`: the hopping strength.
-* `v_ho`: strength of the external harmonic oscillator potential ``ϵ_i = v_{ho} i^2``
+* `v_ho`: strength of the external harmonic oscillator potential ``ϵ_i = v_{ho} i^2``.
+The first index is `i=0` and the maximum of the potential occurs in the centre of the
+lattice.
 
 # See also
 
@@ -29,7 +49,9 @@ end
 
 function HubbardReal1DEP(addr::BoseFS{<:Any,M}; u=1.0, t=1.0, v_ho=1.0) where M
     U, T, V = promote(float(u), float(t), float(v_ho))
-    js = range(1-cld(M,2); length=M)
+    # js = range(1-cld(M,2); length=M)
+    is = range(-fld(M,2); length=M) # [-M÷2, M÷2) including left boundary
+    js = shift_lattice(is) # shifted such that is[1] = 0
     potential = SVector{M}(V*j^2 for j in js)
     return HubbardReal1DEP{typeof(U),typeof(addr),U,T,M}(addr, potential)
 end

--- a/src/Hamiltonians/HubbardReal1DEP.jl
+++ b/src/Hamiltonians/HubbardReal1DEP.jl
@@ -74,8 +74,12 @@ function num_offdiagonals(::HubbardReal1DEP, address::BoseFS)
     return 2 * num_occupied_modes(address)
 end
 
-function diagonal_element(h::HubbardReal1DEP, address::BoseFS)
-    h.u * bose_hubbard_interaction(address) / 2 + onr(address)⋅h.ep
+function diagonal_element(h::HubbardReal1DEP, address::BoseFS
+    sum(occupied_modes(address)) do index
+        occnum, mode = index
+        h.u * occnum * (occnum - 1) / 2 + h.ep[mode] * occnum
+    end
+end
 end
 
 function get_offdiagonal(h::HubbardReal1DEP, add::BoseFS, chosen)

--- a/src/Hamiltonians/HubbardReal1DEP.jl
+++ b/src/Hamiltonians/HubbardReal1DEP.jl
@@ -51,7 +51,7 @@ function HubbardReal1DEP(addr::BoseFS{<:Any,M}; u=1.0, t=1.0, v_ho=1.0) where M
     U, T, V = promote(float(u), float(t), float(v_ho))
     # js = range(1-cld(M,2); length=M)
     is = range(-fld(M,2); length=M) # [-M÷2, M÷2) including left boundary
-    js = shift_lattice(is) # shifted such that is[1] = 0
+    js = shift_lattice(is) # shifted such that js[1] = 0
     potential = SVector{M}(V*j^2 for j in js)
     return HubbardReal1DEP{typeof(U),typeof(addr),U,T,M}(addr, potential)
 end

--- a/src/Hamiltonians/HubbardReal1DEP.jl
+++ b/src/Hamiltonians/HubbardReal1DEP.jl
@@ -74,12 +74,11 @@ function num_offdiagonals(::HubbardReal1DEP, address::BoseFS)
     return 2 * num_occupied_modes(address)
 end
 
-function diagonal_element(h::HubbardReal1DEP, address::BoseFS
+function diagonal_element(h::HubbardReal1DEP, address::BoseFS)
     sum(occupied_modes(address)) do index
         occnum, mode = index
         h.u * occnum * (occnum - 1) / 2 + h.ep[mode] * occnum
     end
-end
 end
 
 function get_offdiagonal(h::HubbardReal1DEP, add::BoseFS, chosen)

--- a/src/Hamiltonians/HubbardReal1DEP.jl
+++ b/src/Hamiltonians/HubbardReal1DEP.jl
@@ -57,7 +57,7 @@ function HubbardReal1DEP(addr::BoseFS{<:Any,M}; u=1.0, t=1.0, v_ho=1.0) where M
 end
 
 function Base.show(io::IO, h::HubbardReal1DEP)
-    print(io, "HubbardReal1DEP($(h.add); u=$(h.u), t=$(h.t))")
+    print(io, "HubbardReal1DEP($(h.add); u=$(h.u), t=$(h.t), v_ho=$(h.ep[2]))")
 end
 
 LOStructure(::Type{<:HubbardReal1DEP{<:Real}}) = IsHermitian()

--- a/src/Hamiltonians/HubbardReal1DEP.jl
+++ b/src/Hamiltonians/HubbardReal1DEP.jl
@@ -1,0 +1,62 @@
+"""
+    HubbardReal1DEP(address; u=1.0, t=1.0, v_ho=1.0)
+
+Implements a one-dimensional Bose Hubbard chain in real space with external potential.
+
+```math
+\\hat{H} = -t \\sum_{\\langle i,j\\rangle} a_i^† a_j + \\sum_i ϵ_i n_i
++ \\frac{u}{2}\\sum_i n_i (n_i-1)
+```
+
+# Arguments
+
+* `address`: the starting address, defines number of particles and sites.
+* `u`: the interaction parameter.
+* `t`: the hopping strength.
+* `v_ho`: strength of the external harmonic oscillator potential ``ϵ_i = v_{ho} i^2``
+
+# See also
+
+* [`HubbardReal1D`](@ref)
+* [`HubbardMom1D`](@ref)
+* [`ExtendedHubbardReal1D`](@ref)
+
+"""
+struct HubbardReal1DEP{TT,A<:AbstractFockAddress,U,T,M} <: AbstractHamiltonian{TT}
+    add::A
+    ep::SVector{M,TT}
+end
+
+function HubbardReal1DEP(addr::BoseFS{<:Any,M}; u=1.0, t=1.0, v_ho=1.0) where M
+    U, T, V = promote(float(u), float(t), float(v_ho))
+    js = range(1-cld(M,2); length=M)
+    potential = SVector{M}(V*j^2 for j in js)
+    return HubbardReal1DEP{typeof(U),typeof(addr),U,T,M}(addr, potential)
+end
+
+function Base.show(io::IO, h::HubbardReal1DEP)
+    print(io, "HubbardReal1DEP($(h.add); u=$(h.u), t=$(h.t))")
+end
+
+LOStructure(::Type{<:HubbardReal1DEP{<:Real}}) = IsHermitian()
+
+Base.getproperty(h::HubbardReal1DEP, s::Symbol) = getproperty(h, Val(s))
+Base.getproperty(h::HubbardReal1DEP{<:Any,<:Any,U}, ::Val{:u}) where U = U
+Base.getproperty(h::HubbardReal1DEP{<:Any,<:Any,<:Any,T}, ::Val{:t}) where T = T
+Base.getproperty(h::HubbardReal1DEP, ::Val{:add}) = getfield(h, :add)
+Base.getproperty(h::HubbardReal1DEP, ::Val{:ep}) = getfield(h, :ep)
+
+starting_address(h::HubbardReal1DEP) = h.add
+
+function num_offdiagonals(::HubbardReal1DEP, address::BoseFS)
+    return 2 * num_occupied_modes(address)
+end
+
+function diagonal_element(h::HubbardReal1DEP, address::BoseFS)
+    h.u * bose_hubbard_interaction(address) / 2 + onr(address)⋅h.ep
+end
+
+function get_offdiagonal(h::HubbardReal1DEP, add::BoseFS, chosen)
+    naddress, onproduct = hopnextneighbour(add, chosen)
+    return naddress, - h.t * sqrt(onproduct)
+end

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -606,3 +606,26 @@ end
     @test diagonal_element(g0s,bfs1) == 4/3
     @test diagonal_element(g0s,bfs2) == 1/3
 end
+
+using Rimu.Hamiltonians: build_sparse_matrix_from_LO
+@testset "HubbardReal1DEP" begin
+    m = 100 # number of lattice sites, i.e. L in units of the lattice parameter alpha
+    n = 1 # number of particles
+    addr = BoseFS(Tuple(i == cld(m,2) ? n : 0 for i in 1:m)) # at the bottom of potential
+    l0 = 10 # harmonic oscillator length in units of alpha; 1 << l0 << m
+    v_ho = 0.5/l0^2 # energies now in units of hbar omega
+    t = 0.5*l0^2 # energies now in units of hbar omega
+    h = HubbardReal1DEP(addr; t, v_ho)
+    # all particles at the bottom of potential well
+    @test diagonal_element(h, addr) == 0 == h.ep⋅onr(addr)
+    sm, basis = build_sparse_matrix_from_LO(h)
+    energies = eigvals(Matrix(sm)) .+ 2n*t # shifted by bottom of Hubbard dispersion
+    @test energies[1:3] ≈ 0.5:1.0:2.5 atol=0.005 # first few eigenvalues
+    # using Plots
+    # r = 1:15
+    # scatter(r .-1, energies[r], label="Hubbard with ho potential", legend=:bottomright)
+    # plot!(n->n+0.5, r .-1, label="n + 1/2")
+    # ylabel!("Energy")
+    # xlabel!("ho quantum number n")
+    # title!("Harmonic oscillator in Hubbard, M = $m, l_0 = $l0")
+end

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -610,6 +610,12 @@ end
 
 using Rimu.Hamiltonians: build_sparse_matrix_from_LO
 @testset "HubbardReal1DEP" begin
+    for M in [3,4]
+        is = range(-fld(M,2); length=M) # [-M÷2, M÷2) including left boundary
+        js = shift_lattice(is) # shifted such that js[1] = 0
+        @test js[1] == 0
+        @test shift_lattice_inv(js) == is
+    end
     m = 100 # number of lattice sites, i.e. L in units of the lattice parameter alpha
     n = 1 # number of particles
     addr = BoseFS(Tuple(i == 1 ? n : 0 for i in 1:m)) # at the bottom of potential

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -58,6 +58,7 @@ end
 @testset "Interface tests" begin
     for H in (
         HubbardReal1D(BoseFS((1, 2, 3, 4)); u=1.0, t=2.0),
+        HubbardReal1DEP(BoseFS((1, 2, 3, 4)); u=1.0, t=2.0, v_ho=3.0),
         HubbardMom1D(BoseFS((6, 0, 0, 4)); t=1.0, u=0.5),
         HubbardMom1D(BoseFS((6, 0, 0, 4)); t=1.0, u=0.5 + im),
         ExtendedHubbardReal1D(BoseFS((1,0,0,0,1)); u=1.0, v=2.0, t=3.0),
@@ -611,7 +612,7 @@ using Rimu.Hamiltonians: build_sparse_matrix_from_LO
 @testset "HubbardReal1DEP" begin
     m = 100 # number of lattice sites, i.e. L in units of the lattice parameter alpha
     n = 1 # number of particles
-    addr = BoseFS(Tuple(i == cld(m,2) ? n : 0 for i in 1:m)) # at the bottom of potential
+    addr = BoseFS(Tuple(i == 1 ? n : 0 for i in 1:m)) # at the bottom of potential
     l0 = 10 # harmonic oscillator length in units of alpha; 1 << l0 << m
     v_ho = 0.5/l0^2 # energies now in units of hbar omega
     t = 0.5*l0^2 # energies now in units of hbar omega
@@ -621,6 +622,7 @@ using Rimu.Hamiltonians: build_sparse_matrix_from_LO
     sm, basis = build_sparse_matrix_from_LO(h)
     energies = eigvals(Matrix(sm)) .+ 2n*t # shifted by bottom of Hubbard dispersion
     @test energies[1:3] ≈ 0.5:1.0:2.5 atol=0.005 # first few eigenvalues
+    # # Here is a quick plot script that shows eigenvalues to deviate around n = 10
     # using Plots
     # r = 1:15
     # scatter(r .-1, energies[r], label="Hubbard with ho potential", legend=:bottomright)


### PR DESCRIPTION
Meant as a reference implementation for checking momentum-space implementations later.

New features:
* `HubbardReal1DEP` realises 1D Hubbard chain with external potential
* `shift_lattice` and `shift_lattice_inv` are convenience functions for shifting the lattice