### PR TITLE
Performance bugfix in `reverse(::CompositeFS)`

### DIFF
--- a/src/BitStringAddresses/multicomponent.jl
+++ b/src/BitStringAddresses/multicomponent.jl
@@ -78,7 +78,7 @@ function Base.show(io::IO, c::CompositeFS{C}) where {C}
 end
 
 function Base.reverse(c::CompositeFS)
-    typeof(c)(reverse.(c.components))
+    typeof(c)(map(reverse, c.components))
 end
 
 """


### PR DESCRIPTION
Replaces broadcasting with `map`. Apparently, broadcasting on tuples sometimes allocates.