### PR TITLE
Disable fail-fast in GH actions

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -30,6 +30,7 @@ jobs:
         # exclude:
         #   - os: macOS-latest
         #     julia-arch: x86
+      fail-fast: false
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/allocations.yml
+++ b/.github/workflows/allocations.yml
@@ -14,6 +14,7 @@ jobs:
       matrix:
         julia-version: [1, 'nightly']
         julia-arch: [x64]
+      fail-fast: false
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This will allow actions on Julia v1 to finish even if they fail on nightly.