### PR TITLE
Bugfix/exact spawning

### DIFF
--- a/src/StochasticStyles/StochasticStyles.jl
+++ b/src/StochasticStyles/StochasticStyles.jl
@@ -33,7 +33,8 @@ import ..Interfaces:
     fciqmc_col!, step_stats, update_dvec!, compress!
 export
     StochasticStyle, IsStochasticInteger, IsDeterministic, IsStochasticWithThreshold,
-    IsDynamicSemistochastic, StyleUnknown
+    IsDynamicSemistochastic, StyleUnknown, Exact, WithReplacement, DynamicSemistochastic,
+    WithoutReplacement, Bernoulli
 
 include("spawning.jl")
 include("compression.jl")

--- a/src/StochasticStyles/spawning.jl
+++ b/src/StochasticStyles/spawning.jl
@@ -427,6 +427,8 @@ Base.@kwdef struct DynamicSemistochastic{T,S<:SpawningStrategy} <: SpawningStrat
 end
 
 @inline function spawn!(s::DynamicSemistochastic, w, offdiags::AbstractVector, add, val, dτ)
+    # assumes that s.strat.strength and s.strat.threshold are defined
+    # special-case substrategies that don't fit the pattern!
     thresh = min(s.abs_threshold, length(offdiags))
     amount = s.strat.strength * abs(val) * s.rel_threshold
     if amount ≥ thresh
@@ -440,4 +442,9 @@ end
         attempts, spawns, annihilations = spawn!(s.strat, w, offdiags, add, val, dτ)
         return (0, 1, attempts, spawns, annihilations)
     end
+end
+
+# bypass branching code for Exact() sub-strategy
+@inline function spawn!(s::DynamicSemistochastic{<:Any, <:Exact}, args...)
+    return (1, 0, spawn!(s.strat, args...)...)
 end

--- a/test/StochasticStyles.jl
+++ b/test/StochasticStyles.jl
@@ -250,3 +250,17 @@ end
         @test walkernumber(target * (1/1000)) ≈ walkernumber(dv) rtol=0.1
     end
 end
+
+@testset "Exact substrategy to DynamicSemistochastic" begin
+    dss_e = DynamicSemistochastic(Exact(), 1.0, Inf)
+    add, H = (BoseFS((0,0,0,3,1,1)), HubbardMom1D(BoseFS((0,0,0,3,1,1)); u=6.0))
+    val = rand() * num_offdiagonals(H, add) * 1.2
+    exact = DVec(add => 1.0)
+    ds_exact = DVec(add => 1.0)
+    spawn!(Exact(), exact, H, add, val, 1e-5)
+    spawn!(dss_e, ds_exact, H, add, val, 1e-5)
+    @test keys(exact) == keys(ds_exact)
+    for k in keys(exact)
+        @test exact[k] ≈ ds_exact[k]
+    end
+end


### PR DESCRIPTION
Allow `Exact()` to be used as a sub-strategy for `IsDynamicSemistochastic`.
Available spawning strategies are now exported.