### PR TITLE
Fix long compilation times when creating Fock addresses

### DIFF
--- a/src/BitStringAddresses/BitStringAddresses.jl
+++ b/src/BitStringAddresses/BitStringAddresses.jl
@@ -6,6 +6,7 @@ module BitStringAddresses
 
 using LinearAlgebra
 using StaticArrays
+using SparseArrays
 using Setfield
 using Parameters
 

--- a/src/BitStringAddresses/bosefs.jl
+++ b/src/BitStringAddresses/bosefs.jl
@@ -87,7 +87,7 @@ function BoseFS{N,M}(onr::Union{AbstractArray{<:Integer},NTuple{M,<:Integer}}) w
     else
         S = S_sparse
     end
-    return BoseFS{N,M,S}(from_bose_onr(S, SVector{M,Int}(onr)))
+    return BoseFS{N,M,S}(from_bose_onr(S, onr))
 end
 function BoseFS(onr::Union{AbstractArray,Tuple})
     M = length(onr)

--- a/src/BitStringAddresses/bosefs.jl
+++ b/src/BitStringAddresses/bosefs.jl
@@ -76,16 +76,17 @@ function BoseFS{N,M}(onr::Union{AbstractArray{<:Integer},NTuple{M,<:Integer}}) w
         ))
     end
     spl_type = select_int_type(M)
-    S_sparse = SortedParticleList{N,M,spl_type}
-    S_dense = typeof(BitString{M + N - 1}(0))
+
     # Pick smaller address type, but prefer sparse.
     # Alway pick dense if it fits into one chunk.
-    sparse_size_64 = ceil(Int, sizeof(S_sparse) / 8)
-    dense_size_64 = ceil(Int, sizeof(S_dense) / 8)
-    if num_chunks(S_dense) == 1 || dense_size_64 < sparse_size_64
-        S = S_dense
+
+    # Compute the size of container in words
+    sparse_sizeof = ceil(Int, N * sizeof(spl_type) / 8)
+    dense_sizeof = ceil(Int, (N + M - 1) / 64)
+    if dense_sizeof == 1 || dense_sizeof < sparse_sizeof
+        S = typeof(BitString{M + N - 1}(0))
     else
-        S = S_sparse
+        S = SortedParticleList{N,M,spl_type}
     end
     return BoseFS{N,M,S}(from_bose_onr(S, onr))
 end

--- a/src/BitStringAddresses/bosefs.jl
+++ b/src/BitStringAddresses/bosefs.jl
@@ -74,6 +74,9 @@ function BoseFS{N,M}(onr::Union{AbstractArray{<:Integer},NTuple{M,<:Integer}}) w
         sum(onr) == N || throw(ArgumentError(
             "invalid ONR: $N particles expected, $(sum(onr)) given"
         ))
+        length(onr) == M || throw(ArgumentError(
+            "invalid ONR: $M modes expected, $(length(onr)) given"
+        ))
     end
     spl_type = select_int_type(M)
 

--- a/src/BitStringAddresses/fermifs.jl
+++ b/src/BitStringAddresses/fermifs.jl
@@ -78,16 +78,16 @@ end
 function FermiFS{N,M}(onr::Union{AbstractArray{<:Integer},NTuple{M,<:Integer}}) where {N,M}
     @boundscheck check_fermi_onr(onr, N)
     spl_type = select_int_type(M)
-    S_sparse = SortedParticleList{N,M,spl_type}
-    S_dense = typeof(BitString{M}(0))
     # Pick smaller address type, but prefer dense.
     # Alway pick dense if it fits into one chunk.
-    sparse_size_64 = ceil(Int, sizeof(S_sparse) / 8)
-    dense_size_64 = ceil(Int, sizeof(S_dense) / 8)
-    if num_chunks(S_dense) == 1 || dense_size_64 ≤ sparse_size_64
-        S = S_dense
+
+    # Compute the size of container in words
+    sparse_sizeof = ceil(Int, N * sizeof(spl_type) / 8)
+    dense_sizeof = ceil(Int, M / 64)
+    if dense_sizeof == 1 || dense_sizeof ≤ sparse_sizeof
+        S = typeof(BitString{M}(0))
     else
-        S = S_sparse
+        S = SortedParticleList{N,M,spl_type}
     end
     return FermiFS{N,M,S}(from_fermi_onr(S, onr))
 end

--- a/src/BitStringAddresses/fermifs.jl
+++ b/src/BitStringAddresses/fermifs.jl
@@ -53,7 +53,7 @@ struct FermiFS{N,M,S} <: SingleComponentFockAddress{N,M}
     bs::S
 end
 
-function check_fermi_onr(onr, N)
+function check_fermi_onr(onr, N, M)
     sum(onr) == N ||
         throw(ArgumentError("Invalid ONR: $N particles expected, $(sum(onr)) given."))
     length(onr) == M ||

--- a/src/BitStringAddresses/fermifs.jl
+++ b/src/BitStringAddresses/fermifs.jl
@@ -89,7 +89,7 @@ function FermiFS{N,M}(onr::Union{AbstractArray{<:Integer},NTuple{M,<:Integer}}) 
     else
         S = S_sparse
     end
-    return FermiFS{N,M,S}(from_fermi_onr(S, SVector{M,Int}(onr)))
+    return FermiFS{N,M,S}(from_fermi_onr(S, onr))
 end
 function FermiFS(onr::Union{AbstractArray,Tuple})
     M = length(onr)

--- a/src/BitStringAddresses/fermifs.jl
+++ b/src/BitStringAddresses/fermifs.jl
@@ -56,13 +56,15 @@ end
 function check_fermi_onr(onr, N)
     sum(onr) == N ||
         throw(ArgumentError("Invalid ONR: $N particles expected, $(sum(onr)) given."))
+    length(onr) == M ||
+        throw(ArgumentError("Invalid ONR: $M modes expected, $(length(onr)) given."))
     all(in((0, 1)), onr) ||
         throw(ArgumentError("Invalid ONR: may only contain 0s and 1s."))
 end
 
 function FermiFS{N,M,S}(onr::Union{SVector{M},MVector{M},NTuple{M}}) where {N,M,S}
     @boundscheck begin
-        check_fermi_onr(onr, N)
+        check_fermi_onr(onr, N, M)
         if S <: BitString
             M == num_bits(S) || throw(ArgumentError(
                 "invalid ONR: $B-bit BitString does not fit $M modes"
@@ -76,7 +78,7 @@ function FermiFS{N,M,S}(onr::Union{SVector{M},MVector{M},NTuple{M}}) where {N,M,
     return FermiFS{N,M,S}(from_fermi_onr(S, onr))
 end
 function FermiFS{N,M}(onr::Union{AbstractArray{<:Integer},NTuple{M,<:Integer}}) where {N,M}
-    @boundscheck check_fermi_onr(onr, N)
+    @boundscheck check_fermi_onr(onr, N, M)
     spl_type = select_int_type(M)
     # Pick smaller address type, but prefer dense.
     # Alway pick dense if it fits into one chunk.

--- a/src/BitStringAddresses/fockaddress.jl
+++ b/src/BitStringAddresses/fockaddress.jl
@@ -646,7 +646,7 @@ function LinearAlgebra.dot(occ_a::OccupiedModeIterator, occ_b::OccupiedModeItera
 end
 
 function sparse_to_onr(M, pairs)
-    onr = zeros(Int, M)
+    onr = spzeros(Int, M)
     for (k, v) in pairs
         v ≥ 0 || throw(ArgumentError("Invalid pair `$k=>$v`: particle number negative"))
         0 < k ≤ M || throw(ArgumentError("Invalid pair `$k => $v`: key of of range `1:$M`"))

--- a/src/BitStringAddresses/sortedparticlelist.jl
+++ b/src/BitStringAddresses/sortedparticlelist.jl
@@ -55,6 +55,17 @@ function from_onr(::Type{S}, onr) where {N,M,T,S<:SortedParticleList{N,M,T}}
     end
     return SortedParticleList{N,M,T}(SVector(spl))
 end
+function from_onr(::Type{S}, onr::SparseVector) where {N,M,T,S<:SortedParticleList{N,M,T}}
+    spl = zeros(MVector{N,T})
+    curr = 1
+    for (n, v) in zip(rowvals(onr), nonzeros(onr))
+        for _ in 1:v
+            spl[curr] = n
+            curr += 1
+        end
+    end
+    return SortedParticleList{N,M,T}(SVector(spl))
+end
 
 function Base.isless(ss1::SortedParticleList, ss2::SortedParticleList)
     return isless(ss1.storage, ss2.storage)

--- a/test/BitStringAddresses.jl
+++ b/test/BitStringAddresses.jl
@@ -162,7 +162,7 @@ end
     two_full = BoseFS{136,136,typeof(bs)}(bs)
 
     @test_throws ArgumentError BoseFS{2,3}((1, 2, 3))
-    @test_throws DimensionMismatch BoseFS{6,2}([1, 2, 3])
+    @test_throws ArgumentError BoseFS{6,2}([1, 2, 3])
 
     @testset "constructors" begin
         small_dense = BoseFS(ones(Int, 32))


### PR DESCRIPTION
Before:
```
julia> @time BoseFS(5000, 1 => 1)
  3.939499 seconds (6.41 M allocations: 314.837 MiB, 1.80% gc time, 99.99% compilation time)
BoseFS{1,5000}(1 => 1)
```
After:
```
julia> @time BoseFS(5000, 1 => 1)
  0.039385 seconds (48.01 k allocations: 3.274 MiB)
BoseFS{1,5000}(1 => 1)
```

The main issue was that all constructors went through a `SVector` ONR. There are two other small improvements in this PR: 
* supplying sorted particle list style arguments stores the intermediate ONR in a sparse vector.
* comparing which type packs the values better is done without initializing said types.