### PR TITLE
Bugfix/working memory

### DIFF
--- a/src/DictVectors/dvec.jl
+++ b/src/DictVectors/dvec.jl
@@ -73,7 +73,7 @@ function DVec{K,V}(; style::StochasticStyle=default_style(V), capacity=0) where 
     return DVec(Dict{K,V}(); style, capacity)
 end
 # From another DVec
-function DVec(dv::AbstractDVec{K,V}, style=StochasticStyle(dv), capacity=0) where {K,V}
+function DVec(dv::AbstractDVec{K,V}; style=StochasticStyle(dv), capacity=0) where {K,V}
     dvec = DVec{K,V}(; style, capacity=max(capacity, length(dv)))
     return copyto!(dvec, dv)
 end

--- a/src/lomc.jl
+++ b/src/lomc.jl
@@ -118,7 +118,7 @@ function QMCState(
 
     # Set up threading
     threading = select_threading_strategy(threading, _n_walkers(v, s_strat))
-    wm = working_memory(threading, v)
+    wm = isnothing(wm) ? working_memory(threading, v) : wm
 
     # Set up post_step
     if !(post_step isa Tuple)
@@ -286,7 +286,7 @@ function lomc!(state::QMCState, df=DataFrame(); laststep=0, name="lomc!")
         @assert replica.params.laststep == laststep
     end
     check_transform(state.replica, state.hamiltonian)
-            
+
     # main loop
     initial_step = step
     update_steps = max((laststep - initial_step) ÷ 200, 100) # log often but not too often

--- a/test/DictVectors.jl
+++ b/test/DictVectors.jl
@@ -30,7 +30,7 @@ function test_dvec_interface(type, keys, vals, cap)
                 @test dvec3[k] == dvec4[k] == zero(V)
             end
 
-            dvec5 = type(dvec2)
+            dvec5 = type(dvec2; capacity=2cap)
             @test dvec5 == dvec2
 
             dvec6 = type(IdDict(pairs))

--- a/test/lomc.jl
+++ b/test/lomc.jl
@@ -37,6 +37,13 @@ using Logging
         df = lomc!(state, df).df
         @test size(df, 1) == 200
         @test df.steps == [1:100; 1:100]
+
+        # test passing working memory
+        v = copy(dv)
+        wm = copy(dv)
+        df, state = lomc!(H, v; wm, laststep=10, threading=false)
+        @test state.replicas[1].w === wm # after even number of steps
+        @test state.replicas[1].v === v
     end
 
     @testset "Setting walkernumber" begin
@@ -64,7 +71,7 @@ using Logging
     @testset "Replicas" begin
         add = near_uniform(BoseFS{5,15})
         H = HubbardReal1D(add)
-        G = GutzwillerSampling(H, g=1)   
+        G = GutzwillerSampling(H, g=1)
         dv = DVec(add => 1, style=IsDynamicSemistochastic())
 
         @testset "NoStats" begin
@@ -331,7 +338,7 @@ using Logging
             @test df2.norm ≈ df3.norm
             @test df3 == df4
 
-            # ReportToFile with skipping interval  
+            # ReportToFile with skipping interval
             df5 = df1[10:10:100,:]
             r_strat = ReportToFile(filename="test-report.arrow", reporting_interval=10, io=devnull, chunk_size=10)
             df = lomc!(H, copy(dv); r_strat, laststep=100).df


### PR DESCRIPTION
Fixes two minor bugs:
- passing working memory to `lomc!` was broken - now works
- constructing a `DVec` from another `DVec` did not accept keyword arguments - now it does 