### PR TITLE
Bugfix/g2example tests

### DIFF
--- a/scripts/G2-example.jl
+++ b/scripts/G2-example.jl
@@ -116,3 +116,4 @@ end
 using Test                                  #hide
 r = rayleigh_replica_estimator(df; op_name = "Op1", skip=steps_equilibrate) #hide
 @test r.f ≈ 0.23371704332410984 rtol=0.01   #hide
+nothing                                     #hide

--- a/src/lomc.jl
+++ b/src/lomc.jl
@@ -207,7 +207,7 @@ and triggers the integer walker FCIQMC algorithm. See [`DVec`](@ref) and
   diagonal_element(ham, starting_address(ham)))` -
   basic parameters of simulation state, see [`FciqmcRunStrategy`](@ref); is mutated
 * `laststep` - can be used to override information otherwise contained in `params`
-* `s_strat::ShiftStrategy = DoubleLogUpdate(targetwalkers = 100, ζ = 0.08, ξ = ζ^2/4)` -
+* `s_strat::ShiftStrategy = DoubleLogUpdate(targetwalkers = 1000, ζ = 0.08, ξ = ζ^2/4)` -
   how to update the `shift`, see [`ShiftStrategy`](@ref)
 * `maxlength = 2 * s_strat.targetwalkers + 100` - upper limit on the length of `v`; when
   reached, `lomc!` will abort


### PR DESCRIPTION
- hide test output in `G2-example.jl`
- correct `lomc!` docstring, fixes #172 