### PR TITLE
get basis w/o sparse matrix

### DIFF
--- a/docs/src/hamiltonians.md
+++ b/docs/src/hamiltonians.md
@@ -36,6 +36,10 @@ Hamiltonians.BasisSetRep
 sparse
 Matrix
 ```
+If only the basis is required and not the matrix representation it is more efficient to use
+```@docs
+Hamiltonians.build_basis
+```
 
 ## Model Hamiltonians
 

--- a/src/Hamiltonians/Hamiltonians.jl
+++ b/src/Hamiltonians/Hamiltonians.jl
@@ -55,7 +55,7 @@ import ..Interfaces: diagonal_element, num_offdiagonals, get_offdiagonal, starti
 export AbstractHamiltonian
 # export TwoComponentHamiltonian
 export dimension, rayleigh_quotient, momentum
-export BasisSetRep, build_basis_only_from_LO
+export BasisSetRep, build_basis
 
 export MatrixHamiltonian
 export HubbardReal1D, HubbardMom1D, ExtendedHubbardReal1D, HubbardRealSpace

--- a/src/Hamiltonians/Hamiltonians.jl
+++ b/src/Hamiltonians/Hamiltonians.jl
@@ -55,7 +55,7 @@ import ..Interfaces: diagonal_element, num_offdiagonals, get_offdiagonal, starti
 export AbstractHamiltonian
 # export TwoComponentHamiltonian
 export dimension, rayleigh_quotient, momentum
-export BasisSetRep
+export BasisSetRep, build_basis_only_from_LO
 
 export MatrixHamiltonian
 export HubbardReal1D, HubbardMom1D, ExtendedHubbardReal1D, HubbardRealSpace

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -1151,23 +1151,6 @@ end
         @test starting_address(BasisSetRep(ham, addr2)) ==  addr2
     end
 
-    @testset "basis-only" begin
-        m = 5
-        n = 5
-        add = BoseFS(m, 1 => n)
-        ham = HubbardReal1D(add)
-        @test_throws ArgumentError build_basis_only_from_LO(ham, BoseFS((1,2,3))) # wrong address type
-        # starting address
-        bsr = BasisSetRep(ham)
-        basis = build_basis_only_from_LO(ham)
-        @test basis == bsr.basis
-        # other address
-        add = BoseFS(m, m => n)
-        bsr = BasisSetRep(ham, add)
-        basis = build_basis_only_from_LO(ham, add)
-        @test basis == bsr.basis
-    end
-
     @testset "filtering" begin
         ham = HubbardReal1D(near_uniform(BoseFS{10,2}))
         @test_throws ArgumentError BasisSetRep(ham; cutoff=19) # starting address cut off
@@ -1229,6 +1212,28 @@ end
         @test !issymmetric(even_sm) # not symmetric due to floating point errors
         @test issymmetric(even_m) # because it was passed through `fix_approx_hermitian!`
         @test even_sm ≈ even_m # still approximately the same!
+    end
+
+    @testset "basis-only" begin
+        m = 5
+        n = 5
+        add = near_uniform(BoseFS{n,m})
+        ham = HubbardReal1D(add)
+        @test_throws ArgumentError build_basis_only_from_LO(ham, BoseFS((1,2,3))) # wrong address type
+        # same basis as BSR
+        bsr = BasisSetRep(ham)
+        basis = build_basis_only_from_LO(ham)
+        @test basis == bsr.basis
+        # sorting
+        bsr = BasisSetRep(ham, add; sort = true)
+        basis = build_basis_only_from_LO(ham, add; sort = true)
+        @test basis == bsr.basis
+        # filtering
+        @test_throws ArgumentError build_basis_only_from_LO(ham, add; cutoff = -1)
+        cutoff = n * (n-1) / 4  # half maximum energy
+        bsr = BasisSetRep(ham, add; cutoff)
+        basis = build_basis_only_from_LO(ham, add; cutoff)
+        @test basis == bsr.basis
     end
 end
 

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -1219,20 +1219,19 @@ end
         n = 5
         add = near_uniform(BoseFS{n,m})
         ham = HubbardReal1D(add)
-        @test_throws ArgumentError build_basis_only_from_LO(ham, BoseFS((1,2,3))) # wrong address type
+        @test_throws ArgumentError build_basis(ham, BoseFS((1,2,3))) # wrong address type
         # same basis as BSR
         bsr = BasisSetRep(ham)
-        basis = build_basis_only_from_LO(ham)
+        basis = build_basis(ham)
         @test basis == bsr.basis
         # sorting
-        bsr = BasisSetRep(ham, add; sort = true)
-        basis = build_basis_only_from_LO(ham, add; sort = true)
-        @test basis == bsr.basis
+        basis = build_basis(ham, add; sort = true)
+        @test basis == sort!(bsr.basis)
         # filtering
-        @test_throws ArgumentError build_basis_only_from_LO(ham, add; cutoff = -1)
+        @test_throws ArgumentError build_basis(ham, add; cutoff = -1)
         cutoff = n * (n-1) / 4  # half maximum energy
         bsr = BasisSetRep(ham, add; cutoff)
-        basis = build_basis_only_from_LO(ham, add; cutoff)
+        basis = build_basis(ham, add; cutoff)
         @test basis == bsr.basis
     end
 end

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -1228,6 +1228,7 @@ end
         basis = build_basis(ham, add; sort = true)
         @test basis == sort!(bsr.basis)
         # filtering
+        @test_throws ArgumentError build_basis(ham, add; max_size = 100)
         @test_throws ArgumentError build_basis(ham, add; cutoff = -1)
         cutoff = n * (n-1) / 4  # half maximum energy
         bsr = BasisSetRep(ham, add; cutoff)

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -1151,6 +1151,23 @@ end
         @test starting_address(BasisSetRep(ham, addr2)) ==  addr2
     end
 
+    @testset "basis-only" begin
+        m = 5
+        n = 5
+        add = BoseFS(m, 1 => n)
+        ham = HubbardReal1D(add)
+        @test_throws ArgumentError build_basis_only_from_LO(ham, BoseFS((1,2,3))) # wrong address type
+        # starting address
+        bsr = BasisSetRep(ham)
+        basis = build_basis_only_from_LO(ham)
+        @test basis == bsr.basis
+        # other address
+        add = BoseFS(m, m => n)
+        bsr = BasisSetRep(ham, add)
+        basis = build_basis_only_from_LO(ham, add)
+        @test basis == bsr.basis
+    end
+
     @testset "filtering" begin
         ham = HubbardReal1D(near_uniform(BoseFS{10,2}))
         @test_throws ArgumentError BasisSetRep(ham; cutoff=19) # starting address cut off


### PR DESCRIPTION
New function `build_basis` that works similarly to internal function `build_sparse_matrix_from_LO`, but does not compute or return the sparse matrix.