### PR TITLE
Optimize sparse matrix construction, add option to select column based on their diagonal elements.

### DIFF
--- a/src/Hamiltonians/Momentum.jl
+++ b/src/Hamiltonians/Momentum.jl
@@ -29,6 +29,11 @@ Base.show(io::IO, mom::Momentum{C}) where {C} = print(io, "Momentum($C; fold=$(m
 LOStructure(::Type{<:Momentum}) = IsDiagonal()
 num_offdiagonals(ham::Momentum, add) = 0
 
+function fold_mod(m, M)
+    m = mod(m, M)
+    return m > M ÷ 2 ? m - M : m
+end
+
 function momentum(add::SingleComponentFockAddress; fold=false)
     M = num_modes(add)
     res = 0
@@ -36,7 +41,7 @@ function momentum(add::SingleComponentFockAddress; fold=false)
         res += (i.mode - cld(M, 2)) * i.occnum
     end
     if fold
-        return float(mod(res, M))
+        return float(fold_mod(res, M))
     else
         return float(res)
     end
@@ -47,7 +52,7 @@ function momentum(add::CompositeFS; fold=false)
         momentum(fs; fold=false)
     end
     if fold
-        return float(mod(res, M))
+        return float(fold_mod(res, M))
     else
         return float(res)
     end
@@ -56,7 +61,9 @@ end
 diagonal_element(m::Momentum{0}, a::SingleComponentFockAddress) = momentum(a; fold=m.fold)
 diagonal_element(m::Momentum{1}, a::SingleComponentFockAddress) = momentum(a; fold=m.fold)
 
-diagonal_element(m::Momentum{0}, a::BoseFS2C) = momentum((a.bsa, a.bsb); fold=m.fold)
+# TODO: this is to be removed along with BoseFS2C
+diagonal_element(m::Momentum{0}, a::BoseFS2C) =
+    momentum(CompositeFS(a.bsa, a.bsb); fold=m.fold)
 diagonal_element(m::Momentum{1}, a::BoseFS2C) = momentum(a.bsa; fold=m.fold)
 diagonal_element(m::Momentum{2}, a::BoseFS2C) = momentum(a.bsb; fold=m.fold)
 

--- a/src/Hamiltonians/Momentum.jl
+++ b/src/Hamiltonians/Momentum.jl
@@ -29,55 +29,31 @@ Base.show(io::IO, mom::Momentum{C}) where {C} = print(io, "Momentum($C; fold=$(m
 LOStructure(::Type{<:Momentum}) = IsDiagonal()
 num_offdiagonals(ham::Momentum, add) = 0
 
-function fold_mod(m, M)
-    m = mod(m, M)
-    return m > M ÷ 2 ? m - M : m
-end
-
-function momentum(add::SingleComponentFockAddress; fold=false)
+@inline function _momentum(add::SingleComponentFockAddress, fold)
     M = num_modes(add)
-    res = sum(OccupiedModeMap(add)) do i
-        i.occnum * (i.mode - cld(M, 2))
-    end
+    momentum = float(dot(-cld(M,2)+1:fld(M,2), OccupiedModeMap(add)))
     if fold
-        return fold_mod(res, M)
+        return mod1(momentum + cld(M,2), M) - cld(M,2)
     else
-        return res
+        return momentum
     end
 end
-function momentum(add::CompositeFS; fold=false)
-    M = num_modes(add)
-    res = sum(add.components) do fs
-        momentum(fs; fold=false)
-    end
+@inline function _momentum(adds, fold)
+    M = num_modes(adds[1])
+    momentum = sum(a -> _momentum(a, false), adds)
     if fold
-        return fold_mod(res, M)
+        return mod1(momentum + cld(M,2), M) - cld(M,2)
     else
-        return res
+        return momentum
     end
 end
 
-function diagonal_element(m::Momentum{0}, a::SingleComponentFockAddress)
-    return float(momentum(a; fold=m.fold))
-end
-function diagonal_element(m::Momentum{1}, a::SingleComponentFockAddress)
-    return float(momentum(a; fold=m.fold))
-end
+diagonal_element(m::Momentum{0}, a::SingleComponentFockAddress) = _momentum(a, m.fold)
+diagonal_element(m::Momentum{1}, a::SingleComponentFockAddress) = _momentum(a, m.fold)
 
-# TODO: this is to be removed along with BoseFS2C
-function diagonal_element(m::Momentum{0}, a::BoseFS2C)
-    return float(momentum(CompositeFS(a.bsa, a.bsb); fold=m.fold))
-end
-function diagonal_element(m::Momentum{1}, a::BoseFS2C)
-    return float(momentum(a.bsa; fold=m.fold))
-end
-function diagonal_element(m::Momentum{2}, a::BoseFS2C)
-    return float(momentum(a.bsb; fold=m.fold))
-end
+diagonal_element(m::Momentum{0}, a::BoseFS2C) = _momentum((a.bsa, a.bsb), m.fold)
+diagonal_element(m::Momentum{1}, a::BoseFS2C) = _momentum(a.bsa, m.fold)
+diagonal_element(m::Momentum{2}, a::BoseFS2C) = _momentum(a.bsb, m.fold)
 
-function diagonal_element(m::Momentum{0}, a::CompositeFS)
-    return float(momentum(a; fold=m.fold))
-end
-function diagonal_element(m::Momentum{N}, a::CompositeFS) where {N}
-    return float(momentum(a.components[N]; fold=m.fold))
-end
+diagonal_element(m::Momentum{0}, a::CompositeFS) = _momentum(a.components, m.fold)
+diagonal_element(m::Momentum{N}, a::CompositeFS) where {N} = _momentum(a.components[N], m.fold)

--- a/src/Hamiltonians/Momentum.jl
+++ b/src/Hamiltonians/Momentum.jl
@@ -36,14 +36,13 @@ end
 
 function momentum(add::SingleComponentFockAddress; fold=false)
     M = num_modes(add)
-    res = 0
-    for i in OccupiedModeMap(add)
-        res += (i.mode - cld(M, 2)) * i.occnum
+    res = sum(OccupiedModeMap(add)) do i
+        i.occnum * (i.mode - cld(M, 2))
     end
     if fold
-        return float(fold_mod(res, M))
+        return fold_mod(res, M)
     else
-        return float(res)
+        return res
     end
 end
 function momentum(add::CompositeFS; fold=false)
@@ -52,21 +51,33 @@ function momentum(add::CompositeFS; fold=false)
         momentum(fs; fold=false)
     end
     if fold
-        return float(fold_mod(res, M))
+        return fold_mod(res, M)
     else
-        return float(res)
+        return res
     end
 end
 
-diagonal_element(m::Momentum{0}, a::SingleComponentFockAddress) = momentum(a; fold=m.fold)
-diagonal_element(m::Momentum{1}, a::SingleComponentFockAddress) = momentum(a; fold=m.fold)
+function diagonal_element(m::Momentum{0}, a::SingleComponentFockAddress)
+    return float(momentum(a; fold=m.fold))
+end
+function diagonal_element(m::Momentum{1}, a::SingleComponentFockAddress)
+    return float(momentum(a; fold=m.fold))
+end
 
 # TODO: this is to be removed along with BoseFS2C
-diagonal_element(m::Momentum{0}, a::BoseFS2C) =
-    momentum(CompositeFS(a.bsa, a.bsb); fold=m.fold)
-diagonal_element(m::Momentum{1}, a::BoseFS2C) = momentum(a.bsa; fold=m.fold)
-diagonal_element(m::Momentum{2}, a::BoseFS2C) = momentum(a.bsb; fold=m.fold)
+function diagonal_element(m::Momentum{0}, a::BoseFS2C)
+    return float(momentum(CompositeFS(a.bsa, a.bsb); fold=m.fold))
+end
+function diagonal_element(m::Momentum{1}, a::BoseFS2C)
+    return float(momentum(a.bsa; fold=m.fold))
+end
+function diagonal_element(m::Momentum{2}, a::BoseFS2C)
+    return float(momentum(a.bsb; fold=m.fold))
+end
 
-diagonal_element(m::Momentum{0}, a::CompositeFS) = momentum(a; fold=m.fold)
-diagonal_element(m::Momentum{N}, a::CompositeFS) where {N} =
-    momentum(a.components[N]; fold=m.fold)
+function diagonal_element(m::Momentum{0}, a::CompositeFS)
+    return float(momentum(a; fold=m.fold))
+end
+function diagonal_element(m::Momentum{N}, a::CompositeFS) where {N}
+    return float(momentum(a.components[N]; fold=m.fold))
+end

--- a/src/Hamiltonians/abstract.jl
+++ b/src/Hamiltonians/abstract.jl
@@ -139,56 +139,72 @@ julia> rayleigh_quotient(mom, v) # momentum expectation value for state vector `
 momentum
 
 """
-    sm, basis = build_sparse_matrix_from_LO(ham::AbstractHamiltonian, add; nnzs = 0)
+    sm, basis = build_sparse_matrix_from_LO(ham, add; energy_cutoff, nnzs)
 
 Create a sparse matrix `sm` of all reachable matrix elements of a linear operator `ham`
 starting from the address `add`. The vector `basis` contains the addresses of basis
 configurations.
 Providing the number `nnzs` of expected calculated matrix elements may improve performance.
+The default estimates for `nnzs` is `num_offdiagonals(ham, add)^2`.
+Providing an energy cutoff will skip the columns with diagonal elements greater or equal to
+`energy_cutoff`. This is not enabled by default.
 
 See [`BasisSetRep`](@ref).
 """
 function build_sparse_matrix_from_LO(
-    ham::AbstractHamiltonian, fs=starting_address(ham); nnzs = 0
+    ham, address=starting_address(ham);
+    energy_cutoff=nothing, nnzs=num_offdiagonals(ham, address)^2
 )
-    adds = [fs] # list of addresses of length linear dimension of matrix
-    adds_dict = Dict(fs=>1) # dictionary for index lookup
-    I = Int[]         # row indices, length nnz
-    J = Int[]         # column indices, length nnz
-    V = eltype(ham)[] # values, length nnz
-    if nnzs > 0
-        sizehint!(I, nnzs)
-        sizehint!(J, nnzs)
-        sizehint!(V, nnzs)
-    end
+    T = eltype(ham)
+    adds = [address]          # Queue of addresses. Also returned as the basis.
+    dict = Dict(address => 1) # Mapping from addresses to indices
+    col = Dict{Int,T}()       # Temporary column storage
+    sizehint!(col, num_offdiagonals(ham, address))
 
-    i = 0 # 1:dim, column of matrix
-    while true # loop over columns of the matrix
-        i += 1 # next column
-        i > length(adds) && break
-        add = adds[i] # new address from list
-        # compute and push diagonal matrix element
-        melem = diagonal_element(ham, add)
-        push!(I, i)
-        push!(J, i)
-        push!(V, melem)
-        for (nadd, melem) in offdiagonals(ham, add) # loop over rows
-            iszero(melem) && continue
-            j = get(adds_dict, nadd, nothing) # look up index; much faster than `findnext`
+    is = Int[] # row indices
+    js = Int[] # column indice
+    vs = T[]   # non-zero values
+
+    sizehint!(is, nnzs)
+    sizehint!(js, nnzs)
+    sizehint!(vs, nnzs)
+
+    i = 0
+    while i < length(adds)
+        i += 1
+        add = adds[i]
+        push!(is, i)
+        push!(js, i)
+        push!(vs, diagonal_element(ham, add))
+
+        empty!(col)
+        for (off, v) in offdiagonals(ham, add)
+            iszero(v) && continue
+            j = get(dict, off, nothing)
             if isnothing(j)
-                # new address: increase dimension of matrix by adding a row
-                push!(adds, nadd)
-                j = length(adds) # row index points to the new element in `adds`
-                adds_dict[nadd] = j
+                # Energy cutoff: remember skipped addresses, but avoid adding them to `adds`
+                if !isnothing(energy_cutoff) && diagonal_element(ham, off) ≥ energy_cutoff
+                    dict[off] = 0
+                    j = 0
+                else
+                    push!(adds, off)
+                    j = length(adds)
+                    dict[off] = j
+                end
             end
-            # new nonzero matrix element
-            push!(I, i)
-            push!(J, j)
-            push!(V, melem)
+            if !iszero(j)
+                col[j] = get(col, j, zero(T)) + v
+            end
+        end
+        # Copy the column into the sparse matrix vectors.
+        for (j, v) in col
+            iszero(v) && continue
+            push!(is, i)
+            push!(js, j)
+            push!(vs, v)
         end
     end
-    # when the index `(i,j)` occurs mutiple times in `I` and `J` the elements are added.
-    return sparse(I, J, V), adds
+    return sparse(is, js, vs, length(adds), length(adds)), adds
 end
 
 """
@@ -243,7 +259,7 @@ end
 
 function BasisSetRep(
     h::AbstractHamiltonian, addr=starting_address(h);
-    sizelim=10^4, nnzs = 0
+    sizelim=10^6, nnzs = 0
 )
     dimension(Float64, h) < sizelim || throw(ArgumentError("dimension larger than sizelim"))
     check_address_type(h, addr)
@@ -265,6 +281,7 @@ dimension(::Type{T}, bsr::BasisSetRep) where {T} = T(length(bsr.basis))
 """
     sparse(h::AbstractHamiltonian, addr=starting_address(h); sizelim=10^4)
     sparse(bsr::BasisSetRep)
+
 Return a sparse matrix representation of `h` or `bsr`. An `ArgumentError` is thrown if
 `dimension(h) > sizelim` in order to prevent memory overflow. Set `sizelim = Inf` in order
 to disable this behaviour.
@@ -279,35 +296,36 @@ SparseArrays.sparse(bsr::BasisSetRep) = bsr.sm
 """
     Matrix(h::AbstractHamiltonian, addr=starting_address(h); sizelim=10^4)
     Matrix(bsr::BasisSetRep)
+
 Return a dense matrix representation of `h` or `bsr`. An `ArgumentError` is thrown if
 `dimension(h) > sizelim` in order to prevent memory overflow. Set `sizelim = Inf` in order
 to disable this behaviour.
 
 See [`BasisSetRep`](@ref).
 """
-function Base.Matrix(h::AbstractHamiltonian, args...; kwargs...)
-    return Matrix(BasisSetRep(h, args...; kwargs...))
+function Base.Matrix(h::AbstractHamiltonian, args...; sizelim=1e4, kwargs...)
+    return Matrix(BasisSetRep(h, args...; sizelim, kwargs...))
 end
 Base.Matrix(bsr::BasisSetRep) = Matrix(bsr.sm)
 
 """
     TransformUndoer{T,K<:AbstractHamiltonian,O<:Union{AbstractHamiltonian,Nothing}} <: AbstractHamiltonian{T}
 
-Type for creating a new operator for the purpose of calculating overlaps of transformed 
-vectors, which are defined by some transformation `transform`. The new operator should 
-represent the effect of undoing the transformation before calculating overlaps, including 
+Type for creating a new operator for the purpose of calculating overlaps of transformed
+vectors, which are defined by some transformation `transform`. The new operator should
+represent the effect of undoing the transformation before calculating overlaps, including
 with an optional operator `op`.
 
-Not exported; transformations should define all necessary methods and properties, 
-see [`AbstractHamiltonian`](@ref). An `ArgumentError` is thrown if used with an 
+Not exported; transformations should define all necessary methods and properties,
+see [`AbstractHamiltonian`](@ref). An `ArgumentError` is thrown if used with an
 unsupported transformation.
 
-# Example 
+# Example
 
-A similarity transform ``\\hat{G} = f \\hat{H} f^{-1}`` has eigenvector 
+A similarity transform ``\\hat{G} = f \\hat{H} f^{-1}`` has eigenvector
 ``d = f \\cdot c`` where ``c`` is an eigenvector of ``\\hat{H}``. Then the
-overlap ``c' \\cdot c = d' \\cdot f^{-2} \\cdot d`` can be computed by defining all 
-necessary methods for `TransformUndoer(G)` to represent the operator ``f^{-2}`` and 
+overlap ``c' \\cdot c = d' \\cdot f^{-2} \\cdot d`` can be computed by defining all
+necessary methods for `TransformUndoer(G)` to represent the operator ``f^{-2}`` and
 calculating `dot(d, TransformUndoer(G), d)`.
 
 Observables in the transformed basis can be computed by defining `TransformUndoer(G, A)`

--- a/src/Hamiltonians/abstract.jl
+++ b/src/Hamiltonians/abstract.jl
@@ -156,7 +156,7 @@ not enabled by default.
 
 Setting `sort` to `true` will sort the matrix rows and columns. This is useful when the
 order of the columns matters, e.g. when comparing matrices. Any additional keyword arguments
-are passed on to `sortperm`.
+are passed on to `Base.sortperm`.
 
 See [`BasisSetRep`](@ref).
 """
@@ -233,12 +233,25 @@ function build_sparse_matrix_from_LO(
 end
 
 """
-    BasisSetRep(h::AbstractHamiltonian, addr=starting_address(h); sizelim=10^4, nnzs = 0)
+    BasisSetRep(
+        h::AbstractHamiltonian, addr=starting_address(h);
+        sizelim=10^4, nnzs, cutoff, filter, sort, kwargs...
+    )
 
 Eagerly construct the basis set representation of the operator `h` with all addresses
 reachable from `addr`. An `ArgumentError` is thrown if `dimension(h) > sizelim` in order
 to prevent memory overflow. Set `sizelim = Inf` in order to disable this behaviour.
+
 Providing the number `nnzs` of expected calculated matrix elements may improve performance.
+The default estimates for `nnzs` is `dimension(ham)`.
+
+Providing an energy cutoff will skip the columns and rows with diagonal elements greater
+than `cutoff`. Alternatively, an arbitrary `filter` function can be used instead. These are
+not enabled by default.
+
+Setting `sort` to `true` will sort the matrix rows and columns. This is useful when the
+order of the columns matters, e.g. when comparing matrices. Any additional keyword arguments
+are passed on to `Base.sortperm`.
 
 ## Fields
 * `sm`: sparse matrix representing `h` in the basis `basis`

--- a/src/Hamiltonians/abstract.jl
+++ b/src/Hamiltonians/abstract.jl
@@ -235,12 +235,14 @@ end
 """
     BasisSetRep(
         h::AbstractHamiltonian, addr=starting_address(h);
-        sizelim=10^4, nnzs, cutoff, filter, sort, kwargs...
+        sizelim=10^6, nnzs, cutoff, filter, sort, kwargs...
     )
 
 Eagerly construct the basis set representation of the operator `h` with all addresses
-reachable from `addr`. An `ArgumentError` is thrown if `dimension(h) > sizelim` in order
-to prevent memory overflow. Set `sizelim = Inf` in order to disable this behaviour.
+reachable from `addr`.
+
+An `ArgumentError` is thrown if `dimension(h) > sizelim` in order to prevent memory
+overflow. Set `sizelim = Inf` in order to disable this behaviour.
 
 Providing the number `nnzs` of expected calculated matrix elements may improve performance.
 The default estimates for `nnzs` is `dimension(ham)`.
@@ -318,12 +320,11 @@ dimension(::Type{T}, bsr::BasisSetRep) where {T} = T(length(bsr.basis))
 
 
 """
-    sparse(h::AbstractHamiltonian, addr=starting_address(h); sizelim=10^4)
+    sparse(h::AbstractHamiltonian, addr=starting_address(h); kwargs...)
     sparse(bsr::BasisSetRep)
 
-Return a sparse matrix representation of `h` or `bsr`. An `ArgumentError` is thrown if
-`dimension(h) > sizelim` in order to prevent memory overflow. Set `sizelim = Inf` in order
-to disable this behaviour.
+Return a sparse matrix representation of `h` or `bsr`. `kwargs` are passed to
+[`BasisSetRep`](@ref).
 
 See [`BasisSetRep`](@ref).
 """
@@ -333,12 +334,11 @@ end
 SparseArrays.sparse(bsr::BasisSetRep) = bsr.sm
 
 """
-    Matrix(h::AbstractHamiltonian, addr=starting_address(h); sizelim=10^4)
+    Matrix(h::AbstractHamiltonian, addr=starting_address(h); sizelim=10^4, kwargs...)
     Matrix(bsr::BasisSetRep)
 
-Return a dense matrix representation of `h` or `bsr`. An `ArgumentError` is thrown if
-`dimension(h) > sizelim` in order to prevent memory overflow. Set `sizelim = Inf` in order
-to disable this behaviour.
+Return a dense matrix representation of `h` or `bsr`. `kwargs` are passed to
+[`BasisSetRep`](@ref).
 
 See [`BasisSetRep`](@ref).
 """

--- a/src/Hamiltonians/abstract.jl
+++ b/src/Hamiltonians/abstract.jl
@@ -223,7 +223,7 @@ function build_sparse_matrix_from_LO(
         end
     end
 
-    matrix = sparse(is, js, vs, length(adds), length(adds))
+    matrix = sparse(js, is, vs, length(adds), length(adds))
     if sort
         perm = sortperm(adds; kwargs...)
         return permute!(matrix, perm, perm), permute!(adds, perm)

--- a/src/Hamiltonians/abstract.jl
+++ b/src/Hamiltonians/abstract.jl
@@ -150,9 +150,9 @@ configurations.
 Providing the number `nnzs` of expected calculated matrix elements may improve performance.
 The default estimates for `nnzs` is `dimension(ham)`.
 
-Providing an energy cutoff will skip the columns with diagonal elements greater than
-`cutoff`. Alternatively, an arbitrary `filter` function can be used instead.
-These are not enabled by default.
+Providing an energy cutoff will skip the columns and rows with diagonal elements greater
+than `cutoff`. Alternatively, an arbitrary `filter` function can be used instead. These are
+not enabled by default.
 
 Setting `sort` to `true` will sort the matrix rows and columns. This is useful when the
 order of the columns matters, e.g. when comparing matrices. Any additional keyword arguments

--- a/src/Hamiltonians/abstract.jl
+++ b/src/Hamiltonians/abstract.jl
@@ -234,6 +234,7 @@ end
 
 """
     BasisSetRep(h::AbstractHamiltonian, addr=starting_address(h); sizelim=10^4, nnzs = 0)
+
 Eagerly construct the basis set representation of the operator `h` with all addresses
 reachable from `addr`. An `ArgumentError` is thrown if `dimension(h) > sizelim` in order
 to prevent memory overflow. Set `sizelim = Inf` in order to disable this behaviour.

--- a/src/Hamiltonians/abstract.jl
+++ b/src/Hamiltonians/abstract.jl
@@ -170,7 +170,7 @@ function build_sparse_matrix_from_LO(
     if !isnothing(filter) && !filter(address)
         throw(ArgumentError(string(
             "Starting address does not pass `filter`. ",
-            "Please pick adifferent address or a different filter."
+            "Please pick a different address or a different filter."
         )))
     end
     T = eltype(ham)

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -549,29 +549,9 @@ end
     end
 
     @testset "adjoints" begin
-        ###
-        ### Define Hamiltonian from a matrix.
-        ###
-        struct MatrixHam{T} <: AbstractHamiltonian{T}
-            arr::Matrix{T}
-        end
-
-        Rimu.diagonal_element(m::MatrixHam, i) = m.arr[i, i]
-        Rimu.num_offdiagonals(m::MatrixHam, i) = size(m.arr, 1) - 1
-        function Rimu.get_offdiagonal(m::MatrixHam, i, j)
-            if j ≥ i # skip diagonal
-                j += 1
-            end
-            return j, m.arr[i, j]
-        end
-
-        Rimu.starting_address(::MatrixHam) = 1
-
-        LinearAlgebra.adjoint(m::MatrixHam) = MatrixHam(collect(m.arr'))
-        Hamiltonians.LOStructure(::Type{<:MatrixHam}) = AdjointKnown()
-        M = MatrixHam(rand(Complex{Float64}, (20, 20)))
-        @test Matrix(M) == M.arr
-        @test Matrix(M') == M.arr'
+        M = MatrixHamiltonian(rand(Complex{Float64}, (20, 20)))
+        @test Matrix(M; sort=true) == M.m
+        @test Matrix(M'; sort=true) == M.m'
 
         @testset "Gutzwiller adjoint" begin
             @test Matrix(GutzwillerSampling(M, 0.2)') == Matrix(GutzwillerSampling(M, 0.2))'
@@ -1053,7 +1033,7 @@ end
     addr2 = bsr.basis[2]
     @test starting_address(BasisSetRep(ham, addr2)) ==  addr2
 
-    @test_throws ArgumentError BasisSetRep(ham; cutoff=20) # starting address cut off
+    @test_throws ArgumentError BasisSetRep(ham; cutoff=19) # starting address cut off
 
     mat_orig = Matrix(ham; sort=true)
     mat_cut_index = diag(mat_orig) .< 30

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -435,14 +435,14 @@ end
             end
         end
 
-        @testset "Gutzwiller observables" begin            
+        @testset "Gutzwiller observables" begin
             for H in (
                 HubbardReal1D(BoseFS((2,2,2)), u=6),
                 HubbardMom1D(BoseFS((2,2,2)), u=6),
                 ExtendedHubbardReal1D(BoseFS((1,1,1,1,1,1,1,1,1,1,1,1)), u=6, t=2.0),
                 # BoseHubbardMom1D2C(BoseFS2C((1,2,3), (1,0,0)), ub=2.0), # multicomponent not implemented for G2RealCorrelator
             )
-                # energy    
+                # energy
                 g = rand()
                 x = rand()
                 G = GutzwillerSampling(H, g)
@@ -455,7 +455,7 @@ end
                 Egutz = dot(dv, G, dv)/dot(dv, dv)
                 Etrans = dot(dv, fHf, dv)/dot(dv, fsq, dv)
                 @test Ebare ≈ Egutz ≈ Etrans
-                
+
                 # general operators
                 m = num_modes(add)
                 g2vals = map(d -> dot(dv, G2RealCorrelator(d), dv)/dot(dv, dv), 0:m-1)
@@ -484,7 +484,7 @@ end
             BoseFS{6,3}((2, 2, 2)) => 0.6004825560434165;
             capacity=100,
         )
-        @testset "GuidingVector transformation" begin            
+        @testset "GuidingVector transformation" begin
             @testset "With empty vector" begin
                 G = GuidingVectorSampling(H, empty(v), 0.2)
 
@@ -515,7 +515,7 @@ end
             end
         end
 
-        @testset "Guiding vector observables" begin            
+        @testset "Guiding vector observables" begin
             for H in (
                 HubbardReal1D(BoseFS((2,2,2)), u=6),
                 HubbardMom1D(BoseFS((2,2,2)), u=6),
@@ -534,7 +534,7 @@ end
                 Egutz = dot(dv, G, dv)/dot(dv, dv)
                 Etrans = dot(dv, fHf, dv)/dot(dv, fsq, dv)
                 @test Ebare ≈ Egutz ≈ Etrans
-                
+
                 # general operators
                 m = num_modes(add)
                 g2vals = map(d -> dot(dv, G2RealCorrelator(d), dv)/dot(dv, dv), 0:m-1)
@@ -1044,7 +1044,7 @@ end
     @test_throws ArgumentError BasisSetRep(ham) # dimension too large
     m = 2
     n = 10
-    addr = BoseFS(Tuple(i == 1 ? n : 0 for i in 1:m))
+    addr = near_uniform(BoseFS{n,m})
     ham = HubbardReal1D(addr)
     bsr = BasisSetRep(ham; nnzs = dimension(ham))
     @test length(bsr.basis) == dimension(bsr) ≤  dimension(ham)
@@ -1053,4 +1053,9 @@ end
     @test sparse(bsr) == bsr.sm == sparse(ham)
     addr2 = bsr.basis[2]
     @test starting_address(BasisSetRep(ham, addr2)) ==  addr2
+
+    @test_throws ArgumentError BasisSetRep(ham; cutoff=20) # starting address cut off
+    mat = Matrix(ham; cutoff=30)
+    @test size(mat2, 1) < size(sparse(bsr), 1)
+    @test all(<(30), diag(mat))
 end

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -1055,9 +1055,16 @@ end
     @test starting_address(BasisSetRep(ham, addr2)) ==  addr2
 
     @test_throws ArgumentError BasisSetRep(ham; cutoff=20) # starting address cut off
-    mat_orig = Matrix(bsr)
-    mat_cut = Matrix(ham; cutoff=30)
-    @test size(mat_cut, 1) < size(mat_orig, 1)
-    @test all(<(30), diag(mat_cut))
-    @test count(≥(30), diag(Matrix(bsr))) == size(mat_orig, 1) - size(mat_cut, 1)
+
+    mat_orig = Matrix(ham; sort=true)
+    mat_cut_index = diag(mat_orig) .< 30
+    mat_cut_manual = mat_orig[mat_cut_index, mat_cut_index]
+    mat_cut = Matrix(ham; cutoff=30, sort=true)
+    @test mat_cut == mat_cut_manual
+
+    filterfun(fs) = maximum(onr(fs)) < 8
+    mat_cut_index = filterfun.(BasisSetRep(ham; sort=true).basis)
+    mat_cut_manual = mat_orig[mat_cut_index, mat_cut_index]
+    mat_cut = Matrix(ham; filter=filterfun, sort=true)
+    @test mat_cut == mat_cut_manual
 end

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -718,10 +718,6 @@ end
 end
 
 @testset "Momentum" begin
-    @test momentum(FermiFS2C((1,0,0,0), (1,0,0,0)); fold=false) ≡ -2
-    @test momentum(FermiFS2C((1,0,0,0), (1,0,0,0)); fold=true) ≡ 2
-    @test momentum(FermiFS2C((1,0,0), (1,0,0)); fold=true) ≡ 1
-
     @test diagonal_element(Momentum(), BoseFS((0,0,2,1,3))) ≡ 2.0
     @test diagonal_element(Momentum(fold=false), BoseFS((0,0,2,1,3))) ≡ 7.0
     @test diagonal_element(Momentum(1), BoseFS((1,0,0,0))) ≡ -1.0
@@ -1060,16 +1056,12 @@ end
         add2 = BoseFS((0,1,0,1))
         ham = HubbardMom1D(add1)
 
-        @test momentum(add1; fold=true) == momentum(add2; fold=true)
-
         @test Matrix(ham, add1; sort=true) == Matrix(ham, add2; sort=true)
         @test Matrix(ham, add1) ≠ Matrix(ham, add2)
 
         add1 = BoseFS((2,0,0,0,0))
         add2 = BoseFS((0,1,0,0,1))
         ham = HubbardMom1D(add1)
-
-        @test momentum(add1; fold=true) == momentum(add2; fold=true)
 
         @test Matrix(ham, add1; sort=true) == Matrix(ham, add2; sort=true)
         @test Matrix(ham, add1) ≠ Matrix(ham, add2)

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -718,17 +718,17 @@ end
 end
 
 @testset "Momentum" begin
-    @test momentum(FermiFS2C((1,0,0,0), (1,0,0,0)); fold=false) == -2
-    @test momentum(FermiFS2C((1,0,0,0), (1,0,0,0)); fold=true) == 2
-    @test momentum(FermiFS2C((1,0,0), (1,0,0)); fold=true) == 1
+    @test momentum(FermiFS2C((1,0,0,0), (1,0,0,0)); fold=false) ≡ -2
+    @test momentum(FermiFS2C((1,0,0,0), (1,0,0,0)); fold=true) ≡ 2
+    @test momentum(FermiFS2C((1,0,0), (1,0,0)); fold=true) ≡ 1
 
-    @test diagonal_element(Momentum(), BoseFS((0,0,2,1,3))) == 2
-    @test diagonal_element(Momentum(fold=false), BoseFS((0,0,2,1,3))) == 7
-    @test diagonal_element(Momentum(1), BoseFS((1,0,0,0))) == -1
+    @test diagonal_element(Momentum(), BoseFS((0,0,2,1,3))) ≡ 2.0
+    @test diagonal_element(Momentum(fold=false), BoseFS((0,0,2,1,3))) ≡ 7.0
+    @test diagonal_element(Momentum(1), BoseFS((1,0,0,0))) ≡ -1.0
     @test_throws MethodError diagonal_element(Momentum(2), BoseFS((0,1,0)))
 
     for add in (BoseFS2C((0,1,2,3,0), (1,2,3,4,5)), FermiFS2C((1,0,0,1), (0,0,1,0)))
-        @test diagonal_element(Momentum(1), add) + diagonal_element(Momentum(2), add) ==
+        @test diagonal_element(Momentum(1), add) + diagonal_element(Momentum(2), add) ≡
             diagonal_element(Momentum(0), add)
     end
 

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -569,13 +569,12 @@ end
 
         LinearAlgebra.adjoint(m::MatrixHam) = MatrixHam(collect(m.arr'))
         Hamiltonians.LOStructure(::Type{<:MatrixHam}) = AdjointKnown()
-        dm(h) = Hamiltonians.build_sparse_matrix_from_LO(h)[1] |> Matrix
         M = MatrixHam(rand(Complex{Float64}, (20, 20)))
-        @test dm(M) == M.arr
-        @test dm(M') == M.arr'
+        @test Matrix(M) == M.arr
+        @test Matrix(M') == M.arr'
 
         @testset "Gutzwiller adjoint" begin
-            @test dm(GutzwillerSampling(M, 0.2)') == dm(GutzwillerSampling(M, 0.2))'
+            @test Matrix(GutzwillerSampling(M, 0.2)') == Matrix(GutzwillerSampling(M, 0.2))'
             @test LOStructure(GutzwillerSampling(M, 0.2)) isa AdjointKnown
             @test LOStructure(
                 GutzwillerSampling(HubbardReal1D(BoseFS((1,2)),t=0+2im), 0.2)
@@ -583,8 +582,8 @@ end
         end
         @testset "GuidingVector adjoint" begin
             v = DVec(starting_address(M) => 10; capacity=10)
-            @test dm(GuidingVectorSampling(M, v, 0.2)') ≈
-                dm(GuidingVectorSampling(M, v, 0.2))'
+            @test Matrix(GuidingVectorSampling(M, v, 0.2)') ≈
+                Matrix(GuidingVectorSampling(M, v, 0.2))'
             @test LOStructure(GuidingVectorSampling(M, v, 0.2)) isa AdjointKnown
             @test LOStructure(GuidingVectorSampling(
                 HubbardReal1D(BoseFS((1,2)),t=0+2im),

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -1055,7 +1055,9 @@ end
     @test starting_address(BasisSetRep(ham, addr2)) ==  addr2
 
     @test_throws ArgumentError BasisSetRep(ham; cutoff=20) # starting address cut off
-    mat = Matrix(ham; cutoff=30)
-    @test size(mat2, 1) < size(sparse(bsr), 1)
-    @test all(<(30), diag(mat))
+    mat_orig = Matrix(bsr)
+    mat_cut = Matrix(ham; cutoff=30)
+    @test size(mat_cut, 1) < size(mat_orig, 1)
+    @test all(<(30), diag(mat_cut))
+    @test count(≥(30), diag(Matrix(bsr))) == size(mat_orig, 1) - size(mat_cut, 1)
 end


### PR DESCRIPTION
* The new way of building matrices is slightly slower for small matrices, but uses much less memory for large ones. The `cutoff` argument can now be passed to `BasisSetRep`, `Matrix`, and `sparse` to skip constructing columns with high-energy diagonal elements. This should not have a noticeable effect on performance when not used.
* Increased the default size limits for building sparse matrices to `1e6` added a default estimates for the amount of storage needed when constructing the matrix. 