### PR TITLE
interaction strength for HO hamiltonians

### DIFF
--- a/src/Hamiltonians/HOCartesianEnergyConserved.jl
+++ b/src/Hamiltonians/HOCartesianEnergyConserved.jl
@@ -102,9 +102,12 @@ end
 
 Implements a bosonic harmonic oscillator in Cartesian basis with contact interactions 
 ```math
-\\hat{H} = \\sum_{i} \\epsilon_i n_i + \\frac{g}{2}\\sum_{ijkl} V_{ijkl} a^†_i a^†_j a_k a_l.
+\\hat{H} = \\sum_{i} \\epsilon_i n_i + \\frac{g}{2}\\sum_{ijkl} V_{ijkl} a^†_i a^†_j a_k a_l ,
 ```
-For a ``D``-dimensional harmonic oscillator indices ``\\mathbf{i}, mathbf{j}, \\ldots`` 
+with the additional restriction that the interactions only couple states with the same
+non-interacting energy. See [`HOCartesianEnergyConservedPerDim`](@ref) for a model 
+that conserves energy separately per spatial dimension.
+For a ``D``-dimensional harmonic oscillator indices ``\\mathbf{i}, \\mathbf{j}, \\ldots``
 are ``D``-tuples. The energy scale is defined by the first dimension i.e. ``\\hbar \\omega_x`` 
 so that single particle energies are 
 ```math

--- a/src/Hamiltonians/HOCartesianEnergyConserved.jl
+++ b/src/Hamiltonians/HOCartesianEnergyConserved.jl
@@ -100,21 +100,21 @@ end
 """
     HOCartesianEnergyConserved(addr; S, η, g = 1.0, interaction_only = false)
 
-Implements a bosonic harmonic oscillator in Cartesian basis with contact interactions.
+Implements a bosonic harmonic oscillator in Cartesian basis with contact interactions 
 ```math
-\\hat{H} = \\sum_{i} \\epsilon_i n_i + \\frac{g}{2}\\sum_{ijkl} V_{ijkl} a^†_i a^†_j a_k a_l
+\\hat{H} = \\sum_{i} \\epsilon_i n_i + \\frac{g}{2}\\sum_{ijkl} V_{ijkl} a^†_i a^†_j a_k a_l.
 ```
-Indices ``\\mathbf{i}, \\ldots`` are ``D``-tuples for a ``D``-dimensional harmonic oscillator. 
-The energy scale is defined by the first dimension i.e. ``\\hbar \\omega_x`` so that 
-single particle energies are 
+For a ``D``-dimensional harmonic oscillator indices ``\\mathbf{i}, mathbf{j}, \\ldots`` 
+are ``D``-tuples. The energy scale is defined by the first dimension i.e. ``\\hbar \\omega_x`` 
+so that single particle energies are 
 ```math
-    \\frac{\\epsilon_\\mathbf{i}}{\\hbar \\omega_x} = (i_x + 1/2) + \\eta_y (i_y+1/2) + \\ldots``.
+    \\frac{\\epsilon_\\mathbf{i}}{\\hbar \\omega_x} = (i_x + 1/2) + \\eta_y (i_y+1/2) + \\ldots.
 ```
 The factors ``\\eta_y, \\ldots`` allow for anisotropic trapping geometries and are assumed to 
 be greater than `1` so that ``\\omega_x`` is the smallest trapping frequency.
 
-Matrix elements ``V_{\\mathbf{ijkl}}`` are for a contact interaction calculated in this basis using 
-first-order degenerate perturbation theory.
+Matrix elements ``V_{\\mathbf{ijkl}}`` are for a contact interaction calculated in this 
+basis using first-order degenerate perturbation theory.
 ```math
     V_{\\mathbf{ijkl}} = \\delta_{\\mathbf{i} + \\mathbf{j}}^{\\mathbf{k} + \\mathbf{l}} 
         \\prod_{d \\in x, y,\\ldots} \\mathcal{I}(i_d,j_d,k_d,l_d),
@@ -198,7 +198,8 @@ function HOCartesianEnergyConserved(
         energies = reshape(map(x -> dot(aspect1, Tuple(x) .- 1/2), states), P)
     end
 
-    u = sqrt(prod(aspect1)) * g / 2
+    # the aspect ratio appears from a change of variable when calculating the interaction integrals
+    u = g / (2 * sqrt(prod(aspect1)))
 
     max_level = S_sort[1] - 1
     r = 0:max_level
@@ -208,8 +209,13 @@ function HOCartesianEnergyConserved(
 end
 
 function Base.show(io::IO, h::HOCartesianEnergyConserved)
-    print(io, "HOCartesianEnergyConserved($(h.addr); S=$(h.S), η=$(h.aspect1), u=$(h.u))")
+    flag = iszero(h.energies)
+    # invert the scaling of u parameter
+    g = h.u * 2 * sqrt(prod(h.aspect1))
+    print(io, "HOCartesianEnergyConserved($(h.addr); S=$(h.S), η=$(h.aspect1), g=$g, interaction_only=$flag)")
 end
+
+Base.:(==)(H::HOCartesianEnergyConserved, G::HOCartesianEnergyConserved) = all(map(p -> getproperty(H, p) == getproperty(G, p), propertynames(H)))
 
 function starting_address(h::HOCartesianEnergyConserved)
     return h.addr

--- a/src/Hamiltonians/HOCartesianEnergyConservedPerDim.jl
+++ b/src/Hamiltonians/HOCartesianEnergyConservedPerDim.jl
@@ -81,11 +81,11 @@ Implements a bosonic harmonic oscillator in Cartesian basis with contact interac
 ```math
 \\hat{H} = \\sum_{i} ϵ_i n_i + \\frac{g}{2}\\sum_{ijkl} V_{ijkl} a^†_i a^†_j a_k a_l,
 ```
-with the adiitional restriction that the interactions only couple states with the same
+with the additional restriction that the interactions only couple states with the same
 energy in each dimension separately. See [`HOCartesianEnergyConserved`](@ref) for a model that 
 conserves total energy.
 
-For a ``D``-dimensional harmonic oscillator indices ``\\mathbf{i}, mathbf{j}, \\ldots`` 
+For a ``D``-dimensional harmonic oscillator indices ``\\mathbf{i}, \\mathbf{j}, \\ldots`` 
 are ``D``-tuples. The energy scale is defined by the first dimension i.e. ``\\hbar \\omega_x`` 
 so that single particle energies are 
 ```math

--- a/src/Hamiltonians/HOCartesianEnergyConservedPerDim.jl
+++ b/src/Hamiltonians/HOCartesianEnergyConservedPerDim.jl
@@ -18,7 +18,7 @@ function four_oscillator_integral_1D(i, j, k, l; max_level = typemax(Int))
     p = sqrt(gamma(k + 1) * gamma(l + 1)) / sqrt(2 * gamma(i + 1) * gamma(j + 1)) / pi^2
     s = sum(gamma(t + 1/2) * gamma(i - t + 1/2) * gamma(j - t + 1/2) / (gamma(t + 1) * gamma(k - t + 1) * gamma(l - t + 1)) for t in 0 : min_kl)
     
-    return p * s / 2
+    return p * s
 end
 
 """
@@ -79,17 +79,17 @@ end
 
 Implements a bosonic harmonic oscillator in Cartesian basis with contact interactions 
 ```math
-\\hat{H} = \\sum_{i} ϵ_i n_i + \\frac{g}{2}\\sum_{ijkl} V_{ijkl} a^†_i a^†_j a_k a_l
+\\hat{H} = \\sum_{i} ϵ_i n_i + \\frac{g}{2}\\sum_{ijkl} V_{ijkl} a^†_i a^†_j a_k a_l,
 ```
 with the adiitional restriction that the interactions only couple states with the same
 energy in each dimension separately. See [`HOCartesianEnergyConserved`](@ref) for a model that 
 conserves total energy.
 
-Indices ``\\mathbf{i}, \\ldots`` are ``D``-tuples for a ``D``-dimensional harmonic oscillator. 
-The energy scale is defined by the first dimension i.e. ``\\hbar \\omega_x`` so that 
-single particle energies are 
+For a ``D``-dimensional harmonic oscillator indices ``\\mathbf{i}, mathbf{j}, \\ldots`` 
+are ``D``-tuples. The energy scale is defined by the first dimension i.e. ``\\hbar \\omega_x`` 
+so that single particle energies are 
 ```math
-    \\frac{\\epsilon_\\mathbf{i}}{\\hbar \\omega_x} = (i_x + 1/2) + \\eta_y (i_y+1/2) + \\ldots``.
+    \\frac{\\epsilon_\\mathbf{i}}{\\hbar \\omega_x} = (i_x + 1/2) + \\eta_y (i_y+1/2) + \\ldots.
 ```
 The factors ``\\eta_y, \\ldots`` allow for anisotropic trapping geometries and are assumed to 
 be greater than `1` so that ``\\omega_x`` is the smallest trapping frequency.
@@ -162,7 +162,8 @@ function HOCartesianEnergyConservedPerDim(
         energies = reshape(map(x -> dot(aspect1, Tuple(x) .- 1/2), states), P)
     end
 
-    u = sqrt(prod(aspect1)) * g / 2
+    # the aspect ratio appears from a change of variable when calculating the interaction integrals
+    u = g / (2 * sqrt(prod(aspect1)))
 
     M = maximum(S)
     bigrange = 0:M-1
@@ -176,8 +177,13 @@ function HOCartesianEnergyConservedPerDim(
 end
 
 function Base.show(io::IO, h::HOCartesianEnergyConservedPerDim)
-    print(io, "HOCartesianEnergyConservedPerDim($(h.addr); S=$(h.S), η=$(h.aspect1), u=$(h.u))")
+    flag = iszero(h.energies)
+    # invert the scaling of u parameter
+    g = h.u * 2 * sqrt(prod(h.aspect1))
+    print(io, "HOCartesianEnergyConservedPerDim($(h.addr); S=$(h.S), η=$(h.aspect1), g=$g, interaction_only=$flag)")
 end
+
+Base.:(==)(H::HOCartesianEnergyConservedPerDim, G::HOCartesianEnergyConservedPerDim) = all(map(p -> getproperty(H, p) == getproperty(G, p), propertynames(H)))
 
 function starting_address(h::HOCartesianEnergyConservedPerDim)
     return h.addr

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -1340,6 +1340,8 @@ end
         b2 = Hamiltonians.find_Ebounds(3, 2, S, H.aspect)
         @test b1 == b2
         @test !(b1 === b2)
+
+        @test eval(Meta.parse(repr(H))) == H
     end
 
     @testset "HOCartesianEnergyConservedPerDim" begin
@@ -1374,7 +1376,9 @@ end
         H = HOCartesianEnergyConservedPerDim(addr; S, η = (1,2,3))
         @test H.aspect1 == (1.0,2.0,3.0)
         H = HOCartesianEnergyConservedPerDim(addr; S, η = 2)
-        @test H.aspect1 == (1.0,2.0,2.0)        
+        @test H.aspect1 == (1.0,2.0,2.0)
+
+        @test eval(Meta.parse(repr(H))) == H
     end
 
     @testset "Angular momentum" begin

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -1364,7 +1364,7 @@ end
 
         # interaction matrix elements
         @test count(H.vtable .== 0) == 70
-        @test sum(H.vtable) ≈ 3.3630246382916664
+        @test sum(H.vtable) ≈ 2 * 3.3630246382916664
 
         # aspect ratio
         S = (4,2,2)


### PR DESCRIPTION
Changes to `HOCartesianEnergyConserved` and `HOCartesianEnergyConservedPerDim`
- Interaction strength now correctly scales with aspect ratio
- fixed `show` so output can be used as constructor in REPL
- removed factor of 1/2 from `four_oscillator_integral_1D`, (now consistent w/ Eq 14 in Papenbrock 2002)
- docstring tweaks