### PR TITLE
Feature/report to file with skip

### DIFF
--- a/scripts/BHM-example-mpi.jl
+++ b/scripts/BHM-example-mpi.jl
@@ -29,7 +29,7 @@ dvec = MPIData(DVec(address => 1.0; style=IsDynamicSemistochastic()))
 # the root MPI rank will write to the file. The `chunk_size` parameter determines how often
 # the data is saved to the file.
 
-r_strat = ReportToFile(filename="result.arrow", save_if=is_mpi_root(), chunk_size=1000)
+r_strat = ReportToFile(filename="result.arrow", save_if=is_mpi_root(), reporting_interval = 1, chunk_size=1000)
 
 # Now, we can set other parameters as usual. We will perform the computation with 10_000
 # walkers. We will also compute the projected energy.

--- a/scripts/BHM-example.jl
+++ b/scripts/BHM-example.jl
@@ -36,8 +36,8 @@ steps_measure = 2_000
 # Set the size of a time step
 dτ = 0.001
 # and we report QMC data every k-th step,
-# setting `k = 1` means we record QMC data every step:
-k = 1
+# set the interval to record QMC data:
+reporting_interval = 1
 
 # Now we prepare initial state and allocate memory.
 # The initial address is defined above as `aIni = near_uniform(Ĥ)`.
@@ -53,7 +53,7 @@ params = RunTillLastStep(dτ = dτ, laststep = steps_equilibrate + steps_measure
 # Strategy for updating the shift:
 s_strat = DoubleLogUpdate(targetwalkers = targetwalkers, ζ = 0.08)
 # Strategy for reporting info:
-r_strat = ReportDFAndInfo(k = k, i = 100)
+r_strat = ReportDFAndInfo(reporting_interval = reporting_interval, info_interval = 100)
 # Strategy for updating dτ:
 τ_strat = ConstantTimeStep()
 # set up the calculation and reporting of the projected energy

--- a/src/lomc.jl
+++ b/src/lomc.jl
@@ -292,7 +292,9 @@ function lomc!(state::QMCState, df=DataFrame(); laststep=0, name="lomc!")
     # update_steps = 400
     @withprogress name=name while step < laststep
         step += 1
-        report!(state.r_strat, step, report, :steps, step)
+        if step % reporting_interval(state.r_strat) == 0
+            report!(state.r_strat, step, report, :steps, step)
+        end
         # This loop could be threaded if num_threads() == num_replicas? MPIData would
         # need to be aware of the replica's id and use that in communication.
         success = true
@@ -302,9 +304,9 @@ function lomc!(state::QMCState, df=DataFrame(); laststep=0, name="lomc!")
         if step % reporting_interval(state.r_strat) == 0
             replica_names, replica_values = replica_stats(state.replica, state.replicas)
             report!(state.r_strat, step, report, replica_names, replica_values)
-        end        
-        report_after_step(state.r_strat, step, report, state)
-        ensure_correct_lengths(report)
+            report_after_step(state.r_strat, step, report, state)
+            ensure_correct_lengths(report)
+        end
         if step % update_steps == 0 # for updating progress bars
             @logprogress (step-initial_step)/(laststep-initial_step)
         end

--- a/src/lomc.jl
+++ b/src/lomc.jl
@@ -301,8 +301,8 @@ function lomc!(state::QMCState, df=DataFrame(); laststep=0, name="lomc!")
         end
         if step % reporting_interval(state.r_strat) == 0
             replica_names, replica_values = replica_stats(state.replica, state.replicas)
-        end
-        report!(state.r_strat, step, report, replica_names, replica_values)
+            report!(state.r_strat, step, report, replica_names, replica_values)
+        end        
         report_after_step(state.r_strat, step, report, state)
         ensure_correct_lengths(report)
         if step % update_steps == 0 # for updating progress bars

--- a/src/strategies_and_params/poststepstrategy.jl
+++ b/src/strategies_and_params/poststepstrategy.jl
@@ -24,8 +24,9 @@ abstract type PostStepStrategy end
 """
     post_step(::PostStepStrategy, ::ReplicaState) -> kvpairs
 
-Compute statistics after FCIQMC step. Should return a tuple of `:key => value` pairs. See
-also [`PostStepStrategy`](@ref).
+Compute statistics after FCIQMC step. Should return a tuple of `:key => value` pairs. 
+This function is only called every `reporting_interval` steps, as defined by the `ReportingStrategy`. 
+See also [`PostStepStrategy`](@ref), [`ReportingStrategy`](@ref).
 """
 post_step
 

--- a/src/strategies_and_params/poststepstrategy.jl
+++ b/src/strategies_and_params/poststepstrategy.jl
@@ -25,7 +25,7 @@ abstract type PostStepStrategy end
     post_step(::PostStepStrategy, ::ReplicaState) -> kvpairs
 
 Compute statistics after FCIQMC step. Should return a tuple of `:key => value` pairs. 
-This function is only called every `reporting_interval` steps, as defined by the `ReportingStrategy`. 
+This function is only called every [`reporting_interval`](@ref) steps, as defined by the `ReportingStrategy`. 
 See also [`PostStepStrategy`](@ref), [`ReportingStrategy`](@ref).
 """
 post_step

--- a/src/strategies_and_params/replicastrategy.jl
+++ b/src/strategies_and_params/replicastrategy.jl
@@ -29,7 +29,7 @@ num_replicas(::ReplicaStrategy{N}) where {N} = N
 Return the names and values of statistics related to `N` replicas consistent with the
 [`ReplicaStrategy`](@ref) `RS`. `names`
 should be a tuple of `Symbol`s or `String`s and `values` should be a tuple of the same
-length. This fuction will be called every `reporting_interval` steps from [`lomc!`](@ref), 
+length. This fuction will be called every [`reporting_interval`](@ref) steps from [`lomc!`](@ref), 
 or once per time step if `reporting_interval` is not defined.
 
 Part of the [`ReplicaStrategy`](@ref) interface. See also [`ReplicaState`](@ref).

--- a/src/strategies_and_params/replicastrategy.jl
+++ b/src/strategies_and_params/replicastrategy.jl
@@ -29,7 +29,8 @@ num_replicas(::ReplicaStrategy{N}) where {N} = N
 Return the names and values of statistics related to `N` replicas consistent with the
 [`ReplicaStrategy`](@ref) `RS`. `names`
 should be a tuple of `Symbol`s or `String`s and `values` should be a tuple of the same
-length. This fuction will be called once per time step from [`lomc!`](@ref).
+length. This fuction will be called every `reporting_interval` steps from [`lomc!`](@ref), 
+or once per time step if `reporting_interval` is not defined.
 
 Part of the [`ReplicaStrategy`](@ref) interface. See also [`ReplicaState`](@ref).
 """
@@ -85,7 +86,7 @@ end
 """
     all_overlaps(operators, vectors)
 
-Get all overlaps between vectors and operators. This function is overlpaded for `MPIData`.
+Get all overlaps between vectors and operators. This function is overloaded for `MPIData`.
 """
 function all_overlaps(operators::Tuple, vecs::NTuple{N,AbstractDVec}) where {N}
     T = promote_type((valtype(v) for v in vecs)..., eltype.(operators)...)

--- a/src/strategies_and_params/reportingstrategy.jl
+++ b/src/strategies_and_params/reportingstrategy.jl
@@ -139,7 +139,7 @@ end
     reporting_interval(::ReportingStrategy)
 
 Get the interval between steps for which non-essential statistics are reported. Defaults to
-1 if chosen `ReportingStrategy` does not specify an interval.
+1 if chosen [`ReportingStrategy`](@ref) does not specify an interval.
 """
 reporting_interval(::ReportingStrategy) = 1
 

--- a/src/strategies_and_params/reportingstrategy.jl
+++ b/src/strategies_and_params/reportingstrategy.jl
@@ -227,7 +227,7 @@ function refine_r_strat(s::ReportToFile)
     end
     return s
 end
-function report!(s::ReportToFile, _, args...)
+function report!(s::ReportToFile, step, args...)
     if s.save_if
         step % s.k == 0 && report!(args...)
     end

--- a/src/strategies_and_params/reportingstrategy.jl
+++ b/src/strategies_and_params/reportingstrategy.jl
@@ -168,7 +168,7 @@ end
     ReportDFAndInfo(; reporting_interval=1, info_interval=100, io=stdout, writeinfo=false) <: ReportingStrategy
 
 The default [`ReportingStrategy`](@ref). Report every `reporting_interval`th step to a `DataFrame` 
-and write info message to `io` every `info_interval`th step (unless `writeinfo == false`). The flag 
+and write info message to `io` every `info_interval`th reported step (unless `writeinfo == false`). The flag 
 `writeinfo` is useful for controlling info messages in MPI codes, e.g. by setting
 `writeinfo =`[`is_mpi_root()`](@ref).
 """
@@ -183,7 +183,7 @@ function report!(s::ReportDFAndInfo, step, args...)
     return nothing
 end
 function report_after_step(s::ReportDFAndInfo, step, _, state)
-    if s.writeinfo && step % s.info_interval == 0
+    if s.writeinfo && step % (s.info_interval * s.reporting_interval) == 0
         print_stats(s.io, step, state)
     end
 end
@@ -248,7 +248,7 @@ function report!(s::ReportToFile, step, args...)
     return nothing
 end
 function report_after_step(s::ReportToFile, step, report, state)
-    if s.save_if && step * s.reporting_interval % s.chunk_size == 0
+    if s.save_if && step % (s.chunk_size * s.reporting_interval) == 0
         # Report some stats:
         print_stats(s.io, step, state)
 

--- a/src/strategies_and_params/reportingstrategy.jl
+++ b/src/strategies_and_params/reportingstrategy.jl
@@ -95,6 +95,7 @@ A `ReportingStrategy` can define any of the following:
 * [`report!`](@ref)
 * [`report_after_step`](@ref)
 * [`finalize_report!`](@ref)
+* [`reporting_interval`](@ref)
 
 """
 abstract type ReportingStrategy end

--- a/src/strategies_and_params/reportingstrategy.jl
+++ b/src/strategies_and_params/reportingstrategy.jl
@@ -138,7 +138,7 @@ end
 """
     reporting_interval(::ReportingStrategy)
 
-Return the interval between steps for which non-essential statistics are reported. Defaults to
+Get the interval between steps for which non-essential statistics are reported. Defaults to
 1 if chosen `ReportingStrategy` does not specify an interval.
 """
 function reporting_interval(::ReportingStrategy)
@@ -200,7 +200,7 @@ jobs or large numbers of replicas, when the report can incur a significant memor
 # Keyword arguments
 
 * `filename`: the file to report to. If the file already exists, a new file is created.
-* `reporting_interval`: interval between steps that are reported to a (temporary) `DataFrame`.
+* `reporting_interval`: interval between simulation steps that are reported to a `DataFrame`.
 * `chunk_size = 1000`: the size of each chunk that is written to the file. A `DataFrame` of
   this size is collected in memory and written to disk. When saving, an info message is also
   printed to `io`.

--- a/src/strategies_and_params/reportingstrategy.jl
+++ b/src/strategies_and_params/reportingstrategy.jl
@@ -128,8 +128,8 @@ end
 """
     report_after_step(::ReportingStrategy, step, report, state)
 
-This function is called exactly once at the very end of a step. For example, it can be used
-to print some information to `stdout`.
+This function is called at the very end of a step, after `reporting_interval`(@ref) steps. 
+For example, it can be used to print some information to `stdout`.
 """
 function report_after_step(::ReportingStrategy, args...)
     return nothing

--- a/src/strategies_and_params/reportingstrategy.jl
+++ b/src/strategies_and_params/reportingstrategy.jl
@@ -141,10 +141,7 @@ end
 Get the interval between steps for which non-essential statistics are reported. Defaults to
 1 if chosen `ReportingStrategy` does not specify an interval.
 """
-function reporting_interval(::ReportingStrategy)
-    skip = 1
-    return skip
-end
+reporting_interval(::ReportingStrategy) = 1
 
 """
     finalize_report!(::ReportingStrategy, report)

--- a/src/strategies_and_params/reportingstrategy.jl
+++ b/src/strategies_and_params/reportingstrategy.jl
@@ -178,9 +178,8 @@ and write info message to `io` every `info_interval`th reported step (unless `wr
     io::IO = stdout
     writeinfo::Bool = false
 end
-function report!(s::ReportDFAndInfo, step, args...)
-    step % s.reporting_interval == 0 && report!(args...)
-    return nothing
+function report!(s::ReportDFAndInfo, _, args...)
+    report!(args...)
 end
 function report_after_step(s::ReportDFAndInfo, step, _, state)
     if s.writeinfo && step % (s.info_interval * s.reporting_interval) == 0
@@ -241,11 +240,10 @@ function refine_r_strat(s::ReportToFile)
     end
     return s
 end
-function report!(s::ReportToFile, step, args...)
+function report!(s::ReportToFile, _, args...)
     if s.save_if
-        step % s.reporting_interval == 0 && report!(args...)
+        report!(args...)
     end
-    return nothing
 end
 function report_after_step(s::ReportToFile, step, report, state)
     if s.save_if && step % (s.chunk_size * s.reporting_interval) == 0

--- a/test/lomc.jl
+++ b/test/lomc.jl
@@ -304,7 +304,8 @@ using Statistics
             @test isempty(df)
             df6 = RimuIO.load_df("test-report-3.arrow")
 
-            @test df6 == df5
+            @test df6.shift ≈ df5.shift
+            @test df6.norm ≈ df5.norm
 
             # Clean up.
             rm("test-report.arrow"; force=true)

--- a/test/lomc.jl
+++ b/test/lomc.jl
@@ -257,21 +257,22 @@ using Statistics
         dv = DVec(add => 1, style=IsDeterministic())
 
         @testset "ReportDFAndInfo" begin
-            r_strat = ReportDFAndInfo(reporting_interval=5, info_interval=20, io=devnull, writeinfo=true)
+            r_strat = ReportDFAndInfo(reporting_interval=5, info_interval=10, io=devnull, writeinfo=true)
             df = lomc!(H, copy(dv); r_strat, laststep=100).df
             @test size(df, 1) == 20
 
             out = @capture_out begin
-                r_strat = ReportDFAndInfo(reporting_interval=5, info_interval=20, io=stdout, writeinfo=true)
+                r_strat = ReportDFAndInfo(reporting_interval=5, info_interval=10, io=stdout, writeinfo=true)
                 lomc!(H, copy(dv); r_strat, laststep=100)
             end
-            @test length(split(out, '\n')) == 6 # (last line is empty)
+            @test length(split(out, '\n')) == 3 # (last line is empty)
         end
         @testset "ReportToFile" begin
             # Clean up.
             rm("test-report.arrow"; force=true)
             rm("test-report-1.arrow"; force=true)
             rm("test-report-2.arrow"; force=true)
+            rm("test-report-3.arrow"; force=true)
 
             r_strat = ReportToFile(filename="test-report.arrow", io=devnull, save_if=false)
             df = lomc!(H, copy(dv); r_strat, laststep=100).df
@@ -296,29 +297,20 @@ using Statistics
             @test df2.norm ≈ df3.norm
             @test df3 == df4
 
+            # ReportToFile with skipping interval  
+            df5 = df1[10:10:100,:]
+            r_strat = ReportToFile(filename="test-report.arrow", reporting_interval=10, io=devnull, chunk_size=10)
+            df = lomc!(H, copy(dv); r_strat, laststep=100).df
+            @test isempty(df)
+            df6 = RimuIO.load_df("test-report-3.arrow")
+
+            @test df6 == df5
+
             # Clean up.
             rm("test-report.arrow"; force=true)
             rm("test-report-1.arrow"; force=true)
             rm("test-report-2.arrow"; force=true)
-
-            # ReportToFile with skipping interval
-            ConsistentRNG.seedCRNG!(1337)            
-            r_strat = ReportToFile(filename="test-report.arrow", io=devnull, chunk_size=10)
-            df = lomc!(H, copy(dv); r_strat, laststep=100).df
-            @test isempty(df)
-            df1 = RimuIO.load_df("test-report.arrow")
-
-            ConsistentRNG.seedCRNG!(1337)
-            r_strat = ReportToFile(filename="test-report.arrow", reporting_interval=10, io=devnull, chunk_size=10)
-            df = lomc!(H, copy(dv); r_strat, laststep=100).df
-            @test isempty(df)
-            df2 = RimuIO.load_df("test-report-1.arrow")
-
-            @test df1[10:10:100,:] == df2
-
-            # Clean up.
-            rm("test-report.arrow"; force=true)
-            rm("test-report-1.arrow"; force=true)
+            rm("test-report-3.arrow"; force=true)
         end
     end
 


### PR DESCRIPTION
Add reporting_interval to ReportToFile
Add a new function to ReportingStrategy: reporting_interval, default 1
Allows ReportToFile to report at an interval of steps, similar to ReportDFandInfo
Rename k and i arguments of ReportDFandInfo