### PR TITLE
Clean up MPI testing

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -271,28 +271,4 @@ end
     include("doctests.jl")
 end
 
-using MPI
-# Note: This test is only for local testing, as MPI is tested separately on CI
-@testset "MPI" begin
-    if !haskey(ENV, "CI") # skip test if running on CI
-        if VERSION ≥ v"1.9" && pkgversion(MPI) ≥ v"0.20"
-            mpiexec_cmd = mpiexec()
-        else
-            # read name of mpi executable from environment variable if defined
-            mpiexec_cmd = haskey(ENV, "JULIA_MPIEXEC") ? ENV["JULIA_MPIEXEC"] : "mpirun"
-        end
-        is_local = !haskey(ENV, "CI")
-
-        juliaexec = Base.julia_cmd()
-
-        mpi_test_filename = isfile("mpi_runtests.jl") ?  "mpi_runtests.jl" : "test/mpi_runtests.jl"
-        if isfile(mpi_test_filename)
-            rr = run(`$mpiexec_cmd -np 2 $juliaexec -t 1 --project $mpi_test_filename`)
-            @test rr.exitcode == 0
-        else
-            @warn "Could not find mpi_runtests.jl. Not testing MPI."
-        end
-    else
-        @info "Skip testing MPI from `runtests.jl` on CI"
-    end
-end
+# Note: Running Rimu with several MPI ranks is tested seperately on GitHub CI and not here.


### PR DESCRIPTION
Removes code for testing Rimu with MPI outside of CI.

Due to its nature this code was not tested during CI and thus has become difficult to maintain, and was broken in practice. 
As a consequence, running
```julia-repl
> ]test Rimu
```
would error unless MPI has been set up carefully beforehand. This error has now been fixed. 

Rimu's ability to run in parallel under MPI is still currently tested on GitHub CI.
