### PR TITLE
Bugfix/momentum

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Rimu"
 uuid = "c53c40cc-bd84-11e9-2cf4-a9fde2b9386e"
 authors = ["Joachim Brand <j.brand@massey.ac.nz>"]
-version = "0.8.0"
+version = "0.8.1"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/src/Hamiltonians/HubbardMom1D.jl
+++ b/src/Hamiltonians/HubbardMom1D.jl
@@ -263,6 +263,8 @@ struct MomentumMom1D{T,H<:AbstractHamiltonian{T}} <: AbstractHamiltonian{T}
 end
 LOStructure(::Type{MomentumMom1D{H,T}}) where {H,T <: Real} = IsHermitian()
 num_offdiagonals(ham::MomentumMom1D, add) = 0
-diagonal_element(mom::MomentumMom1D, add) = mod1(onr(add)⋅ks(mom.ham) + π, 2π) - π # fold into (-π, π]
+diagonal_element(mom::MomentumMom1D, add) = mod1(onr(add)⋅ks(mom.ham) + π, 2π) - π
+# fold into (-π, π]
+starting_address(mom::MomentumMom1D) = starting_address(mom.ham)
 
 momentum(ham::HubbardMom1D) = MomentumMom1D(ham)

--- a/src/Hamiltonians/HubbardMom1D.jl
+++ b/src/Hamiltonians/HubbardMom1D.jl
@@ -261,7 +261,7 @@ end
 struct MomentumMom1D{T,H<:AbstractHamiltonian{T}} <: AbstractHamiltonian{T}
     ham::H
 end
-LOStructure(::Type{MomentumMom1D{H,T}}) where {H,T <: Real} = IsHermitian()
+LOStructure(::Type{MomentumMom1D{H,T}}) where {H,T <: Real} = IsDiagonal()
 num_offdiagonals(ham::MomentumMom1D, add) = 0
 diagonal_element(mom::MomentumMom1D, add) = mod1(onr(add)⋅ks(mom.ham) + π, 2π) - π
 # fold into (-π, π]

--- a/src/Hamiltonians/abstract.jl
+++ b/src/Hamiltonians/abstract.jl
@@ -19,11 +19,11 @@ Approximate formula for log of binomial coefficient. [Source](https://en.wikiped
 logbinomialapprox(n,k) = (n+0.5)*log((n+0.5)/(n-k+0.5))+k*log((n-k+0.5)/k) - 0.5*log(2π*k)
 
 """
-    dimension(::Type{T}, h)
+    dimension([::Type{T}], h)
 
-Return the dimension of Hilbert space as `T`. If the result does not fit into `T`, return
-`nothing`. If `T<:AbstractFloat`, an approximate value computed with the improved
-Stirling formula may be returned instead.
+Return the estimated dimension of Hilbert space as `T` (defaults to `Int`). If the result
+does not fit into `T`, return `nothing`. If `T<:AbstractFloat`, an approximate value
+computed with the improved Stirling formula may be returned instead.
 
 # Examples
 

--- a/src/strategies_and_params/shiftstrategy.jl
+++ b/src/strategies_and_params/shiftstrategy.jl
@@ -217,27 +217,27 @@ end
 end
 
 """
-    DoubleLogProjected(; targetwalkers, projector, ζ = 0.08, ξ = ζ^2/4) <: ShiftStrategy
+    DoubleLogProjected(; target, projector, ζ = 0.08, ξ = ζ^2/4) <: ShiftStrategy
 Strategy for updating the shift according to the log formula with damping
 parameter `ζ` and `ξ` after projecting onto `projector`.
 
 ```math
-S^{n+1} = S^n -\\frac{ζ}{dτ}\\ln\\left(\\frac{P⋅Ψ^{(n+1)}}{P⋅Ψ^{(n)}}\\right)-\\frac{ξ}{dτ}\\ln\\left(\\frac{P⋅Ψ^{(n+1)}}{\\text{targetwalkers}}\\right)
+S^{n+1} = S^n -\\frac{ζ}{dτ}\\ln\\left(\\frac{P⋅Ψ^{(n+1)}}{P⋅Ψ^{(n)}}\\right)-\\frac{ξ}{dτ}\\ln\\left(\\frac{P⋅Ψ^{(n+1)}}{\\text{target}}\\right)
 ```
 
 Note that adjusting the keyword `maxlength` in [`lomc!`](@ref) is advised as the
-default based on `targetwalkers` may not be appropriate.
+default may not be appropriate.
 
 See [`ShiftStrategy`](@ref), [`lomc!`](@ref).
 """
 struct DoubleLogProjected{T,P} <: ShiftStrategy
-    targetwalkers::T
+    target::T
     projector::P
     ζ::Float64 # damping parameter, best left at value of 0.08
     ξ::Float64 # restoring force to bring walker number to the target
 end
-function DoubleLogProjected(; targetwalkers, projector, ζ = 0.08, ξ = ζ^2/4)
-    return DoubleLogProjected(targetwalkers, freeze(projector), ζ, ξ)
+function DoubleLogProjected(; target, projector, ζ = 0.08, ξ = ζ^2/4)
+    return DoubleLogProjected(target, freeze(projector), ζ, ξ)
 end
 
 @inline function update_shift(s::DoubleLogProjected,
@@ -246,6 +246,6 @@ end
     # return new shift and new shiftMode
     tp = s.projector⋅v_new
     pp = s.projector⋅v_old
-    new_shift = shift - s.ζ/dτ * log(tp/pp) - s.ξ/dτ * log(tp/s.targetwalkers)
+    new_shift = shift - s.ζ/dτ * log(tp/pp) - s.ξ/dτ * log(tp/s.target)
     return new_shift, true, tnorm, true
 end

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -97,6 +97,7 @@ end
         TimeReversalSymmetry(HubbardMom1D(FermiFS2C((1,0,1),(0,1,1)))),
         TimeReversalSymmetry(BoseHubbardMom1D2C(BoseFS2C((0,1,1),(1,0,1)))),
         Stoquastic(HubbardMom1D(BoseFS((0,5,0)))),
+        momentum(HubbardMom1D(BoseFS((0,5,0)))),
     )
         test_hamiltonian_interface(H)
     end


### PR DESCRIPTION
This PR completes (and tests) the `AbstractHamiltonian` interface for `MomentumMom1D`.

It also includes fixes to the `ShiftStrategy` `DoubleLogProjected`.

The version string is bumped to `v0.8.1`.