### PR TITLE
`Stoquastic` wrapper for Hamiltonians

### DIFF
--- a/docs/src/hamiltonians.md
+++ b/docs/src/hamiltonians.md
@@ -18,9 +18,9 @@ for the model, instantiate the model like this in the input file:
 hubb = HubbardReal1D(BoseFS((1,2,0,3)); u=1.0, t=1.0)
 ```
 
-The Hamiltonian `hubb` is now ready to be used for FCIQMC in [`lomc!`](@ref) 
-and for exact diagonalisation with [`KrylovKit.jl`](https://github.com/Jutho/KrylovKit.jl) directly, or after 
-transforming into a sparse matrix first with 
+The Hamiltonian `hubb` is now ready to be used for FCIQMC in [`lomc!`](@ref)
+and for exact diagonalisation with [`KrylovKit.jl`](https://github.com/Jutho/KrylovKit.jl) directly, or after
+transforming into a sparse matrix first with
 ```julia-repl
 using SparseArrays
 sh = sparse(hubb)
@@ -30,7 +30,7 @@ or into a full matrix with
 using LinearAlgebra
 fh = Matrix(hubb)
 ```
-This functionality relies on 
+This functionality relies on
 ```@docs
 Hamiltonians.BasisSetRep
 sparse
@@ -39,7 +39,7 @@ Matrix
 
 ## Model Hamiltonians
 
-Here is a list of fully implemented model Hamiltonians. There are several variants 
+Here is a list of fully implemented model Hamiltonians. There are several variants
 of the Hubbard model in real and momentum space, as well as some other models.
 
 ### Real space Hubbard models
@@ -75,17 +75,18 @@ shift_lattice_inv
 ```
 
 ## Hamiltonian wrappers
-The following Hamiltonians are constructed from an existing 
+The following Hamiltonians are constructed from an existing
 Hamiltonian instance and change its behaviour:
 ```@docs
 GutzwillerSampling
 GuidingVectorSampling
 ParitySymmetry
 TimeReversalSymmetry
+Stoquastic
 ```
 
 ## Observables
-Observables are [`AbstractHamiltonian`](@ref)s that represent a physical 
+Observables are [`AbstractHamiltonian`](@ref)s that represent a physical
 observable. Their ground state expectation values can be sampled by passing
 them into [`AllOverlaps`](@ref).
 ```@docs

--- a/src/Hamiltonians/Hamiltonians.jl
+++ b/src/Hamiltonians/Hamiltonians.jl
@@ -27,6 +27,7 @@ Other
 - [`GuidingVectorSampling`](@ref)
 - [`ParitySymmetry`](@ref)
 - [`TimeReversalSymmetry`](@ref)
+- [`Stoquastic`](@ref)
 
 ## [Observables](#Observables)
 - [`G2MomCorrelator`](@ref)
@@ -65,6 +66,7 @@ export BoseHubbardMom1D2C, BoseHubbardReal1D2C
 export GutzwillerSampling, GuidingVectorSampling
 export ParitySymmetry
 export TimeReversalSymmetry
+export Stoquastic
 export Transcorrelated1D
 export hubbard_dispersion, continuum_dispersion
 
@@ -97,6 +99,7 @@ include("GutzwillerSampling.jl")
 include("GuidingVectorSampling.jl")
 include("ParitySymmetry.jl")
 include("TRSymmetry.jl")
+include("Stoquastic.jl")
 
 include("Transcorrelated1D.jl")
 

--- a/src/Hamiltonians/Stoquastic.jl
+++ b/src/Hamiltonians/Stoquastic.jl
@@ -1,5 +1,5 @@
 """
-    Stoquastic(ham :> AbstractHamiltonian) :> AbstractHamiltonian
+    Stoquastic(ham <: AbstractHamiltonian) <: AbstractHamiltonian
 A wrapper for an [`AbstractHamiltonian`](@ref) that replaces all off-diagonal matrix
 elements `v` by `-abs(v)`, thus making the new Hamiltonian *stoquastic*.
 

--- a/src/Hamiltonians/Stoquastic.jl
+++ b/src/Hamiltonians/Stoquastic.jl
@@ -14,7 +14,7 @@ Stoquastic(h) = Stoquastic{eltype(h),typeof(h)}(h)
 
 starting_address(h::Stoquastic) = starting_address(h.hamiltonian)
 
-LOStructure(::Type{<:Stoquastic{<:Ant,H}}) where {H} = LOStructure(H)
+LOStructure(::Type{<:Stoquastic{<:Any,H}}) where {H} = LOStructure(H)
 Base.adjoint(h::Stoquastic) = Stoquastic(h.hamiltonian')
 
 dimension(h::Stoquastic) = dimension(h.hamiltonian)

--- a/src/Hamiltonians/Stoquastic.jl
+++ b/src/Hamiltonians/Stoquastic.jl
@@ -1,0 +1,32 @@
+"""
+    Stoquastic(ham :> AbstractHamiltonian) :> AbstractHamiltonian
+A wrapper for an [`AbstractHamiltonian`](@ref) that replaces all off-diagonal matrix
+elements `v` by `-abs(v)`, thus making the new Hamiltonian *stoquastic*.
+
+A stoquastic Hamiltonian does not have a Monte Carlo sign problem. For a hermitian `ham`
+the smallest eigenvalue of `Stoquastic(ham)` is ≤ the smallest eigenvalue of `ham`.
+"""
+struct Stoquastic{T,H} <: AbstractHamiltonian{T}
+    hamiltonian::H
+end
+
+Stoquastic(h) = Stoquastic{eltype(h),typeof(h)}(h)
+
+starting_address(h::Stoquastic) = starting_address(h.hamiltonian)
+
+LOStructure(SH::Type{<:Stoquastic{<:Any,H}}) where {H} = _los_stoquastic(LOStructure(H), SH)
+
+_los_stoquastic(::IsHermitian, _) = IsHermitian()
+_los_stoquastic(::IsDiagonal, _) = IsDiagonal()
+_los_stoquastic(_, _) = AdjointUnknown()
+# Maybe implement AdjointKnown later?
+
+
+dimension(h::Stoquastic) = dimension(h.hamiltonian)
+num_offdiagonals(h::Stoquastic, add) = num_offdiagonals(h.hamiltonian, add)
+diagonal_element(h::Stoquastic, add) = diagonal_element(h.hamiltonian, add)
+
+function get_offdiagonal(h::Stoquastic, add1, chosen)
+    add2, matrix_element = get_offdiagonal(h.hamiltonian, add1, chosen)
+    return add2, -abs(matrix_element)
+end

--- a/src/Hamiltonians/Stoquastic.jl
+++ b/src/Hamiltonians/Stoquastic.jl
@@ -14,13 +14,8 @@ Stoquastic(h) = Stoquastic{eltype(h),typeof(h)}(h)
 
 starting_address(h::Stoquastic) = starting_address(h.hamiltonian)
 
-LOStructure(SH::Type{<:Stoquastic{<:Any,H}}) where {H} = _los_stoquastic(LOStructure(H), SH)
-
-_los_stoquastic(::IsHermitian, _) = IsHermitian()
-_los_stoquastic(::IsDiagonal, _) = IsDiagonal()
-_los_stoquastic(_, _) = AdjointUnknown()
-# Maybe implement AdjointKnown later?
-
+LOStructure(::Type{<:Stoquastic{<:Ant,H}}) where {H} = LOStructure(H)
+Base.adjoint(h::Stoquastic) = Stoquastic(h.hamiltonian')
 
 dimension(h::Stoquastic) = dimension(h.hamiltonian)
 num_offdiagonals(h::Stoquastic, add) = num_offdiagonals(h.hamiltonian, add)

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -1057,8 +1057,11 @@ end
 end
 
 @testset "Stoquastic" begin
-    ham = HubbardMom1D(BoseFS((0,5,0))) # a matrix that has a sign problem
+    ham = HubbardMom1D(BoseFS((0,5,0))) # a Hamiltonian that has a sign problem
     sham = Stoquastic(ham) # sign problem removed, but smaller ground state eigenvalue
     stoquastic_gap = eigvals(Matrix(ham))[1] - eigvals(Matrix(sham))[1]
     @test stoquastic_gap > 0
+    tc_ham = Transcorrelated1D(FermiFS2C((1,1,0),(1,0,1)))
+    @test LOStructure(Stoquastic(tc_ham)) == AdjointUnknown()
+    @test LOStructure(Stoquastic(G2RealCorrelator(2))) == IsDiagonal()
 end


### PR DESCRIPTION
Define a wrapper for an `AbstractHamiltonian`, that will replace it with the stoquasticised version.