### PR TITLE
Feature/dimension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -61,7 +61,7 @@ StrFormat = "1"
 StrLiterals = "1"
 TerminalLoggers = "0.1.4"
 VectorInterface = "0.2"
-julia = "1.6"
+julia = "1.7"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/docs/src/hamiltonians.md
+++ b/docs/src/hamiltonians.md
@@ -137,6 +137,7 @@ Hamiltonians.adjoint
 Hamiltonians.dot
 Hamiltonians.AbstractOffdiagonals
 Hamiltonians.Offdiagonals
+Hamiltonians.check_address_type
 ```
 
 ## Geometry

--- a/docs/src/hamiltonians.md
+++ b/docs/src/hamiltonians.md
@@ -128,6 +128,7 @@ random_offdiagonal
 Hamiltonians.LOStructure
 dimension
 has_adjoint
+allowed_address_type
 ```
 
 This interface relies on unexported functionality, including

--- a/src/Hamiltonians/GuidingVectorSampling.jl
+++ b/src/Hamiltonians/GuidingVectorSampling.jl
@@ -45,7 +45,7 @@ julia> get_offdiagonal(G, starting_address(G), 4)
 
 # Observables
 
-To calculate observables, pass the transformed Hamiltonian `G` to 
+To calculate observables, pass the transformed Hamiltonian `G` to
 [`AllOverlaps`](@ref) with keyword argument `transform=G`.
 """
 struct GuidingVectorSampling{A,T,H<:AbstractHamiltonian{T},D,E} <: AbstractHamiltonian{T}
@@ -70,7 +70,7 @@ function LinearAlgebra.adjoint(h::GuidingVectorSampling{A,T,<:Any,D,E}) where {A
     return GuidingVectorSampling{!A,T,typeof(h_adj),D,E}(h_adj, h.vector)
 end
 
-dimension(::Type{T}, h::GuidingVectorSampling) where T = dimension(T, h.hamiltonian)
+dimension(h::GuidingVectorSampling, addr) = dimension(h.hamiltonian, addr)
 
 Base.getproperty(h::GuidingVectorSampling, s::Symbol) = getproperty(h, Val(s))
 Base.getproperty(h::GuidingVectorSampling{<:Any,<:Any,<:Any,<:Any,E}, ::Val{:eps}) where E = E
@@ -135,10 +135,10 @@ Base.size(h::GuidingVectorOffdiagonals) = size(h.offdiagonals)
     TransformUndoer(k::GuidingVectorSampling)
 
 For a guiding vector similarity transformation ``\\hat{G} = f \\hat{H} f^{-1}``
-define the operator ``f^{-1} \\hat{A} f^{-1}``, and special case ``f^{-2}``, in order 
-to calculate observables. Here ``f`` is a diagonal operator whose entries are 
+define the operator ``f^{-1} \\hat{A} f^{-1}``, and special case ``f^{-2}``, in order
+to calculate observables. Here ``f`` is a diagonal operator whose entries are
 the components of the guiding vector, i.e.``f_{ii} = v_i``.
-    
+
 See [`AllOverlaps`](@ref), [`GuidingVectorSampling`](@ref).
 """
 function TransformUndoer(k::GuidingVectorSampling, op::Union{Nothing,AbstractHamiltonian})

--- a/src/Hamiltonians/GutzwillerSampling.jl
+++ b/src/Hamiltonians/GutzwillerSampling.jl
@@ -67,7 +67,7 @@ function LinearAlgebra.adjoint(h::GutzwillerSampling{A,T,<:Any,G}) where {A,T,G}
     return GutzwillerSampling{!A,T,typeof(h_adj),G}(h_adj)
 end
 
-dimension(::Type{T}, h::GutzwillerSampling) where T = dimension(T, h.hamiltonian)
+dimension(h::GutzwillerSampling, addr) = dimension(h.hamiltonian, addr)
 
 Base.getproperty(h::GutzwillerSampling, s::Symbol) = getproperty(h, Val(s))
 Base.getproperty(h::GutzwillerSampling{<:Any,<:Any,<:Any,G}, ::Val{:g}) where G = G

--- a/src/Hamiltonians/Hamiltonians.jl
+++ b/src/Hamiltonians/Hamiltonians.jl
@@ -48,7 +48,7 @@ using ..BitStringAddresses
 
 using ..Interfaces
 import ..Interfaces: diagonal_element, num_offdiagonals, get_offdiagonal, starting_address,
-    offdiagonals, random_offdiagonal, LOStructure
+    offdiagonals, random_offdiagonal, LOStructure, allowed_address_type
 
 export AbstractHamiltonian
 # export TwoComponentHamiltonian

--- a/src/Hamiltonians/MatrixHamiltonian.jl
+++ b/src/Hamiltonians/MatrixHamiltonian.jl
@@ -33,7 +33,7 @@ LinearAlgebra.adjoint(mh::MatrixHamiltonian{<:Any,<:Any,true}) = mh
 
 starting_address(mh::MatrixHamiltonian) = mh.starting_index
 
-dimension(::Type{T}, mh::MatrixHamiltonian) where T = T(size(mh.m,2))
+dimension(mh::MatrixHamiltonian, _) = size(mh.m,2)
 
 num_offdiagonals(mh::MatrixHamiltonian, _) = dimension(mh) - 1
 

--- a/src/Hamiltonians/MatrixHamiltonian.jl
+++ b/src/Hamiltonians/MatrixHamiltonian.jl
@@ -3,11 +3,12 @@
         mat::AbstractMatrix{T};
         starting_address::Int = starting_address(mat)
     ) <: AbstractHamiltonian{T}
-Wrap an abstract matrix `mat` as an [`AbstractHamiltonian`](@ref) object for use with
-regular `Vector`s indexed by integers. Works with stochastic methods of
-[`lomc!()`](@ref). Optionally, a [`starting_address`](@ref) can be provided.
+Wrap an abstract matrix `mat` as an [`AbstractHamiltonian`](@ref) object.
+Works with stochastic methods of [`lomc!()`](@ref) and [`DVec`](@ref).
+Optionally, a valid index can be provided as the [`starting_address`](@ref).
 
 Specialised methods are implemented for sparse matrices of type `AbstractSparseMatrixCSC`.
+One based indexing is required for the matrix `mat`.
 """
 struct MatrixHamiltonian{T,AM,H} <: AbstractHamiltonian{T}
     m::AM
@@ -18,10 +19,11 @@ function MatrixHamiltonian(
     m::AM;
     starting_address=starting_address(m)
 ) where AM <:AbstractMatrix
-    s = length.(axes(m))
-    @assert s[1]==s[2] "Matrix needs to be square, got $s."
+    Base.require_one_based_indexing(m)
+    s = size(m)
+    s[1] == s[2] || throw(ArgumentError("Matrix needs to be square, got $s."))
     i = Int(starting_address)
-    @assert minimum(axes(m, 2)) ≤ i ≤ maximum(axes(m, 2)) "Invalid index $starting_address."
+    1 ≤ i ≤ s[1] || throw(ArgumentError("Invalid `starting_address` $starting_address."))
     MatrixHamiltonian{eltype(m), AM, ishermitian(m)}(m, i)
 end
 

--- a/src/Hamiltonians/abstract.jl
+++ b/src/Hamiltonians/abstract.jl
@@ -1,7 +1,9 @@
 """
-    check_address_type(h::AbstractHamiltonian, addr::A) where A
-    check_address_type(h::AbstractHamiltonian, A)
-Throw an `ArgumentError` if the type of `addr`, `A`, is not compatible with `h`.
+    check_address_type(h::AbstractHamiltonian, addr_or_type)
+Throw an `ArgumentError` if `addr_or_type` is not compatible with `h`. Acceptable arguments
+are either an address or an address type, or a tuple or array thereof.
+
+See also [`allowed_address_type`](@ref).
 """
 function check_address_type(h::AbstractHamiltonian, ::Type{A}) where {A}
     B = allowed_address_type(h)
@@ -9,7 +11,7 @@ function check_address_type(h::AbstractHamiltonian, ::Type{A}) where {A}
 end
 check_address_type(h::AbstractHamiltonian, addr) = check_address_type(h, typeof(addr))
 function check_address_type(h::AbstractHamiltonian, v::Union{AbstractArray,Tuple})
-    all(check_address_type(h, typeof(a)) for a in v)
+    all(check_address_type(h, a) for a in v)
 end
 
 (h::AbstractHamiltonian)(v) = h * v

--- a/src/Hamiltonians/abstract.jl
+++ b/src/Hamiltonians/abstract.jl
@@ -583,7 +583,7 @@ Base.Matrix(bsr::BasisSetRep) = Matrix(bsr.sm)
 
 function Base.getindex(ham::AbstractHamiltonian{T}, address1, address2) where {T}
     # calculate the matrix element when only two bitstring addresses are given
-    # this is NOT used for the QMC algorithm and is currenlty not used either
+    # this is NOT used for the QMC algorithm and is currently not used either
     # for building the matrix for conventional diagonalisation.
     # Only used for verifying matrix.
     # This will be slow and inefficient. Avoid using for larger Hamiltonians!

--- a/src/Hamiltonians/abstract.jl
+++ b/src/Hamiltonians/abstract.jl
@@ -11,13 +11,6 @@ end
 
 BitStringAddresses.num_modes(h::AbstractHamiltonian) = num_modes(starting_address(h))
 
-# """
-#     logbinomialapprox(n, k)
-
-# Approximate formula for log of binomial coefficient. [Source](https://en.wikipedia.org/wiki/Binomial_coefficient#Bounds_and_asymptotic_formulas)
-# """
-# logbinomialapprox(n, k) = (n + 0.5) * log((n + 0.5) / (n - k + 0.5)) + k * log((n - k + 0.5) / k) - 0.5 * log(2π * k)
-
 """
     dimension(h::AbstractHamiltonian, addr=starting_address(h))
     dimension(addr::AbstractFockAddress)
@@ -31,7 +24,7 @@ the matrix representing the Hamiltonian is returned.
 # Examples
 
 ```jldoctest
-julia> dimension(BoseFS((1,2,3))
+julia> dimension(BoseFS((1,2,3)))
 28
 
 julia> dimension(HubbardReal1D(BoseFS((1,2,3))))
@@ -66,29 +59,11 @@ function dimension(c::CompositeFS)
     return prod(x -> dimension(x), c.components)
 end
 
-
-
 # for backward compatibility
 function dimension(::Type{T}, h, addr=starting_address(h)) where {T}
     return T(dimension(h, addr))
 end
 dimension(::Type{T}, addr::AbstractFockAddress) where {T} = T(dimension(addr))
-
-
-# function try_binomial(n::T, k::T) where {T}
-#     try
-#         return T(binomial(n, k))
-#     catch
-#         return nothing
-#     end
-# end
-# function approximate_binomial(n::T, k::T) where {T}
-#     try
-#         T(binomial(Int128(n), Int128(k)))
-#     catch
-#         T(exp(logbinomialapprox(n, k)))
-#     end
-# end
 
 Base.isreal(h::AbstractHamiltonian) = eltype(h) <: Real
 LinearAlgebra.isdiag(h::AbstractHamiltonian) = LOStructure(h) ≡ IsDiagonal()

--- a/src/Hamiltonians/abstract.jl
+++ b/src/Hamiltonians/abstract.jl
@@ -150,11 +150,8 @@ performance.
 
 Providing an energy cutoff will skip the columns and rows with diagonal elements greater
 than `cutoff`. Alternatively, an arbitrary `filter` function can be used instead. These are
-not enabled by default.
-
-Instead of a single `address`, a vector of `addresses` can be provided. If no `filter` is
-provided, the matrix will be truncated to the subspace spanned by the `addresses`. For
-generating the matrix with all reachable configurations, use `filter = _ -> true`.
+not enabled by default. To generate the matrix truncated to the subspace spanned by the
+`addresses`, use `filter = Returns(false)`.
 
 Setting `sort` to `true` will sort the `basis` and order the matrix rows and columns
 accordingly. This is useful when the order of the columns matters, e.g. when comparing
@@ -331,7 +328,7 @@ BasisSetRep(HubbardReal1D(BoseFS{1,3}((1, 0, 0)); u=1.0, t=1.0)) with dimension 
  -1.0   0.0  -1.0
  -1.0  -1.0   0.0
 
-julia> BasisSetRep(h, bsr.basis[1:2]; filter=_->false) # passing addresses and truncating
+julia> BasisSetRep(h, bsr.basis[1:2]; filter = Returns(false)) # passing addresses and truncating
 BasisSetRep(HubbardReal1D(BoseFS{1,3}((1, 0, 0)); u=1.0, t=1.0)) with dimension 2 and 4 stored entries:2×2 SparseArrays.SparseMatrixCSC{Float64, Int64} with 4 stored entries:
   0.0  -1.0
  -1.0   0.0

--- a/src/Hamiltonians/abstract.jl
+++ b/src/Hamiltonians/abstract.jl
@@ -609,7 +609,9 @@ LinearAlgebra.adjoint(::IsHermitian, op) = op # adjoint is known
 LinearAlgebra.adjoint(::IsDiagonal, op) = op
 
 """
-    TransformUndoer{T,K<:AbstractHamiltonian,O<:Union{AbstractHamiltonian,Nothing}} <: AbstractHamiltonian{T}
+    TransformUndoer{
+        T,K<:AbstractHamiltonian,O<:Union{AbstractHamiltonian,Nothing}
+    } <: AbstractHamiltonian{T}
 
 Type for creating a new operator for the purpose of calculating overlaps of transformed
 vectors, which are defined by some transformation `transform`. The new operator should
@@ -636,7 +638,9 @@ to represent ``f^{-1} A f^{-1}``.
 * [`GutzwillerSampling`](@ref)
 * [`GuidingVectorSampling`](@ref)
 """
-struct TransformUndoer{T,K<:AbstractHamiltonian,O<:Union{AbstractHamiltonian,Nothing}} <: AbstractHamiltonian{T}
+struct TransformUndoer{
+    T,K<:AbstractHamiltonian,O<:Union{AbstractHamiltonian,Nothing}
+} <: AbstractHamiltonian{T}
     transform::K
     op::O
 end
@@ -649,4 +653,4 @@ TransformUndoer(k::AbstractHamiltonian) = TransformUndoer(k::AbstractHamiltonian
 
 # common methods
 starting_address(s::TransformUndoer) = starting_address(s.transform)
-dimension(s::TransformUndoer) = dimension(s.transform)
+dimension(s::TransformUndoer, addr) = dimension(s.transform, addr)

--- a/src/Hamiltonians/abstract.jl
+++ b/src/Hamiltonians/abstract.jl
@@ -5,11 +5,11 @@ are either an address or an address type, or a tuple or array thereof.
 
 See also [`allowed_address_type`](@ref).
 """
-@inline function check_address_type(h::AbstractHamiltonian, ::Type{A}) where {A}
+@inline function check_address_type(h, ::Type{A}) where {A}
     B = allowed_address_type(h)
     A <: B || throw(ArgumentError("address type mismatch: found $A, expected <: $B"))
 end
-@inline check_address_type(h::AbstractHamiltonian, addr) = check_address_type(h, typeof(addr))
+@inline check_address_type(h, addr) = check_address_type(h, typeof(addr))
 @inline function check_address_type(h::AbstractHamiltonian, v::Union{AbstractArray,Tuple})
     all(check_address_type(h, a) for a in v)
 end

--- a/src/Hamiltonians/abstract.jl
+++ b/src/Hamiltonians/abstract.jl
@@ -330,10 +330,14 @@ BasisSetRep(HubbardReal1D(BoseFS{1,3}((1, 0, 0)); u=1.0, t=1.0)) with dimension 
   0.0  -1.0  -1.0
  -1.0   0.0  -1.0
  -1.0  -1.0   0.0
+
+julia> BasisSetRep(h, bsr.basis[1:2]; filter=_->false) # passing addresses and truncating
+BasisSetRep(HubbardReal1D(BoseFS{1,3}((1, 0, 0)); u=1.0, t=1.0)) with dimension 2 and 4 stored entries:2×2 SparseArrays.SparseMatrixCSC{Float64, Int64} with 4 stored entries:
+  0.0  -1.0
+ -1.0   0.0
 ```
 ```julia-repl
- julia> using LinearAlgebra; eigvals(Matrix(bsr))
- 3-element Vector{Float64}:
+ julia> using LinearAlgebra; eigvals(Matrix(bsr)) # eigenvalues
   -2.0
    1.0
    1.0

--- a/src/Hamiltonians/abstract.jl
+++ b/src/Hamiltonians/abstract.jl
@@ -15,7 +15,7 @@ BitStringAddresses.num_modes(h::AbstractHamiltonian) = num_modes(starting_addres
     dimension(h::AbstractHamiltonian, addr=starting_address(h))
     dimension(addr::AbstractFockAddress)
 
-Return the estimated dimension of Hilbert space.
+Return the estimated dimension of Hilbert space. May return a `BigInt` number.
 
 When called on an address, the dimension of the linear space spanned by the address type is
 returned. When called on an `AbstractHamiltonian`, an upper bound on the dimension of

--- a/src/Hamiltonians/abstract.jl
+++ b/src/Hamiltonians/abstract.jl
@@ -38,7 +38,8 @@ julia> dimension(HubbardReal1D(near_uniform(BoseFS{200,100})))|>Float64
 ```
 # Interface
 
-When extending `AbstractHamiltonian`, implement `dimension(h::AbstractHamiltonian, addr)`.
+When extending `AbstractHamiltonian`, define a method for the two-argument form
+`dimension(h::MyNewHamiltonian, addr)`.
 
 See also [`BasisSetRep`](@doc).
 """

--- a/src/Hamiltonians/abstract.jl
+++ b/src/Hamiltonians/abstract.jl
@@ -584,10 +584,13 @@ function Base.getindex(ham::AbstractHamiltonian{T}, address1, address2) where {T
     # Only used for verifying matrix.
     # This will be slow and inefficient. Avoid using for larger Hamiltonians!
     address1 == address2 && return diagonal_element(ham, address1) # diagonal
+    res = zero(T)
     for (add, val) in offdiagonals(ham, address2) # off-diag column as iterator
-        add == address1 && return val # found address1
+        if add == address1
+            res += val # found address1
+        end
     end
-    return zero(T) # address1 not found
+    return res
 end
 
 LinearAlgebra.adjoint(op::AbstractHamiltonian) = adjoint(LOStructure(op), op)

--- a/src/Hamiltonians/abstract.jl
+++ b/src/Hamiltonians/abstract.jl
@@ -175,28 +175,31 @@ julia> rayleigh_quotient(mom, v) # momentum expectation value for state vector `
 momentum
 
 """
-    sm, basis = build_sparse_matrix_from_LO(
-        ham, address=starting_address(ham); cutoff, filter=nothing, nnzs, col_hint, sort=false, kwargs...
-    )
+    build_sparse_matrix_from_LO(
+        ham, address=starting_address(ham);
+        cutoff, filter=nothing, nnzs, col_hint, sort=false, kwargs...
+    ) -> sm, basis
+    build_sparse_matrix_from_LO(ham, addresses::AbstractVector; kwargs...)
 
 Create a sparse matrix `sm` of all reachable matrix elements of a linear operator `ham`
 starting from `address`. The vector `basis` contains the addresses of basis
 configurations.
 
-Providing the number `nnzs` of expected calculated matrix elements may improve performance.
-The default estimates for `nnzs` is `dimension(ham)`.
-
-Setting a custom value `col_hint` for the estimated number of nonzero
-off-diagonal matrix elements in each matrix column may improve performance.
-The default value for `col_hint` is `num_offdiagonals(ham, address)`.
+Providing the number `nnzs` of expected calculated matrix elements and `col_hint` for the
+estimated number of nonzero off-diagonal matrix elements in each matrix column may improve
+performance.
 
 Providing an energy cutoff will skip the columns and rows with diagonal elements greater
 than `cutoff`. Alternatively, an arbitrary `filter` function can be used instead. These are
 not enabled by default.
 
-Setting `sort` to `true` will sort the matrix rows and columns. This is useful when the
-order of the columns matters, e.g. when comparing matrices. Any additional keyword arguments
-are passed on to `Base.sortperm`.
+Instead of a single `address`, a vector of `addresses` can be provided. If no `filter` is
+provided, the matrix will be truncated to the subspace spanned by the `addresses`. For
+generating the matrix with all reachable configurations, use `filter = _ -> true`.
+
+Setting `sort` to `true` will sort the `basis` and order the matrix rows and columns
+accordingly. This is useful when the order of the columns matters, e.g. when comparing
+matrices. Any additional keyword arguments are passed on to `Base.sortperm`.
 
 See [`BasisSetRep`](@ref).
 """
@@ -204,7 +207,8 @@ function build_sparse_matrix_from_LO(
     ham, address=starting_address(ham);
     cutoff=nothing,
     filter=isnothing(cutoff) ? nothing : (a -> diagonal_element(ham, a) ≤ cutoff),
-    nnzs=dimension(ham), col_hint=num_offdiagonals(ham, address),
+    # nnzs=dimension(ham), col_hint=num_offdiagonals(ham, address),
+    nnzs=0, col_hint=0,
     sort=false, kwargs...
 )
     if !isnothing(filter) && !filter(address)
@@ -213,9 +217,20 @@ function build_sparse_matrix_from_LO(
             "Please pick a different address or a different filter."
         )))
     end
+
+    # Set up `adds` as queue of addresses. Also returned as the basis.
+    if isnothing(filter) && address isa AbstractVector # truncated basis has been passed
+        adds = [address...] # interpret `address` as a list of addresses in truncated basis
+        filter = _ -> false # don't allow adding new addresses
+    elseif address isa AbstractArray # basis has been passed and may be extended
+        adds = [address...]          # copy because we will modify it
+    else # starting address has been passed
+        adds = [address]
+    end
+
     T = eltype(ham)
-    adds = [address]          # Queue of addresses. Also returned as the basis.
-    dict = Dict(address => 1) # Mapping from addresses to indices
+    dict = Dict(add => i for (i, add) in enumerate(adds)) # Map from addresses to indices
+    # dict = Dict(adds[1] => 1) # Mapping from addresses to indices
     col = Dict{Int,T}()       # Temporary column storage
     sizehint!(col, col_hint)
 
@@ -423,7 +438,7 @@ function _bsr_ensure_symmetry(
     sizelim=10^6, test_approx_symmetry=true, kwargs...
 )
     dimension(Float64, h) < sizelim || throw(ArgumentError("dimension larger than sizelim"))
-    check_address_type(h, addr)
+    # check_address_type(h, addr)
     sm, basis = build_sparse_matrix_from_LO(h, addr; kwargs...)
     return BasisSetRep(sm, basis, h)
 end
@@ -434,7 +449,7 @@ function _bsr_ensure_symmetry(
     sizelim=10^6, test_approx_symmetry=true, kwargs...
 )
     dimension(Float64, h) < sizelim || throw(ArgumentError("dimension larger than sizelim"))
-    check_address_type(h, addr)
+    # check_address_type(h, addr)
     sm, basis = build_sparse_matrix_from_LO(h, addr; kwargs...)
     fix_approx_hermitian!(sm; test_approx_symmetry) # enforce hermitian symmetry after building
     return BasisSetRep(sm, basis, h)

--- a/src/Hamiltonians/abstract.jl
+++ b/src/Hamiltonians/abstract.jl
@@ -170,7 +170,7 @@ function build_sparse_matrix_from_LO(
     sort=false, kwargs...
 )
     # Set up `adds` as queue of addresses. Also returned as the basis.
-    adds = addr_or_vec isa AbstractArray ? [addr_or_vec...] : [addr_or_vec]
+    adds = addr_or_vec isa Union{AbstractArray,Tuple} ? [addr_or_vec...] : [addr_or_vec]
 
     T = eltype(ham)
     dict = Dict(add => i for (i, add) in enumerate(adds)) # Map from addresses to indices
@@ -385,7 +385,7 @@ function _bsr_ensure_symmetry(
     ::LOStructure, h::AbstractHamiltonian, addr_or_vec;
     sizelim=10^6, test_approx_symmetry=true, kwargs...
 )
-    single_addr = addr_or_vec isa AbstractArray ? addr_or_vec[1] : addr_or_vec
+    single_addr = addr_or_vec isa Union{AbstractArray,Tuple} ? addr_or_vec[1] : addr_or_vec
     if dimension(h, single_addr) > sizelim
         throw(ArgumentError("dimension larger than sizelim"))
     end
@@ -399,7 +399,7 @@ function _bsr_ensure_symmetry(
     ::IsHermitian, h::AbstractHamiltonian, addr_or_vec;
     sizelim=10^6, test_approx_symmetry=true, kwargs...
 )
-    single_addr = addr_or_vec isa AbstractArray ? addr_or_vec[1] : addr_or_vec
+    single_addr = addr_or_vec isa Union{AbstractArray,Tuple} ? addr_or_vec[1] : addr_or_vec
     if dimension(h, single_addr) > sizelim
         throw(ArgumentError("dimension larger than sizelim"))
     end

--- a/src/Hamiltonians/abstract.jl
+++ b/src/Hamiltonians/abstract.jl
@@ -310,7 +310,7 @@ performance.
 Providing an energy cutoff will skip the columns and rows with diagonal elements greater
 than `cutoff`. Alternatively, an arbitrary `filter` function can be used instead. These are
 not enabled by default. To generate the matrix truncated to the subspace spanned by the
-`addresses`, use `filter = _ -> false`.
+`addresses`, use `filter = Returns(false)`.
 
 Setting `sort` to `true` will sort the matrix rows and columns. This is useful when the
 order of the columns matters, e.g. when comparing matrices. Any additional keyword arguments

--- a/src/Interfaces/Interfaces.jl
+++ b/src/Interfaces/Interfaces.jl
@@ -19,6 +19,7 @@ Follow the links for the definitions of the interfaces!
 * [`random_offdiagonal`](@ref)
 * [`starting_address`](@ref)
 * [`LOStructure`](@ref)
+* [`allowed_address_type`](@ref)
 
 ## working with  [`AbstractDVec`](@ref)s and [`StochasticStyle`](@ref)
 * [`deposit!`](@ref)
@@ -48,7 +49,7 @@ export
     fciqmc_step!, sort_into_targets!
 export
     AbstractHamiltonian, diagonal_element, num_offdiagonals, get_offdiagonal, offdiagonals,
-    random_offdiagonal, starting_address,
+    random_offdiagonal, starting_address, allowed_address_type,
     LOStructure, IsDiagonal, IsHermitian, AdjointKnown, AdjointUnknown, has_adjoint
 
 include("stochasticstyles.jl")

--- a/src/Interfaces/hamiltonians.jl
+++ b/src/Interfaces/hamiltonians.jl
@@ -28,7 +28,7 @@ Methods that need to be implemented:
 Optional methods to implement:
 
 * [`LOStructure(::Type{typeof(lo)})`](@ref LOStructure): defaults to `AdjointUnknown`
-* [`dimension(::AbstractHamiltonian)`](@ref Main.Hamiltonians.dimension): defaults to
+* [`dimension(::AbstractHamiltonian, addr)`](@ref Main.Hamiltonians.dimension): defaults to
   dimension of address space
 * [`momentum(::AbstractHamiltonian)`](@ref Main.Hamiltonians.momentum): no default
 

--- a/src/Interfaces/hamiltonians.jl
+++ b/src/Interfaces/hamiltonians.jl
@@ -30,6 +30,8 @@ Optional methods to implement:
 * [`LOStructure(::Type{typeof(lo)})`](@ref LOStructure): defaults to `AdjointUnknown`
 * [`dimension(::AbstractHamiltonian, addr)`](@ref Main.Hamiltonians.dimension): defaults to
   dimension of address space
+* [`allowed_address_type(h::AbstractHamiltonian)`](@ref): defaults to
+  `typeof(starting_address(h))`
 * [`momentum(::AbstractHamiltonian)`](@ref Main.Hamiltonians.momentum): no default
 
 Provides:
@@ -49,6 +51,15 @@ See also [`Hamiltonians`](@ref Main.Hamiltonians), [`Interfaces`](@ref).
 abstract type AbstractHamiltonian{T} end
 
 Base.eltype(::AbstractHamiltonian{T}) where {T} = T
+
+"""
+    allowed_address_type(h::AbstractHamiltonian)
+Return the type of addresses that can be used with Hamiltonian `h`. Part of the
+[`AbstractHamiltonian`](@ref) interface. Defaults to `typeof(starting_address(h))`.
+
+Overload this function if the Hamiltonian can be used with addresses of different types.
+"""
+allowed_address_type(h::AbstractHamiltonian) = typeof(starting_address(h))
 
 """
     diagonal_element(ham, add)

--- a/src/Interfaces/hamiltonians.jl
+++ b/src/Interfaces/hamiltonians.jl
@@ -28,8 +28,8 @@ Methods that need to be implemented:
 Optional methods to implement:
 
 * [`LOStructure(::Type{typeof(lo)})`](@ref LOStructure): defaults to `AdjointUnknown`
-* [`dimension(::Type{T}, ::AbstractHamiltonian)`](@ref Main.Hamiltonians.dimension): defaults to dimension of address
-  space
+* [`dimension(::AbstractHamiltonian)`](@ref Main.Hamiltonians.dimension): defaults to
+  dimension of address space
 * [`momentum(::AbstractHamiltonian)`](@ref Main.Hamiltonians.momentum): no default
 
 Provides:

--- a/src/Interfaces/hamiltonians.jl
+++ b/src/Interfaces/hamiltonians.jl
@@ -60,6 +60,7 @@ Return the type of addresses that can be used with Hamiltonian `h`. Part of the
 Overload this function if the Hamiltonian can be used with addresses of different types.
 """
 allowed_address_type(h::AbstractHamiltonian) = typeof(starting_address(h))
+allowed_address_type(::AbstractMatrix) = Integer
 
 """
     diagonal_element(ham, add)

--- a/src/lomc.jl
+++ b/src/lomc.jl
@@ -109,6 +109,7 @@ function QMCState(
     post_step=(),
     maxlength= 2 * _n_walkers(v, s_strat) + 100, # padding for small walker numbers
 )
+    Hamiltonians.check_address_type(hamiltonian, keytype(v))
     # Set up r_strat and params
     r_strat = refine_r_strat(r_strat)
     if !isnothing(laststep)

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -1169,7 +1169,7 @@ end
         mat_cut = Matrix(bsr)
         @test mat_cut == mat_cut_manual
         # pass a basis and generate truncated BasisSetRep
-        bsrt = BasisSetRep(ham, bsr.basis; filter=_ -> false, sort=true)
+        bsrt = BasisSetRep(ham, bsr.basis; filter= Returns(false), sort=true)
         @test bsrt.basis == bsr.basis
         @test bsr.sm == bsrt.sm
         # pass addresses and generate reachable basis

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -718,8 +718,8 @@ end
     @test a.shift ≈ c.shift
 
     # MatrixHamiltonian
-    @test_throws AssertionError MatrixHamiltonian([1 2 3; 4 5 6])
-    @test_throws AssertionError MatrixHamiltonian(sm, starting_address = dim+1)
+    @test_throws ArgumentError MatrixHamiltonian([1 2 3; 4 5 6])
+    @test_throws ArgumentError MatrixHamiltonian(sm, starting_address = dim+1)
     # adjoint nonhermitian
     nonhermitian = MatrixHamiltonian([1 2; 4 5])
     @test LOStructure(nonhermitian) == AdjointKnown()

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -1186,7 +1186,7 @@ end
         ham = HubbardReal1D(near_uniform(BoseFS{10,2}))
         bsr = BasisSetRep(ham; sort=true)
         b = bsr.basis
-        @test [ham[i, j] for i in b, j in b] == Matrix(bsr_orig)
+        @test [ham[i, j] for i in b, j in b] == Matrix(bsr)
     end
 
     @testset "momentum blocking" begin

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -55,7 +55,7 @@ function test_hamiltonian_interface(H)
             end
         end
         @testset "dimension" begin
-            @test dimension(H) isa BigInt
+            @test dimension(H) isa Integer
             @test dimension(Float64, H) isa Float64
             @test dimension(Int, H) == dimension(H)
         end

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -55,9 +55,9 @@ function test_hamiltonian_interface(H)
             end
         end
         @testset "dimension" begin
-            @test dimension(H) isa Int
+            @test dimension(H) isa BigInt
             @test dimension(Float64, H) isa Float64
-            @test dimension(Int, H) === dimension(H)
+            @test dimension(Int, H) == dimension(H)
         end
     end
 end

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -1182,6 +1182,13 @@ end
         @test mat_cut == mat_cut_manual
     end
 
+    @testset "getindex" begin
+        ham = HubbardReal1D(near_uniform(BoseFS{10,2}))
+        bsr = BasisSetRep(ham; sort=true)
+        b = bsr.basis
+        @test [ham[i, j] for i in b, j in b] == Matrix(bsr_orig)
+    end
+
     @testset "momentum blocking" begin
         add1 = BoseFS((2,0,0,0))
         add2 = BoseFS((0,1,0,1))

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -59,6 +59,9 @@ function test_hamiltonian_interface(H)
             @test dimension(Float64, H) isa Float64
             @test dimension(Int, H) == dimension(H)
         end
+        @testset "allowed_address_type" begin
+            @test addr isa allowed_address_type(H)
+        end
     end
 end
 

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -1251,12 +1251,13 @@ end
         bsr = BasisSetRep(ham)
         basis = build_basis(ham)
         @test basis == bsr.basis
+        @test basis == build_basis(ham, basis) # passing multiple addresses
         # sorting
         basis = build_basis(ham, add; sort = true)
         @test basis == sort!(bsr.basis)
         # filtering
-        @test_throws ArgumentError build_basis(ham, add; max_size = 100)
-        @test_throws ArgumentError build_basis(ham, add; cutoff = -1)
+        @test_throws ArgumentError build_basis(ham, add; sizelim = 100)
+        @test length(build_basis(ham, add; cutoff = -1)) == 1 # no new addresses added
         cutoff = n * (n-1) / 4  # half maximum energy
         bsr = BasisSetRep(ham, add; cutoff)
         basis = build_basis(ham, add; cutoff)

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -1153,7 +1153,6 @@ end
 
     @testset "filtering" begin
         ham = HubbardReal1D(near_uniform(BoseFS{10,2}))
-        @test_throws ArgumentError BasisSetRep(ham; cutoff=19) # starting address cut off
         mat_orig = Matrix(ham; sort=true)
         mat_cut_index = diag(mat_orig) .< 30
         mat_cut_manual = mat_orig[mat_cut_index, mat_cut_index]

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -1215,6 +1215,8 @@ end
         @test !ishermitian(mat)
         @test_throws ArgumentError fix_approx_hermitian!(mat; test_approx_symmetry=true)
         @test !ishermitian(mat) # still not hermitian
+        fix_approx_hermitian!(mat; test_approx_symmetry=false)
+        @test ishermitian(mat) # now it is hermitian
 
         # sparse matrix
         Random.seed!(17)

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -55,7 +55,7 @@ function test_hamiltonian_interface(H)
             end
         end
         @testset "dimension" begin
-            @test dimension(H) isa Integer
+            @test dimension(H) ≥ dimension(H, starting_address(H))
             @test dimension(Float64, H) isa Float64
             @test dimension(Int, H) == dimension(H)
         end
@@ -154,6 +154,9 @@ end
 
         MatrixHamiltonian([1 2;2 0]),
         GutzwillerSampling(MatrixHamiltonian([1.0 2.0;2.0 0.0]); g=0.3),
+        Rimu.Hamiltonians.TransformUndoer(
+            GutzwillerSampling(MatrixHamiltonian([1.0 2.0; 2.0 0.0]); g=0.3)
+        ),
 
         Transcorrelated1D(CompositeFS(FermiFS((0,0,1,1,0)), FermiFS((0,1,1,0,0))); t=2),
         Transcorrelated1D(CompositeFS(FermiFS((0,0,1,0)), FermiFS((0,1,1,0))); v=3, v_ho=1),

--- a/test/Interfaces.jl
+++ b/test/Interfaces.jl
@@ -30,6 +30,8 @@ using Test
     @test LOStructure(ham) == AdjointKnown()
     @test has_adjoint(ham)
 end
+
+# using lomc! with a matrix is not documented and may be removed in the future
 @testset "lomc! with matrix" begin
     ham = [1 1 2 3 2;
            2 0 2 2 3;


### PR DESCRIPTION
# Simplify `dimension` and allow passing a basis to `BasisSetRep`

- Interface change for `dimension()`
   - `dimension()` no longer requires passing a type.
   - extend `dimension` for new Hamiltonians by defining methods for `dimension(h::MyNewHamiltonian, addr)`.
- New function `allowed_address_type` in `AbstractHamiltonian` interface.
- A vector of addresses (basis) can be passed into `BasisSetRep` and `build_basis`.
- The `filter` keyword in `BasisSetRep` and `build_basis` no longer applies to the passed addresses.
- The `sizehint`s for `BasisSetRep` are now opt-in
- `build_basis` now accepts keyword argument `sizelim` instead of `max_size`
-  fixed bug in `getindex` for `AbstractHamiltonians`
