### PR TITLE
Fix #157, test on latest and nightly Julia

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -61,3 +61,4 @@ jobs:
         with:
           github-token: ${{ secrets.github_token }}
           path-to-lcov: ./lcov.info
+        if: ${{ matrix.julia-version == '1' }}

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -15,13 +15,13 @@ on:
       - feature/github-actions
 
 jobs:
-  testNewVersion:
+  test:
     runs-on: ${{ matrix.os }}
     # env:
     #   ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
     strategy:
       matrix:
-        julia-version: [1.7]
+        julia-version: ['1', 'nightly']
         # julia-arch: [x64, x86]
         julia-arch: [x64]
         # os: [ubuntu-latest, windows-latest, macOS-latest]

--- a/.github/workflows/allocations.yml
+++ b/.github/workflows/allocations.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        julia-version: [1.7, 'nightly']
+        julia-version: [1, 'nightly']
         julia-arch: [x64]
 
     steps:

--- a/.github/workflows/allocations.yml
+++ b/.github/workflows/allocations.yml
@@ -8,7 +8,7 @@ on:
       - 'bugfix/**'
 
 jobs:
-  Allocations:
+  allocations:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/src/DictVectors/dvec.jl
+++ b/src/DictVectors/dvec.jl
@@ -133,10 +133,10 @@ function Base.sum(f::F, dvec::DVec{<:Any,V,<:Any,<:Dict}) where {F,V}
         return f(zero(V))
     else
         vals = dvec.storage.vals
-        slots = dvec.storage.slots
-        result = f(vals[1] * (slots[1] == 0x1))
+        dict = dvec.storage
+        result = f(vals[1] * Base.isslotfilled(dict, 1))
         @inbounds @simd for i in 2:length(vals)
-            result += f(vals[i] * (slots[i] == 0x1))
+            result += f(vals[i] * Base.isslotfilled(dict, i))
         end
         return result
     end

--- a/test/DictVectors.jl
+++ b/test/DictVectors.jl
@@ -201,7 +201,7 @@ function test_dvec_interface(type, keys, vals, cap)
         end
         @testset "projection" begin
             dvec = type(Dict(pairs))
-            @test UniformProjector() ⋅ dvec == sum(dvec)
+            @test UniformProjector() ⋅ dvec == sum(dvec) == sum(vals)
             @test UniformProjector()[2] == 1
             if valtype(dvec) isa AbstractFloat
                 @test NormProjector() ⋅ dvec == norm(dvec, 1)


### PR DESCRIPTION
Fixes #157. Not sure what happened, but from 1.8 onwards, an empty chunk is saved into the Arrow file if `chunk_size` divides the number of steps when using `ReportToFile`. This PR also adds tests on `nightly` and ensures the latest stable Julia version is always used for testing.