### PR TITLE
Time reversal symmetry

### DIFF
--- a/src/BitStringAddresses/BitStringAddresses.jl
+++ b/src/BitStringAddresses/BitStringAddresses.jl
@@ -15,7 +15,7 @@ export BitString
 export num_bits, num_chunks, chunk_type, chunks, chunk_bits, top_chunk_bits
 
 export AbstractFockAddress, SingleComponentFockAddress, BoseFS, BoseFS2C, FermiFS
-export CompositeFS, FermiFS2C
+export CompositeFS, FermiFS2C, time_reverse
 export BoseFSIndex, FermiFSIndex
 export num_particles, num_modes, num_components
 export find_occupied_mode, find_mode, occupied_modes, is_occupied, num_occupied_modes

--- a/src/BitStringAddresses/multicomponent.jl
+++ b/src/BitStringAddresses/multicomponent.jl
@@ -89,9 +89,9 @@ end
     time_reverse(addr)
 Apply the time-reversal operation on a two-component Fock address that flips all the spins.
 
-Currently requires equal particle number in each component.
+Requires each component address to have the same type.
 """
-function time_reverse(c::CompositeFS{2,N,M,T}) where {N,M,T}
+function time_reverse(c::CompositeFS{2,N,M,T}) where {N, M, T <: NTuple{2}}
     return CompositeFS{2,N,M,T}(reverse(c.components))
 end
 

--- a/src/BitStringAddresses/multicomponent.jl
+++ b/src/BitStringAddresses/multicomponent.jl
@@ -36,6 +36,10 @@ function near_uniform(::Type{<:BoseFS2C{NA,NB,M}}) where {NA,NB,M}
     return BoseFS2C(near_uniform(BoseFS{NA,M}), near_uniform(BoseFS{NB,M}))
 end
 
+function time_reverse(c::BoseFS2C{NA,NA,M,S,S,N}) where {NA,M,S,N}
+    return  BoseFS2C{NA,NA,M,S,S,N}(c.bsb, c.bsa)
+end
+
 """
     CompositeFS(addresses::SingleComponentFockAddress...) <: AbstractFockAddress
 
@@ -79,6 +83,16 @@ end
 
 function Base.reverse(c::CompositeFS)
     typeof(c)(map(reverse, c.components))
+end
+
+"""
+    time_reverse(addr)
+Apply the time-reversal operation on a two-component Fock address that flips all the spins.
+
+Currently requires equal particle number in each component.
+"""
+function time_reverse(c::CompositeFS{2,N,M,T}) where {N,M,T}
+    return CompositeFS{2,N,M,T}(reverse(c.components))
 end
 
 """

--- a/src/Hamiltonians/Hamiltonians.jl
+++ b/src/Hamiltonians/Hamiltonians.jl
@@ -80,6 +80,7 @@ include("BoseHubbardMom1D2C.jl")
 include("GutzwillerSampling.jl")
 include("GuidingVectorSampling.jl")
 include("ParitySymmetry.jl")
+include("TRSymmetry.jl")
 
 include("Transcorrelated1D.jl")
 

--- a/src/Hamiltonians/Hamiltonians.jl
+++ b/src/Hamiltonians/Hamiltonians.jl
@@ -80,7 +80,6 @@ include("BoseHubbardMom1D2C.jl")
 include("GutzwillerSampling.jl")
 include("GuidingVectorSampling.jl")
 include("ParitySymmetry.jl")
-include("SingletSymmetry.jl")
 
 include("Transcorrelated1D.jl")
 

--- a/src/Hamiltonians/Hamiltonians.jl
+++ b/src/Hamiltonians/Hamiltonians.jl
@@ -48,6 +48,7 @@ export HubbardMom1DEP
 export BoseHubbardMom1D2C, BoseHubbardReal1D2C
 export GutzwillerSampling, GuidingVectorSampling
 export ParitySymmetry
+export TRSymmetry
 export Transcorrelated1D
 export hubbard_dispersion, continuum_dispersion
 
@@ -79,6 +80,7 @@ include("BoseHubbardMom1D2C.jl")
 include("GutzwillerSampling.jl")
 include("GuidingVectorSampling.jl")
 include("ParitySymmetry.jl")
+include("SingletSymmetry.jl")
 
 include("Transcorrelated1D.jl")
 

--- a/src/Hamiltonians/Hamiltonians.jl
+++ b/src/Hamiltonians/Hamiltonians.jl
@@ -48,7 +48,7 @@ export HubbardMom1DEP
 export BoseHubbardMom1D2C, BoseHubbardReal1D2C
 export GutzwillerSampling, GuidingVectorSampling
 export ParitySymmetry
-export TRSymmetry
+export TimeReversalSymmetry
 export Transcorrelated1D
 export hubbard_dispersion, continuum_dispersion
 

--- a/src/Hamiltonians/TRSymmetry.jl
+++ b/src/Hamiltonians/TRSymmetry.jl
@@ -1,0 +1,114 @@
+"""
+    TRSymmetry(ham::AbstractHamiltonian{T}; even=true) <: AbstractHamiltonian{T}
+
+Impose even or odd time reversal on all states and the Hamiltonian `ham` as controlled by
+the keyword argument `even`.
+
+# Notes
+
+* This modifier only works two component [`starting_address`](@ref)s.
+* For odd time reversal symmetry, the [`starting_address`](@ref) of the underlying
+  Hamiltonian must not be symmetric.
+* If time reversal symmetry is not a symmetry of the Hamiltonian `ham` then the result is
+  undefined.
+* `TRSymmetry` works by modifying the [`offdiagonals`](@ref) iterator.
+
+```jldoctest
+julia> ham = HubbardMom1D(FermiFS2C((1,0,1),(0,1,1)));
+
+julia> size(Matrix(ham))
+(3, 3)
+
+julia> size(Matrix(TRSymmetry(ham)))
+(2, 2)
+
+julia> size(Matrix(TRSymmetry(ham, even=false)))
+(1, 1)
+
+julia> eigvals(Matrix(TRSymmetry(ham)))[1] ≈ eigvals(Matrix(ham))[1]
+true
+
+julia> ham = BoseHubbardMom1D2C(BoseFS2C((1,0,1),(0,1,1)));
+
+julia> size(Matrix(ham))
+(12, 12)
+
+julia> size(Matrix(TRSymmetry(ham)))
+(7, 7)
+
+julia> size(Matrix(TRSymmetry(ham, even=false)))
+(5, 5)
+
+julia> eigvals(Matrix(TRSymmetry(ham, even=false)))[1] ≈ eigvals(Matrix(ham))[1]
+true
+```
+"""
+struct TRSymmetry{T,H<:AbstractHamiltonian{T}} <: AbstractHamiltonian{T}
+    hamiltonian::H
+    even::Bool
+end
+
+function TRSymmetry(hamiltonian; odd=false, even=!odd)
+    address = starting_address(hamiltonian)
+    check_tr_address(address)
+    if !even && address == time_reverse(address)
+        throw(ArgumentError("Even starting address can't be used with odd `TRSymmetry`"))
+    end
+    return TRSymmetry(hamiltonian, even)
+end
+
+function check_tr_address(addr::CompositeFS)
+    if num_components(addr) ≠ 2 || !isequal(num_particles.(addr.components)...)
+        throw(ArgumentError("Two component address with equal particle numbers required for `TRSymmetry`."))
+    end
+end
+function check_tr_address(addr::BoseFS2C{NA,NB,M,SA,SB,N}) where {NA,NB,M,SA,SB,N}
+    if NA ≠ NB || SA ≠ SB
+        throw(ArgumentError("Two component address with equal particle numbers required for `TRSymmetry`."))
+    end
+end
+
+
+function Base.show(io::IO, h::TRSymmetry)
+    print(io, "TRSymmetry(", h.hamiltonian, ", even=", h.even, ")")
+end
+
+LOStructure(h::TRSymmetry) = LOStructure(h.hamiltonian)
+function starting_address(h::TRSymmetry)
+    add = starting_address(h.hamiltonian)
+    return min(add, time_reverse(add))
+end
+
+function Base.adjoint(h::TRSymmetry)
+    return TRSymmetry(adjoint(h.hamiltonian); even=h.even)
+end
+
+get_offdiagonal(h::TRSymmetry, add, i) = offdiagonals(h, add)[i]
+num_offdiagonals(h::TRSymmetry, add) = num_offdiagonals(h.hamiltonian, add)
+
+struct TRSymmetryOffdiagonals{
+    A,T,O<:AbstractVector{Tuple{A,T}}
+} <: AbstractOffdiagonals{A,T}
+    od::O
+    even::Bool
+end
+Base.size(o::TRSymmetryOffdiagonals) = size(o.od)
+
+function offdiagonals(h::TRSymmetry, add)
+    return TRSymmetryOffdiagonals(offdiagonals(h.hamiltonian, add), h.even)
+end
+
+function Base.getindex(o::TRSymmetryOffdiagonals, i)
+    add, val = o.od[i]
+    rev_add = time_reverse(add)
+    left_add = min(rev_add, add)
+    if !o.even && left_add ≠ add
+        val *= -1
+    elseif !o.even && rev_add == add
+        val = zero(val)
+    end
+    return left_add, val
+end
+function diagonal_element(h::TRSymmetry, add)
+    return diagonal_element(h.hamiltonian, add)
+end

--- a/src/Hamiltonians/TRSymmetry.jl
+++ b/src/Hamiltonians/TRSymmetry.jl
@@ -68,10 +68,6 @@ function starting_address(h::TRSymmetry)
     return min(add, time_reverse(add))
 end
 
-function Base.adjoint(h::TRSymmetry)
-    return TRSymmetry(adjoint(h.hamiltonian); even=h.even)
-end
-
 get_offdiagonal(h::TRSymmetry, add, i) = offdiagonals(h, add)[i]
 num_offdiagonals(h::TRSymmetry, add) = num_offdiagonals(h.hamiltonian, add)
 

--- a/src/Hamiltonians/TRSymmetry.jl
+++ b/src/Hamiltonians/TRSymmetry.jl
@@ -6,7 +6,7 @@ the keyword argument `even`.
 
 # Notes
 
-* This modifier only works two component [`starting_address`](@ref)s.
+* This modifier only works two component [`starting_address`](@ref)es.
 * For odd time reversal symmetry, the [`starting_address`](@ref) of the underlying
   Hamiltonian must not be symmetric.
 * If time reversal symmetry is not a symmetry of the Hamiltonian `ham` then the result is

--- a/src/Hamiltonians/TRSymmetry.jl
+++ b/src/Hamiltonians/TRSymmetry.jl
@@ -1,5 +1,5 @@
 """
-    TRSymmetry(ham::AbstractHamiltonian{T}; even=true) <: AbstractHamiltonian{T}
+    TimeReversalSymmetry(ham::AbstractHamiltonian{T}; even=true) <: AbstractHamiltonian{T}
 
 Impose even or odd time reversal on all states and the Hamiltonian `ham` as controlled by
 the keyword argument `even`.
@@ -11,7 +11,7 @@ the keyword argument `even`.
   Hamiltonian must not be symmetric.
 * If time reversal symmetry is not a symmetry of the Hamiltonian `ham` then the result is
   undefined.
-* `TRSymmetry` works by modifying the [`offdiagonals`](@ref) iterator.
+* `TimeReversalSymmetry` works by modifying the [`offdiagonals`](@ref) iterator.
 
 ```jldoctest
 julia> ham = HubbardMom1D(FermiFS2C((1,0,1),(0,1,1)));
@@ -19,57 +19,57 @@ julia> ham = HubbardMom1D(FermiFS2C((1,0,1),(0,1,1)));
 julia> size(Matrix(ham))
 (3, 3)
 
-julia> size(Matrix(TRSymmetry(ham)))
+julia> size(Matrix(TimeReversalSymmetry(ham)))
 (2, 2)
 
-julia> size(Matrix(TRSymmetry(ham, even=false)))
+julia> size(Matrix(TimeReversalSymmetry(ham, even=false)))
 (1, 1)
 
-julia> eigvals(Matrix(TRSymmetry(ham)))[1] ≈ eigvals(Matrix(ham))[1]
+julia> eigvals(Matrix(TimeReversalSymmetry(ham)))[1] ≈ eigvals(Matrix(ham))[1]
 true
 ```
 """
-struct TRSymmetry{T,H<:AbstractHamiltonian{T}} <: AbstractHamiltonian{T}
+struct TimeReversalSymmetry{T,H<:AbstractHamiltonian{T}} <: AbstractHamiltonian{T}
     hamiltonian::H
     even::Bool
 end
 
-function TRSymmetry(hamiltonian::AbstractHamiltonian; odd=false, even=!odd)
+function TimeReversalSymmetry(hamiltonian::AbstractHamiltonian; odd=false, even=!odd)
     address = starting_address(hamiltonian)
     check_tr_address(address)
     if !even && address == time_reverse(address)
-        throw(ArgumentError("Even starting address can't be used with odd `TRSymmetry`"))
+        throw(ArgumentError("Even starting address can't be used with odd `TimeReversalSymmetry`"))
     end
-    return TRSymmetry(hamiltonian, even)
+    return TimeReversalSymmetry(hamiltonian, even)
 end
 
 function check_tr_address(addr)
-    throw(ArgumentError("Two component address with equal particle numbers and component types required for `TRSymmetry`."))
+    throw(ArgumentError("Two component address with equal particle numbers and component types required for `TimeReversalSymmetry`."))
 end
 function check_tr_address(addr::CompositeFS)
     if !(addr.components isa NTuple{2})
-        throw(ArgumentError("Two component address with equal particle numbers and component types required for `TRSymmetry`."))
+        throw(ArgumentError("Two component address with equal particle numbers and component types required for `TimeReversalSymmetry`."))
     end
 end
 function check_tr_address(addr::BoseFS2C{NA,NB,M,SA,SB,N}) where {NA,NB,M,SA,SB,N}
     if NA ≠ NB || SA ≠ SB
-        throw(ArgumentError("Two component address with equal particle numbers required for `TRSymmetry`."))
+        throw(ArgumentError("Two component address with equal particle numbers required for `TimeReversalSymmetry`."))
     end
 end
 
 
-function Base.show(io::IO, h::TRSymmetry)
-    print(io, "TRSymmetry(", h.hamiltonian, ", even=", h.even, ")")
+function Base.show(io::IO, h::TimeReversalSymmetry)
+    print(io, "TimeReversalSymmetry(", h.hamiltonian, ", even=", h.even, ")")
 end
 
-LOStructure(h::TRSymmetry) = AdjointUnknown()
-function starting_address(h::TRSymmetry)
+LOStructure(h::TimeReversalSymmetry) = AdjointUnknown()
+function starting_address(h::TimeReversalSymmetry)
     add = starting_address(h.hamiltonian)
     return min(add, time_reverse(add))
 end
 
-get_offdiagonal(h::TRSymmetry, add, i) = offdiagonals(h, add)[i]
-num_offdiagonals(h::TRSymmetry, add) = num_offdiagonals(h.hamiltonian, add)
+get_offdiagonal(h::TimeReversalSymmetry, add, i) = offdiagonals(h, add)[i]
+num_offdiagonals(h::TimeReversalSymmetry, add) = num_offdiagonals(h.hamiltonian, add)
 
 struct TRSymmetryOffdiagonals{
     A,T,O<:AbstractVector{Tuple{A,T}}
@@ -79,7 +79,7 @@ struct TRSymmetryOffdiagonals{
 end
 Base.size(o::TRSymmetryOffdiagonals) = size(o.od)
 
-function offdiagonals(h::TRSymmetry, add)
+function offdiagonals(h::TimeReversalSymmetry, add)
     return TRSymmetryOffdiagonals(offdiagonals(h.hamiltonian, add), h.even)
 end
 
@@ -94,6 +94,6 @@ function Base.getindex(o::TRSymmetryOffdiagonals, i)
     end
     return left_add, val
 end
-function diagonal_element(h::TRSymmetry, add)
+function diagonal_element(h::TimeReversalSymmetry, add)
     return diagonal_element(h.hamiltonian, add)
 end

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -94,8 +94,8 @@ end
         HubbardMom1DEP(CompositeFS(FermiFS((0,1,1,0,0)), FermiFS((0,0,1,0,0))), v_ho=5),
 
         ParitySymmetry(HubbardRealSpace(CompositeFS(BoseFS((1,2,0)), FermiFS((0,1,0))))),
-        TRSymmetry(HubbardMom1D(FermiFS2C((1,0,1),(0,1,1)))),
-        TRSymmetry(BoseHubbardMom1D2C(BoseFS2C((0,1,1),(1,0,1)))),
+        TimeReversalSymmetry(HubbardMom1D(FermiFS2C((1,0,1),(0,1,1)))),
+        TimeReversalSymmetry(BoseHubbardMom1D2C(BoseFS2C((0,1,1),(1,0,1)))),
     )
         test_hamiltonian_interface(H)
     end
@@ -844,18 +844,18 @@ end
     end
 end
 
-@testset "TRSymmetry" begin
-    @test_throws ArgumentError TRSymmetry(HubbardMom1D(BoseFS((1, 1))))
-    @test_throws ArgumentError TRSymmetry(BoseHubbardMom1D2C(BoseFS2C((1, 1),(2,1))))
+@testset "TimeReversalSymmetry" begin
+    @test_throws ArgumentError TimeReversalSymmetry(HubbardMom1D(BoseFS((1, 1))))
+    @test_throws ArgumentError TimeReversalSymmetry(BoseHubbardMom1D2C(BoseFS2C((1, 1),(2,1))))
     @test_throws ArgumentError begin
-        TRSymmetry(HubbardRealSpace(CompositeFS(FermiFS((1, 1)),BoseFS((2,1)))))
+        TimeReversalSymmetry(HubbardRealSpace(CompositeFS(FermiFS((1, 1)),BoseFS((2,1)))))
     end
-    @test_throws ArgumentError TRSymmetry(HubbardMom1D(FermiFS2C((1,0,1),(1,0,1)));odd=true)
+    @test_throws ArgumentError TimeReversalSymmetry(HubbardMom1D(FermiFS2C((1,0,1),(1,0,1)));odd=true)
 
     @testset "HubbardMom1D" begin
         ham = HubbardMom1D(FermiFS2C((1,0,1),(0,1,1)))
-        even = TRSymmetry(ham; odd=false)
-        odd = TRSymmetry(ham; even=false)
+        even = TimeReversalSymmetry(ham; odd=false)
+        odd = TimeReversalSymmetry(ham; even=false)
 
         ham_m = Matrix(ham)
         even_m = Matrix(even)
@@ -865,8 +865,8 @@ end
     end
     @testset "2-particle BoseHubbardMom1D2C" begin
         ham = BoseHubbardMom1D2C(BoseFS2C((0,1,1),(1,0,1)))
-        even = TRSymmetry(ham)
-        odd = TRSymmetry(ham; even=false)
+        even = TimeReversalSymmetry(ham)
+        odd = TimeReversalSymmetry(ham; even=false)
 
         h_eigs = eigvals(Matrix(ham))
         p_eigs = sort!(vcat(eigvals(Matrix(even)), eigvals(Matrix(odd))))

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -95,7 +95,7 @@ end
 
         ParitySymmetry(HubbardRealSpace(CompositeFS(BoseFS((1,2,0)), FermiFS((0,1,0))))),
         TRSymmetry(HubbardMom1D(FermiFS2C((1,0,1),(0,1,1)))),
-        TRSymmetry(HubbardMom1D(BoseFS2C((1,0,1),(0,1,1)))),
+        TRSymmetry(BoseHubbardMom1D2C(BoseFS2C((0,1,1),(1,0,1)))),
     )
         test_hamiltonian_interface(H)
     end

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -94,6 +94,8 @@ end
         HubbardMom1DEP(CompositeFS(FermiFS((0,1,1,0,0)), FermiFS((0,0,1,0,0))), v_ho=5),
 
         ParitySymmetry(HubbardRealSpace(CompositeFS(BoseFS((1,2,0)), FermiFS((0,1,0))))),
+        TRSymmetry(HubbardMom1D(FermiFS2C((1,0,1),(0,1,1)))),
+        TRSymmetry(HubbardMom1D(BoseFS2C((1,0,1),(0,1,1)))),
     )
         test_hamiltonian_interface(H)
     end
@@ -840,6 +842,43 @@ end
 
         @test ham_m == even_m
     end
+end
+
+@testset "TRSymmetry" begin
+    @test_throws ArgumentError TRSymmetry(HubbardMom1D(BoseFS((1, 1))))
+    @test_throws ArgumentError TRSymmetry(BoseHubbardMom1D2C(BoseFS2C((1, 1),(2,1))))
+    @test_throws ArgumentError begin
+        TRSymmetry(HubbardRealSpace(CompositeFS(FermiFS((1, 1)),BoseFS((2,1)))))
+    end
+    @test_throws ArgumentError TRSymmetry(HubbardMom1D(FermiFS2C((1,0,1),(1,0,1)));odd=true)
+
+    @testset "HubbardMom1D" begin
+        ham = HubbardMom1D(FermiFS2C((1,0,1),(0,1,1)))
+        even = TRSymmetry(ham; odd=false)
+        odd = TRSymmetry(ham; even=false)
+
+        ham_m = Matrix(ham)
+        even_m = Matrix(even)
+        odd_m = Matrix(odd)
+
+        @test sort(vcat(eigvals(even_m), eigvals(odd_m))) ≈ eigvals(ham_m)
+    end
+    @testset "2-particle BoseHubbardMom1D2C" begin
+        ham = BoseHubbardMom1D2C(BoseFS2C((0,1,1),(1,0,1)))
+        even = TRSymmetry(ham)
+        odd = TRSymmetry(ham; even=false)
+
+        h_eigs = eigvals(Matrix(ham))
+        p_eigs = sort!(vcat(eigvals(Matrix(even)), eigvals(Matrix(odd))))
+
+        @test starting_address(even) == time_reverse(starting_address(ham))
+        @test h_eigs ≈ p_eigs
+
+        @test ishermitian(Matrix(odd))
+        @test ishermitian(Matrix(even)) == false
+        @test LOStructure(odd) isa AdjointUnknown
+    end
+
 end
 
 @testset "BasisSetRep" begin


### PR DESCRIPTION
Impose even or odd time reversal on all states and the Hamiltonian `ham` as controlled by
the keyword argument `even`.