### PR TITLE
Diagonal operators

### DIFF
--- a/src/Hamiltonians/DensityMatrixDiagonal.jl
+++ b/src/Hamiltonians/DensityMatrixDiagonal.jl
@@ -48,4 +48,4 @@ function diagonal_element(dmd::DensityMatrixDiagonal{2}, add::BoseFS2C)
 end
 
 num_offdiagonals(dmd::DensityMatrixDiagonal, _) = 0
-LOStructure(::Type{<:DensityMatrixDiagonal}) = IsHermitian()
+LOStructure(::Type{<:DensityMatrixDiagonal}) = IsDiagonal()

--- a/src/Hamiltonians/Momentum.jl
+++ b/src/Hamiltonians/Momentum.jl
@@ -26,7 +26,7 @@ end
 Momentum(component=0; fold=true) = Momentum{component}(fold)
 Base.show(io::IO, mom::Momentum{C}) where {C} = print(io, "Momentum($C; fold=$(mom.fold))")
 
-LOStructure(::Type{<:Momentum}) = IsHermitian()
+LOStructure(::Type{<:Momentum}) = IsDiagonal()
 num_offdiagonals(ham::Momentum, add) = 0
 
 @inline function _momentum(add::SingleComponentFockAddress, fold)

--- a/src/Hamiltonians/operations.jl
+++ b/src/Hamiltonians/operations.jl
@@ -104,3 +104,4 @@ function LinearAlgebra.adjoint(::S, op) where {S<:LOStructure}
 end
 
 LinearAlgebra.adjoint(::IsHermitian, op) = op # adjoint is known
+LinearAlgebra.adjoint(::IsDiagonal, op) = op

--- a/src/Interfaces/Interfaces.jl
+++ b/src/Interfaces/Interfaces.jl
@@ -17,7 +17,7 @@ Follow the links for the definitions of the interfaces!
 * [`num_offdiagonals`](@ref)
 * [`get_offdiagonal`](@ref)
 * [`offdiagonals`](@ref).
-* [`random_offdiagonal`](@ref) 
+* [`random_offdiagonal`](@ref)
 * [`starting_address`](@ref)
 * [`LOStructure`](@ref)
 
@@ -48,7 +48,7 @@ export
 export
     AbstractHamiltonian, diagonal_element, num_offdiagonals, get_offdiagonal, offdiagonals,
     random_offdiagonal, starting_address,
-    LOStructure, IsHermitian, AdjointKnown, AdjointUnknown, has_adjoint
+    LOStructure, IsDiagonal, IsHermitian, AdjointKnown, AdjointUnknown, has_adjoint
 
 include("stochasticstyles.jl")
 include("dictvectors.jl")

--- a/src/Interfaces/hamiltonians.jl
+++ b/src/Interfaces/hamiltonians.jl
@@ -197,6 +197,7 @@ end
 `LOStructure` speficies properties of the linear operator `op`. If a special structure is
 known this can speed up calculations. Implemented structures are:
 
+* `IsDiagonal`: The operator is diagonal.
 * `IsHermitian`: The operator is complex and Hermitian or real and symmetric.
 * `AdjointKnown`: The operator is not Hermitian, but its [`adjoint`](@ref) is implemented.
 * `AdjointUnknown`: [`adjoint`](@ref) for this operator is not implemented.
@@ -207,6 +208,7 @@ In order to define this trait for a new linear operator type, define a method fo
 """
 abstract type LOStructure end
 
+struct IsDiagonal <: LOStructure end
 struct IsHermitian <: LOStructure end
 struct AdjointKnown <: LOStructure end
 struct AdjointUnknown <: LOStructure end

--- a/src/RMPI/mpidata.jl
+++ b/src/RMPI/mpidata.jl
@@ -286,10 +286,16 @@ function copy_to_local!(target, md::MPIData)
 end
 
 function LinearAlgebra.dot(md_left::MPIData, lop, md_right::MPIData)
-    # Idea: lop * md_right can be huge. It might be better to just collect the full left
-    # vector and do the multiplication locally.
-    left = copy_to_local(md_left)
-    return dot(left, lop, md_right)
+    if LOStructure(lop) isa IsDiagonal
+        # If operator is diagonal, the operation can be performed on the local parts.
+        comm = md_left.comm
+        return MPI.Allreduce(dot(localpart(md_left), lop, localpart(md_right)), +, comm)
+    else
+        # Idea: lop * md_right can be huge. It might be better to just collect the full left
+        # vector and do the multiplication locally.
+        left = copy_to_local(md_left)
+        return dot(left, lop, md_right)
+    end
 end
 
 function Rimu.freeze(md::MPIData)
@@ -297,11 +303,18 @@ function Rimu.freeze(md::MPIData)
     return freeze(localpart(md))
 end
 
-function Rimu.all_overlaps(operators::Tuple, vecs::NTuple{N,MPIData}) where {N}
+function get_overlaps_diagonal!(names, values, operators, vecs::NTuple{N}) where {N}
+    for i in 1:N, j in i+1:N
+        push!(names, "c$(i)_dot_c$(j)")
+        push!(values, dot(vecs[i], vecs[j]))
+        for (k, op) in enumerate(operators)
+            push!(names, "c$(i)_Op$(k)_c$(j)")
+            push!(values, dot(vecs[i], op, vecs[j]))
+        end
+    end
+end
+function get_overlaps_nondiagonal!(names, value, operators, vecs::NTuple{N}) where {N}
     local_vec_i = similar(localpart(vecs[1]))
-    T = promote_type((valtype(v) for v in vecs)..., eltype.(operators)...)
-    names = String[]
-    values = T[]
     for i in 1:N, j in i+1:N
         push!(names, "c$(i)_dot_c$(j)")
         push!(values, dot(vecs[i], vecs[j]))
@@ -311,7 +324,18 @@ function Rimu.all_overlaps(operators::Tuple, vecs::NTuple{N,MPIData}) where {N}
             push!(values, dot(local_vec_i, op, vecs[j]))
         end
     end
+end
+
+function Rimu.all_overlaps(operators::Tuple, vecs::NTuple{N,MPIData}) where {N}
+    T = promote_type((valtype(v) for v in vecs)..., eltype.(operators)...)
+    names = String[]
+    values = T[]
+    if all(op -> LOStructure(op) isa IsDiagonal, operators)
+        get_overlaps_diagonal!(names, value, operators, vecs)
+    else
+        get_overlaps_nondiagonal!(names, value, operators, vecs)
+    end
 
     num_reports = (N * (N - 1) ÷ 2) * (length(operators) + 1)
-    return SVector{num_reports,String}(names).data, SVector{num_reports,T}(values).data
+    return Tuple(SVector{num_reports,String}(names)), Tuple(SVector{num_reports,T}(values))
 end

--- a/src/RMPI/mpidata.jl
+++ b/src/RMPI/mpidata.jl
@@ -313,7 +313,7 @@ function get_overlaps_diagonal!(names, values, operators, vecs::NTuple{N}) where
         end
     end
 end
-function get_overlaps_nondiagonal!(names, value, operators, vecs::NTuple{N}) where {N}
+function get_overlaps_nondiagonal!(names, values, operators, vecs::NTuple{N}) where {N}
     local_vec_i = similar(localpart(vecs[1]))
     for i in 1:N, j in i+1:N
         push!(names, "c$(i)_dot_c$(j)")
@@ -331,9 +331,9 @@ function Rimu.all_overlaps(operators::Tuple, vecs::NTuple{N,MPIData}) where {N}
     names = String[]
     values = T[]
     if all(op -> LOStructure(op) isa IsDiagonal, operators)
-        get_overlaps_diagonal!(names, value, operators, vecs)
+        get_overlaps_diagonal!(names, values, operators, vecs)
     else
-        get_overlaps_nondiagonal!(names, value, operators, vecs)
+        get_overlaps_nondiagonal!(names, values, operators, vecs)
     end
 
     num_reports = (N * (N - 1) ÷ 2) * (length(operators) + 1)

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -45,8 +45,8 @@ function test_hamiltonian_interface(H)
         end
         @testset "LOStructure" begin
             @test LOStructure(H) isa LOStructure
-            if LOStructure(H) isa IsHermitian
-                @test H' == H
+            if LOStructure(H) isa IsHermitian || LOStructure(H) isa IsDiagonal
+                @test H' === H
             elseif LOStructure(H) isa AdjointKnown
                 @test begin H'; true; end # make sure no error is thrown
             else
@@ -632,6 +632,7 @@ end
 
     @test num_offdiagonals(Momentum(), BoseFS((0,1,0))) == 0
     @test LOStructure(Momentum(2; fold=true)) == IsDiagonal()
+    @test Momentum(1)' === Momentum(1)
 end
 
 @testset "DensityMatrixDiagonal" begin
@@ -651,6 +652,7 @@ end
 
     @test num_offdiagonals(DensityMatrixDiagonal(1), BoseFS((0,1,0))) == 0
     @test LOStructure(DensityMatrixDiagonal(2)) == IsDiagonal()
+    @test DensityMatrixDiagonal(15)' === DensityMatrixDiagonal(15)
 end
 
 @testset "HubbardReal1DEP" begin

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -631,7 +631,7 @@ end
     end
 
     @test num_offdiagonals(Momentum(), BoseFS((0,1,0))) == 0
-    @test LOStructure(Momentum(2; fold=true)) == IsHermitian()
+    @test LOStructure(Momentum(2; fold=true)) == IsDiagonal()
 end
 
 @testset "DensityMatrixDiagonal" begin
@@ -650,7 +650,7 @@ end
     end
 
     @test num_offdiagonals(DensityMatrixDiagonal(1), BoseFS((0,1,0))) == 0
-    @test LOStructure(DensityMatrixDiagonal(2)) == IsHermitian()
+    @test LOStructure(DensityMatrixDiagonal(2)) == IsDiagonal()
 end
 
 @testset "HubbardReal1DEP" begin

--- a/test/lomc.jl
+++ b/test/lomc.jl
@@ -112,7 +112,7 @@ using Statistics
             # MPIData
             df, _ = lomc!(H, MPIData(dv); replica=AllOverlaps(4, H))
             @test num_stats(df) == 2 * binomial(4, 2)
-            df, _ = lomc!(H, MPIData(dv); replica=AllOverlaps(5, H))
+            df, _ = lomc!(H, MPIData(dv); replica=AllOverlaps(5, DensityMatrixDiagonal(1)))
             @test num_stats(df) == 2 * binomial(5, 2)
         end
     end

--- a/test/mpi_runtests.jl
+++ b/test/mpi_runtests.jl
@@ -103,22 +103,24 @@ end
                     @testset "Operations" begin
                         @test dot(v, w) ≈ dot(dv, dw)
 
-                        @test dot(v, H, w) ≈ dot(v, H, dw)
-                        @test dot(w, H, v) ≈ dot(w, H, dv)
-                        @test dot(w, H, v) ≈ dot(dw, H, dv)
-                        @test dot(w, H, v) ≈ dot(dw, H, v)
-
                         @test dot(freeze(dw), dv) ≈ dot(w, v)
                         @test dot(freeze(dv), dw) ≈ dot(v, w)
 
-                        du = MPIData(H * dv)
-                        u = H * v
-                        @test correct_ranks(du)
+                        for op in (H, DensityMatrixDiagonal(1))
+                            @test dot(v, op, w) ≈ dot(v, op, dw)
+                            @test dot(w, op, v) ≈ dot(w, op, dv)
+                            @test dot(w, op, v) ≈ dot(dw, op, dv)
+                            @test dot(w, op, v) ≈ dot(dw, op, v)
 
-                        @test length(u) == length(du)
-                        @test norm(u, 1) ≈ norm(du, 1)
-                        @test norm(u, 2) ≈ norm(du, 2)
-                        @test norm(u, Inf) ≈ norm(du, Inf)
+                            du = MPIData(op * dv)
+                            u = op * v
+                            @test correct_ranks(du)
+
+                            @test length(u) == length(du)
+                            @test norm(u, 1) ≈ norm(du, 1)
+                            @test norm(u, 2) ≈ norm(du, 2)
+                            @test norm(u, Inf) ≈ norm(du, Inf)
+                        end
                     end
                 end
             end


### PR DESCRIPTION
Add a new `LOStructure`: `IsDiagonal`.
This allows us to skip spreading the vector across ranks with MPI and `AllOverlaps` with diagonal operators.