### PR TITLE
Faster BasisSetRep

### DIFF
--- a/src/Hamiltonians/abstract.jl
+++ b/src/Hamiltonians/abstract.jl
@@ -152,6 +152,7 @@ function build_sparse_matrix_from_LO(
     ham::AbstractHamiltonian, fs=starting_address(ham); nnzs = 0
 )
     adds = [fs] # list of addresses of length linear dimension of matrix
+    adds_dict = Dict(fs=>1) # dictionary for index lookup
     I = Int[]         # row indices, length nnz
     J = Int[]         # column indices, length nnz
     V = eltype(ham)[] # values, length nnz
@@ -173,11 +174,12 @@ function build_sparse_matrix_from_LO(
         push!(V, melem)
         for (nadd, melem) in offdiagonals(ham, add) # loop over rows
             iszero(melem) && continue
-            j = findnext(a -> a == nadd, adds, 1) # find index of `nadd` in `adds`
+            j = get(adds_dict, nadd, nothing) # look up index; much faster than `findnext`
             if isnothing(j)
                 # new address: increase dimension of matrix by adding a row
                 push!(adds, nadd)
                 j = length(adds) # row index points to the new element in `adds`
+                adds_dict[nadd] = j
             end
             # new nonzero matrix element
             push!(I, i)


### PR DESCRIPTION
Use dictionary lookup rather than search when building the matrix for `BasisSetRep` as suggested by @mtsch.

Old:
```
julia> h = HubbardReal1D(BoseFS((1,2,0,1,1,1,1,1,1,1)))
HubbardReal1D(BoseFS{10,10}((1, 2, 0, 1, 1, 1, 1, 1, 1, 1)); u=1.0, t=1.0)

julia> @time m,v = build_sparse_matrix_from_LO(h);
 19.540310 seconds (277.24 k allocations: 95.071 MiB)
```
New (without compilation time):
```
julia>  @time m2,v2= build_sparse_matrix_from_LO(h);
  0.134440 seconds (139 allocations: 90.949 MiB)

julia> 19.540310/0.134440 # speedup
145.34595358524248
```
This is staggering! For larger Hamiltonians the speedup is even greater.

Thanks @mtsch for the suggestion!
