### PR TITLE
Threading with reproducible random numbers

### DIFF
--- a/src/DictVectors/DictVectors.jl
+++ b/src/DictVectors/DictVectors.jl
@@ -49,5 +49,6 @@ include("delegate.jl")
 include("abstractdvec.jl")
 include("dvec.jl")
 include("initiators.jl")
+include("skinnydvec.jl") # does not support the full interface
 
 end # module

--- a/src/DictVectors/skinnydvec.jl
+++ b/src/DictVectors/skinnydvec.jl
@@ -1,0 +1,34 @@
+"""
+    SkinnyDVec(keys, vals; style) <: AbstractDVec
+Implementation of an [`AbstractDVec`](@ref) using lists implemented as `Vector`s for
+internal storage. Doesn't comply with the full [`AbstractDVec`](@ref) interface.
+
+Supports fast iteration. Adding elements with `setindex!` just appends them to the list.
+"""
+struct SkinnyDVec{K,V,S<:StochasticStyle{V}} <: AbstractDVec{K,V}
+    keys::Vector{K}
+    vals::Vector{V}
+    style::S
+end
+function SkinnyDVec(keys, vals; style=default_style(eltype(vals)))
+    length(keys)==length(vals) || throw(ArgumentError("keys and vals must have the same length"))
+    return SkinnyDVec(collect(keys), collect(vals), style)
+end
+StochasticStyle(w::SkinnyDVec) = w.style
+
+Base.length(w::SkinnyDVec) = length(w.keys)
+Base.values(w::SkinnyDVec) = w.vals
+Base.keys(w::SkinnyDVec) = w.keys
+function Base.setindex!(w::SkinnyDVec, val, add) # always append to list
+    push!(w.keys, add)
+    push!(w.vals, val)
+    return w
+end
+Base.getindex(w::SkinnyDVec, key) = zero(valtype(w)) # always return zero
+
+@inline function add!(w::SkinnyDVec, v::AbstractDVec)
+    for (add, val) in pairs(v)
+        w[add] = val
+    end
+    return w
+end

--- a/src/lomc.jl
+++ b/src/lomc.jl
@@ -226,6 +226,7 @@ and triggers the integer walker FCIQMC algorithm. See [`DVec`](@ref) and
 * `threading = :auto` - can be used to control the use of multithreading (overridden by
   `wm`)
   * `:auto` - use multithreading if `s_strat.targetwalkers ≥ 500`
+  * `:reproducible` -  use multithreading with reproducible random numbers
   * `true` - use multithreading if available (set shell variable `JULIA_NUM_THREADS`!)
   * `false` - run on single thread
 * `wm` - working memory; if set, it controls the use of multithreading and overrides

--- a/src/strategies_and_params/threadingstrategy.jl
+++ b/src/strategies_and_params/threadingstrategy.jl
@@ -263,7 +263,7 @@ struct ReproducibleThreading{N} <: ThreadingStrategy
 end
 ReproducibleThreading(; batch_base=Threads.nthreads()) = ReproducibleThreading(batch_base)
 
-working_memory(::ReproducibleThreading, dv) = empty(localpart(dv))
+working_memory(::ReproducibleThreading, dv) = zero(localpart(dv))
 
 @inline function _rt_loop_configs!(w, ham, pairs, shift, dτ, batchsize)
     if amount(pairs) > batchsize # recursively halve `pairs` iterator
@@ -296,7 +296,7 @@ working_memory(::ReproducibleThreading, dv) = empty(localpart(dv))
     return w # results are returned in the passed-in working memory `w`
 end
 
-function fciqmc_step!(t::ReproducibleThreading, wm::AbstractDVec, ham, dv, shift, dτ)
+function fciqmc_step!(t::ReproducibleThreading, wm, ham, dv, shift, dτ)
     v = localpart(dv)
     stat_names, stats_def = step_stats(StochasticStyle(v))
     batchsize = max(100.0, min(amount(pairs(v))/t.n, sqrt(amount(pairs(v))) * 10))

--- a/test/DictVectors.jl
+++ b/test/DictVectors.jl
@@ -279,3 +279,14 @@ end
         @test !isreal(dvec4)
     end
 end
+
+@testset "SkinnyDVec" begin
+    @test_throws ArgumentError DictVectors.SkinnyDVec([:a,:b,:c], [1,2,3,4])
+    sdv = DictVectors.SkinnyDVec([:a,:b,:c], [1,2,3])
+    @test StochasticStyle(sdv) == default_style(Int)
+    @test length(sdv) == 3
+    @test sdv[:a] == 0 == sdv[:d] # getindex always returns zero
+    sdv[:d] = 4 # setindex appends to the list
+    sdv[:a] = 5
+    @test length(sdv) == 5
+end

--- a/test/lomc.jl
+++ b/test/lomc.jl
@@ -466,10 +466,19 @@ using Logging
             df8, s8 = lomc!(
                 H, deepcopy(dv); threading=Rimu.ThreadsXForeachThreading(), laststep, s_strat
             )
+            Random.seed!(17)
+            df9, s9 = lomc!(
+                H, deepcopy(dv); threading=:reproducible, laststep, s_strat
+            )
+            Random.seed!(17)
+            df10, s10 = lomc!(
+                H, deepcopy(dv); threading=Rimu.ReproducibleThreading(), laststep, s_strat
+            )
 
             @test s1.threading == Rimu.SplittablesThreading()
             @test s2.threading == Rimu.SplittablesThreading()
             @test s3.threading == Rimu.NoThreading()
+            @test s9.threading == Rimu.ReproducibleThreading()
 
             # Check that working memory was selected correctly.
             N = Threads.nthreads()
@@ -482,6 +491,8 @@ using Logging
             @test s6.replicas[1].w isa NTuple{N,D}
             @test s7.replicas[1].w isa NTuple{N,D}
             @test s8.replicas[1].w isa NTuple{N,D}
+            @test s9.replicas[1].w isa D
+            @test s10.replicas[1].w isa D
 
             # Check energies.
             E1, _ = mean_and_se(df1.shift[900:end])
@@ -492,6 +503,7 @@ using Logging
             E6, _ = mean_and_se(df6.shift[900:end])
             E7, _ = mean_and_se(df7.shift[900:end])
             E8, _ = mean_and_se(df8.shift[900:end])
+            E9, _ = mean_and_se(df9.shift[900:end])
 
             @test E1 ≈ E2 rtol=0.1
             @test E2 ≈ E3 rtol=0.1
@@ -500,6 +512,10 @@ using Logging
             @test E5 ≈ E6 rtol=0.1
             @test E6 ≈ E7 rtol=0.1
             @test E7 ≈ E8 rtol=0.1
+            @test E8 ≈ E9 rtol=0.1
+
+            # ReproducibleThreading has reproducible random numbers:
+            @test df10.len == df9.len
         end
     end
 end


### PR DESCRIPTION
Introduce a new threading strategy (accessed by setting `threading=:reproducible` in `lomc!`) that allows for reproducible threaded Monte Carlo if the random number generator has been seeded. 

The new `ThreadingStrategy` `ReproducibleThreading` does not use thread-local working memory and instead allocates temporary working memory local to the threaded tasks. This has some allocation overhead and should typically be a bit slower than the default  `ThreadingStrategy`.