### PR TITLE
Apple silicon workaround

### DIFF
--- a/src/RMPI/RMPI.jl
+++ b/src/RMPI/RMPI.jl
@@ -31,7 +31,6 @@ const mpi_registry = Dict{Int,Any}()
 abstract type DistributeStrategy end
 
 include("mpidata.jl")
-include("multiscalar.jl")
 include("helpers.jl")
 include("noexchange.jl")
 include("pointtopoint.jl")

--- a/src/RMPI/RMPI.jl
+++ b/src/RMPI/RMPI.jl
@@ -31,6 +31,7 @@ const mpi_registry = Dict{Int,Any}()
 abstract type DistributeStrategy end
 
 include("mpidata.jl")
+include("multiscalar.jl")
 include("helpers.jl")
 include("noexchange.jl")
 include("pointtopoint.jl")

--- a/src/RMPI/helpers.jl
+++ b/src/RMPI/helpers.jl
@@ -91,7 +91,7 @@ function sort_into_targets!(dtarget::MPIData, w::AbstractDVec, stats)
     @static if Sys.ARCH ∈ (:aarch64, :ppc64le, :powerpc64le) ||
             startswith(lowercase(String(Sys.ARCH)), "arm")
         # Reductions of a custom type (`MultiScalar`) are not possible with MPI.jl on
-        # non-intel architectures at the moment
+        # non-Intel architectures at the moment
         # see https://github.com/JuliaParallel/MPI.jl/issues/404
         res_stats = (MPI.Allreduce(stat, +, dtarget.comm) for stat in stats)
     else

--- a/src/RMPI/helpers.jl
+++ b/src/RMPI/helpers.jl
@@ -87,9 +87,17 @@ end
 
 function sort_into_targets!(dtarget::MPIData, w::AbstractDVec, stats)
     # single threaded MPI version
-    mpi_combine_walkers!(dtarget,w) # combine walkers from different MPI ranks
-    res_stats = (MPI.Allreduce(stat, +, dtarget.comm) for stat in stats)
-    # res_stats = MPI.Allreduce(Rimu.MultiScalar(stats), +, dtarget.comm)
+    mpi_combine_walkers!(dtarget, w) # combine walkers from different MPI ranks
+    @static if Sys.ARCH ∈ (:aarch64, :ppc64le, :powerpc64le) ||
+            startswith(lowercase(String(Sys.ARCH)), "arm")
+        # Reductions of a custom type (`MultiScalar`) are not possible with MPI.jl on
+        # non-intel architectures at the moment
+        # see https://github.com/JuliaParallel/MPI.jl/issues/404
+        res_stats = (MPI.Allreduce(stat, +, dtarget.comm) for stat in stats)
+    else
+        # this should be more efficient if it is allowed
+        res_stats = MPI.Allreduce(Rimu.MultiScalar(stats), +, dtarget.comm)
+    end
     return dtarget, w, res_stats
 end
 

--- a/src/RMPI/helpers.jl
+++ b/src/RMPI/helpers.jl
@@ -88,7 +88,8 @@ end
 function sort_into_targets!(dtarget::MPIData, w::AbstractDVec, stats)
     # single threaded MPI version
     mpi_combine_walkers!(dtarget,w) # combine walkers from different MPI ranks
-    res_stats = MPI.Allreduce(Rimu.MultiScalar(stats), +, dtarget.comm)
+    res_stats = (MPI.Allreduce(stat, +, dtarget.comm) for stat in stats)
+    # res_stats = MPI.Allreduce(Rimu.MultiScalar(stats), +, dtarget.comm)
     return dtarget, w, res_stats
 end
 

--- a/src/RMPI/helpers.jl
+++ b/src/RMPI/helpers.jl
@@ -88,16 +88,7 @@ end
 function sort_into_targets!(dtarget::MPIData, w::AbstractDVec, stats)
     # single threaded MPI version
     mpi_combine_walkers!(dtarget, w) # combine walkers from different MPI ranks
-    @static if Sys.ARCH ∈ (:aarch64, :ppc64le, :powerpc64le) ||
-            startswith(lowercase(String(Sys.ARCH)), "arm")
-        # Reductions of a custom type (`MultiScalar`) are not possible with MPI.jl on
-        # non-Intel architectures at the moment
-        # see https://github.com/JuliaParallel/MPI.jl/issues/404
-        res_stats = (MPI.Allreduce(stat, +, dtarget.comm) for stat in stats)
-    else
-        # this should be more efficient if it is allowed
-        res_stats = MPI.Allreduce(Rimu.MultiScalar(stats), +, dtarget.comm)
-    end
+    res_stats = MPI.Allreduce(Rimu.MultiScalar(stats), +, dtarget.comm)
     return dtarget, w, res_stats
 end
 

--- a/src/RMPI/helpers.jl
+++ b/src/RMPI/helpers.jl
@@ -85,15 +85,10 @@ function mpi_combine_walkers!(dtarget::MPIData, source::AbstractDVec)
     mpi_combine_walkers!(ltarget, storage(source), strategy)
 end
 
-function sort_into_targets!(dtarget::MPIData, w::AbstractDVec, stats::T) where {T}
+function sort_into_targets!(dtarget::MPIData, w::AbstractDVec, stats)
     # single threaded MPI version
     mpi_combine_walkers!(dtarget, w) # combine walkers from different MPI ranks
-    if T<:Vector
-        res_stats = MPI.Allreduce(stats, +, dtarget.comm)
-    else
-        # temporarily convert to Vector for native MPI reduction
-        res_stats = T(MPI.Allreduce([stats...], +, dtarget.comm))
-    end
+    res_stats = MPI.Allreduce(Rimu.MultiScalar(stats), +, dtarget.comm)
     return dtarget, w, res_stats
 end
 

--- a/src/RMPI/mpidata.jl
+++ b/src/RMPI/mpidata.jl
@@ -93,8 +93,12 @@ end
 function Base.mapreduce(f, op, it::MPIDataIterator; kwargs...)
     res = mapreduce(f, op, it.iter; kwargs...)
     T = typeof(res)
-    if T <: Bool # MPI.jl does not support Bool reductions
+    if T <: Bool # MPI.jl does not currently support Bool reductions on ARM
+        #TODO remove when https://github.com/JuliaParallel/MPI.jl/pull/719
+        # is merged and released
         res = convert(UInt8, res)
+    elseif T <: Rimu.MultiScalar # MPI.jl does not support MultiScalar reductions on ARM
+        res = [res...]
     end
     return T(MPI.Allreduce(res, op, it.data.comm))
 end

--- a/src/RMPI/mpidata.jl
+++ b/src/RMPI/mpidata.jl
@@ -93,12 +93,8 @@ end
 function Base.mapreduce(f, op, it::MPIDataIterator; kwargs...)
     res = mapreduce(f, op, it.iter; kwargs...)
     T = typeof(res)
-    if T <: Bool # MPI.jl does not currently support Bool reductions on ARM
-        #TODO remove when https://github.com/JuliaParallel/MPI.jl/pull/719
-        # is merged and released
+    if T <: Bool # MPI.jl does not support Bool reductions
         res = convert(UInt8, res)
-    elseif T <: Rimu.MultiScalar # MPI.jl does not support MultiScalar reductions on ARM
-        res = [res...]
     end
     return T(MPI.Allreduce(res, op, it.data.comm))
 end

--- a/src/RMPI/mpidata.jl
+++ b/src/RMPI/mpidata.jl
@@ -99,13 +99,13 @@ end
 # Replacing it by `+` is necessary for non-Intel architectures due to a limitation of
 # MPI.jl. On Intel processors, it might be more perfomant.
 # see https://github.com/JuliaParallel/MPI.jl/issues/404
-function Base.mapreduce(f, ::typeof(Base.add_sum), it::MPIDataIterator; kwargs...)
-    res = mapreduce(f, +, it.iter; kwargs...)
+function Base.mapreduce(f, op::typeof(Base.add_sum), it::MPIDataIterator; kwargs...)
+    res = mapreduce(f, op, it.iter; kwargs...)
     return MPI.Allreduce(res, +, it.data.comm)
 end
 
-function Base.mapreduce(f, ::typeof(Base.mul_prod), it::MPIDataIterator; kwargs...)
-    res = mapreduce(f, *, it.iter; kwargs...)
+function Base.mapreduce(f, op::typeof(Base.mul_prod), it::MPIDataIterator; kwargs...)
+    res = mapreduce(f, op, it.iter; kwargs...)
     return MPI.Allreduce(res, *, it.data.comm)
 end
 

--- a/src/RMPI/mpidata.jl
+++ b/src/RMPI/mpidata.jl
@@ -118,9 +118,11 @@ MPI syncronizing.
 """
 function LinearAlgebra.norm(md::MPIData, p::Real=2)
     if p === 2
-        return sqrt(sum(abs2, values(md)))
+        return sqrt(mapreduce(abs2, +, values(md)))
+        # return sqrt(sum(abs2, values(md)))
     elseif p === 1
-        return float(sum(abs, values(md)))
+        return float(mapreduce(abs, +, values(md)))
+        # return float(sum(abs, values(md)))
     elseif p === Inf
         return float(mapreduce(abs, max, values(md); init=real(zero(valtype(md)))))
     else

--- a/src/RMPI/multiscalar.jl
+++ b/src/RMPI/multiscalar.jl
@@ -1,0 +1,10 @@
+# Make MPI reduction of a `MultiScalar` work on non-Intel processors.
+# The `MultiScalar` is converted into a vector before sending through MPI.Allreduce.
+# Testing shows that this is about the same speed or even a bit faster on Intel processors
+# than reducing the MultiScalar directly via a custom reduction operator.
+# Defining the method in RMPI is strictly type piracy as MultiScalar belongs to Rimu and
+# not to RMPI. Might clean this up later.
+function MPI.Allreduce(ms::Rimu.MultiScalar{T}, op, comm::MPI.Comm) where {T<:Tuple}
+    result_vector = MPI.Allreduce([ms...], op, comm)
+    return Rimu.MultiScalar(T(result_vector))
+end

--- a/src/StochasticStyles/styles.jl
+++ b/src/StochasticStyles/styles.jl
@@ -46,7 +46,7 @@ function step_stats(::IsStochastic2Pop{T}) where {T}
     z = zero(T)
     return (
         (:spawns, :deaths, :clones, :zombies),
-        [z, z, z, z]
+        MultiScalar(z, z, z, z)
     )
 end
 function fciqmc_col!(::IsStochastic2Pop, w, ham, add, val, shift, dτ)
@@ -61,7 +61,7 @@ function fciqmc_col!(::IsStochastic2Pop, w, ham, add, val, shift, dτ)
 
     clones, deaths, zombies = diagonal_step!(w, ham, add, val, dτ, shift, 0)
 
-    return [spawns, deaths, clones, zombies]
+    return (spawns, deaths, clones, zombies)
 end
 
 """

--- a/src/StochasticStyles/styles.jl
+++ b/src/StochasticStyles/styles.jl
@@ -46,7 +46,7 @@ function step_stats(::IsStochastic2Pop{T}) where {T}
     z = zero(T)
     return (
         (:spawns, :deaths, :clones, :zombies),
-        MultiScalar(z, z, z, z)
+        [z, z, z, z]
     )
 end
 function fciqmc_col!(::IsStochastic2Pop, w, ham, add, val, shift, dτ)
@@ -61,7 +61,7 @@ function fciqmc_col!(::IsStochastic2Pop, w, ham, add, val, shift, dτ)
 
     clones, deaths, zombies = diagonal_step!(w, ham, add, val, dτ, shift, 0)
 
-    return (spawns, deaths, clones, zombies)
+    return [spawns, deaths, clones, zombies]
 end
 
 """

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -35,6 +35,7 @@ MultiScalar(args...) = MultiScalar(args)
 MultiScalar(v::SVector) = MultiScalar(Tuple(v))
 MultiScalar(m::MultiScalar) = m
 MultiScalar{T}(m::MultiScalar{T}) where T<:Tuple = m
+MultiScalar{T}(v::Vector) where {T<:Tuple} = MultiScalar{T}(T(v))
 MultiScalar(arg) = MultiScalar((arg,))
 
 Base.getindex(m::MultiScalar, i) = m.tuple[i]

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -35,7 +35,6 @@ MultiScalar(args...) = MultiScalar(args)
 MultiScalar(v::SVector) = MultiScalar(Tuple(v))
 MultiScalar(m::MultiScalar) = m
 MultiScalar{T}(m::MultiScalar{T}) where T<:Tuple = m
-MultiScalar{T}(v::Vector) where {T<:Tuple} = MultiScalar{T}(T(v))
 MultiScalar(arg) = MultiScalar((arg,))
 
 Base.getindex(m::MultiScalar, i) = m.tuple[i]

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -34,6 +34,7 @@ end
 MultiScalar(args...) = MultiScalar(args)
 MultiScalar(v::SVector) = MultiScalar(Tuple(v))
 MultiScalar(m::MultiScalar) = m
+MultiScalar{T}(m::MultiScalar{T}) where T<:Tuple = m
 MultiScalar(arg) = MultiScalar((arg,))
 
 Base.getindex(m::MultiScalar, i) = m.tuple[i]

--- a/test/RMPI.jl
+++ b/test/RMPI.jl
@@ -52,14 +52,10 @@ end
     @testset "Iteration and reductions" begin
         @test sort(collect(localpart(values(dv1)))) == 1:4
 
-        @test mapreduce(first, +, pairs(dv1)) == 10
-        # @test sum(first, pairs(dv1)) == 10
-        @test mapreduce(last, +, pairs(dv1)) == 10
-        # @test sum(last, pairs(dv1)) == 10
-        @test reduce(*, keys(dv1)) == 24
-        # @test prod(keys(dv1)) == 24
-        @test reduce(+, values(dv2)) == 0
-        # @test sum(values(dv2)) == 0
+        @test sum(first, pairs(dv1)) == 10
+        @test sum(last, pairs(dv1)) == 10
+        @test prod(keys(dv1)) == 24
+        @test sum(values(dv2)) == 0
     end
     @testset "Errors" begin
         @test_throws ErrorException [p for p in pairs(dv1)]

--- a/test/RMPI.jl
+++ b/test/RMPI.jl
@@ -6,17 +6,17 @@ using Test
 
 @testset "DistributeStrategies" begin
     # `DistributeStrategy`s
-    ham = HubbardReal1D(BoseFS((1,2,3)))
+    ham = HubbardReal1D(BoseFS((1, 2, 3)))
     for setup in [RMPI.mpi_no_exchange, RMPI.mpi_all_to_all, RMPI.mpi_point_to_point]
-        dv = DVec(starting_address(ham)=>10; style=IsDynamicSemistochastic())
+        dv = DVec(starting_address(ham) => 10; style=IsDynamicSemistochastic())
         v = MPIData(dv; setup)
-        df, state = lomc!(ham,v)
+        df, state = lomc!(ham, v)
         @test size(df) == (100, 12)
     end
     # need to do mpi_one_sided separately
-    dv = DVec(starting_address(ham)=>10; style=IsDynamicSemistochastic())
-    v = RMPI.mpi_one_sided(dv; capacity = 1000)
-    df, state = lomc!(ham,v)
+    dv = DVec(starting_address(ham) => 10; style=IsDynamicSemistochastic())
+    v = RMPI.mpi_one_sided(dv; capacity=1000)
+    df, state = lomc!(ham, v)
     @test size(df) == (100, 12)
 end
 
@@ -29,13 +29,13 @@ end
                 counts = zeros(Int, k)
                 displs = zeros(Int, k)
 
-                RMPI.sort_and_count!(counts, displs, vals, ordfun.(vals), (0, k-1))
+                RMPI.sort_and_count!(counts, displs, vals, ordfun.(vals), (0, k - 1))
                 @test issorted(vals, by=ordfun)
                 @test sum(counts) == l
 
-                for i in 0:(k - 1)
-                    c = counts[i + 1]
-                    d = displs[i + 1]
+                for i in 0:(k-1)
+                    c = counts[i+1]
+                    d = displs[i+1]
                     r = (1:c) .+ d
                     ords = ordfun.(vals)
                     @test all(ords[r] .== i)
@@ -52,10 +52,14 @@ end
     @testset "Iteration and reductions" begin
         @test sort(collect(localpart(values(dv1)))) == 1:4
 
-        @test sum(first, pairs(dv1)) == 10
-        @test sum(last, pairs(dv1)) == 10
-        @test prod(keys(dv1)) == 24
-        @test sum(values(dv2)) == 0
+        @test mapreduce(first, +, pairs(dv1)) == 10
+        # @test sum(first, pairs(dv1)) == 10
+        @test mapreduce(last, +, pairs(dv1)) == 10
+        # @test sum(last, pairs(dv1)) == 10
+        @test reduce(*, keys(dv1)) == 24
+        # @test prod(keys(dv1)) == 24
+        @test reduce(+, values(dv2)) == 0
+        # @test sum(values(dv2)) == 0
     end
     @testset "Errors" begin
         @test_throws ErrorException [p for p in pairs(dv1)]
@@ -79,7 +83,7 @@ end
     @testset "dot" begin
         @test dot(dv1, dv2) == 0
         @test dot(dv1, dv1) == dot(localpart(dv1), dv1)
-        rand_ham = MatrixHamiltonian(rand(ComplexF64, 4,4))
+        rand_ham = MatrixHamiltonian(rand(ComplexF64, 4, 4))
         ldv1 = localpart(dv1)
         @test norm(dot(dv1, rand_ham, dv1)) ≈ norm(dot(ldv1, rand_ham, ldv1))
     end

--- a/test/mpi_runtests.jl
+++ b/test/mpi_runtests.jl
@@ -295,7 +295,8 @@ end
 
     # Make sure all ranks came this far.
     @testset "Finish" begin
-        @test MPI.Allreduce(0x01, &, mpi_comm()) == 0x01 # 0x01 for true
+        # MPI.jl currently doesn't properly map logical operators (MPI v0.20.8)
+        @test MPI.Allreduce(true, MPI.LAND, mpi_comm())
         # @test MPI.Allreduce(true, &, mpi_comm())
     end
 end

--- a/test/mpi_runtests.jl
+++ b/test/mpi_runtests.jl
@@ -71,7 +71,7 @@ end
             end
             @testset "Single component $type" begin
                 for i in 1:N_REPEATS
-                    add = BoseFS((0,0,10,0,0))
+                    add = BoseFS((0, 0, 10, 0, 0))
                     H = HubbardMom1D(add)
                     Random.seed!(7350 * i)
                     v, dv = setup_dv(
@@ -98,7 +98,7 @@ end
                         @test sum(values(v)) ≈ sum(values(dv))
                         f((k, v)) = (k == add) + v > 0
                         @test mapreduce(f, |, pairs(v); init=true) ==
-                            mapreduce(f, |, pairs(dv); init=true)
+                              mapreduce(f, |, pairs(dv); init=true)
                     end
 
                     @testset "Operations" begin
@@ -127,7 +127,7 @@ end
             end
             @testset "Two-component $type" begin
                 for i in 1:N_REPEATS
-                    add = BoseFS2C((0,0,10,0,0), (0,0,2,0,0))
+                    add = BoseFS2C((0, 0, 10, 0, 0), (0, 0, 2, 0, 0))
                     H = BoseHubbardMom1D2C(add)
                     Random.seed!(7350 * i)
                     v, dv = setup_dv(
@@ -225,7 +225,7 @@ end
             (RMPI.mpi_one_sided, (; capacity=1000)),
         )
             @testset "Regular with $setup and post-steps" begin
-                H = HubbardReal1D(BoseFS((1,1,1,1,1,1,1)); u=6.0)
+                H = HubbardReal1D(BoseFS((1, 1, 1, 1, 1, 1, 1)); u=6.0)
                 dv = MPIData(
                     DVec(starting_address(H) => 3; style=IsDynamicSemistochastic());
                     setup,
@@ -253,7 +253,7 @@ end
                 @test all(0 .≤ df.loneliness .≤ 1)
             end
             @testset "Initiator with $setup" begin
-                H = HubbardMom1D(BoseFS((0,0,0,7,0,0,0)); u=6.0)
+                H = HubbardMom1D(BoseFS((0, 0, 0, 7, 0, 0, 0)); u=6.0)
                 dv = MPIData(
                     InitiatorDVec(starting_address(H) => 3);
                     setup,
@@ -295,7 +295,8 @@ end
 
     # Make sure all ranks came this far.
     @testset "Finish" begin
-        @test MPI.Allreduce(true, &, mpi_comm())
+        @test MPI.Allreduce(0x01, &, mpi_comm()) == 0x01 # 0x01 for true
+        # @test MPI.Allreduce(true, &, mpi_comm())
     end
 end
 


### PR DESCRIPTION
Fix issues with MPI reductions on non-intel processors.

Related to [https://github.com/JuliaParallel/MPI.jl/issues/404](https://github.com/JuliaParallel/MPI.jl/issues/404).

The workaround is to only use standard reduction operations on scalars as these are predefined in `MPI.jl`.

Aimed at solving #197 