### PR TITLE
Compress DataFrames

### DIFF
--- a/src/RimuIO.jl
+++ b/src/RimuIO.jl
@@ -29,7 +29,7 @@ Save dataframe in Arrow format.
 
 Keyword arguments are passed on to
 [`Arrow.write`](https://arrow.apache.org/julia/dev/reference/#Arrow.write). Compression is
-enabled by default for large `DataFrame`s.
+enabled by default for large `DataFrame`s (over 10,000 rows).
 
 See also [`RimuIO.load_df`](@ref).
 """

--- a/src/RimuIO.jl
+++ b/src/RimuIO.jl
@@ -24,14 +24,28 @@ ArrowTypes.toarrow(a::Complex) = (a.re, a.im)
 ArrowTypes.fromarrow(::Type{Complex{T}}, t::Tuple{T,T}) where {T} = Complex{T}(t...)
 
 """
-    RimuIO.save_df(filename, df::DataFrame)
+    RimuIO.save_df(filename, df::DataFrame; kwargs...)
 Save dataframe in Arrow format.
+
+Keyword arguments are passed on to
+[`Arrow.write`](https://arrow.apache.org/julia/dev/reference/#Arrow.write). Compression is
+enabled by default for large `DataFrame`s.
+
+See also [`RimuIO.load_df`](@ref).
 """
-save_df(filename, df::DataFrame) = Arrow.write(filename, df)
+function save_df(
+    filename, df::DataFrame;
+    compress = size(df)[1]>10_000 ? :zstd : nothing,
+    kwargs...
+)
+    Arrow.write(filename, df; compress, kwargs...)
+end
 
 """
     RimuIO.load_df(filename) -> DataFrame
 Load Arrow file into dataframe.
+
+See also [`RimuIO.save_df`](@ref).
 """
 load_df(filename) = DataFrame(Arrow.Table(filename))
 

--- a/src/strategies_and_params/reportingstrategy.jl
+++ b/src/strategies_and_params/reportingstrategy.jl
@@ -189,31 +189,78 @@ end
 """
     ReportToFile(; kwargs...) <: ReportingStrategy
 
-Reporting strategy that writes the report directly to a file. Useful when dealing with long
+[`ReportingStrategy`](@ref) that writes the report directly to a file in the
+[`Arrow`](https://arrow.apache.org/julia/dev/) format. Useful when dealing with long
 jobs or large numbers of replicas, when the report can incur a significant memory cost.
+
+The arrow file can be read back in with [`load_df(filename)`](@ref) or
+`using Arrow; Arrow.Table(filename)`.
 
 # Keyword arguments
 
-* `filename`: the file to report to. If the file already exists, a new file is created.
-* `reporting_interval`: interval between simulation steps that are reported to a `DataFrame`.
+* `filename = "out.arrow"`: the file to report to. If the file already exists, a new file is
+  created.
+* `reporting_interval = 1`: interval between simulation steps that are reported.
 * `chunk_size = 1000`: the size of each chunk that is written to the file. A `DataFrame` of
   this size is collected in memory and written to disk. When saving, an info message is also
   printed to `io`.
-* `save_if = `[`is_mpi_root()`](@ref Rimu.RMPI.is_mpi_root): if this value is true, save the report, otherwise
-  ignore it.
+* `save_if = `[`is_mpi_root()`](@ref Rimu.RMPI.is_mpi_root): if this value is true, save the
+  report, otherwise ignore it.
 * `return_df = false`: if this value is true, read the file and return the data frame at the
   end of computation. Otherwise, an empty `DataFrame` is returned.
 * `io = stdout`: The `IO` to print messages to. Set to `devnull` if you don't want to see
   messages printed out.
+* `compress = :zstd`: compression algorithm to use. Can be `:zstd`, `:lz4` or `nothing`.
+
+See also [`load_df`](@ref) and [`save_df`](@ref).
 """
-@with_kw struct ReportToFile <: ReportingStrategy
+mutable struct ReportToFile{C} <: ReportingStrategy
     filename::String
-    reporting_interval::Int = 1
-    chunk_size::Int = 1000
-    save_if::Bool = RMPI.is_mpi_root()
-    return_df::Bool = false
-    io::IO = stdout
+    reporting_interval::Int
+    chunk_size::Int
+    save_if::Bool
+    return_df::Bool
+    io::IO
+    compress::C # Arrow.ZstdCompressor, Arrow.LZ4FrameCompressor or nothing
+    writer::Union{Arrow.Writer, Nothing}
 end
+
+function ReportToFile(;
+    filename = "out.arrow",
+    reporting_interval = 1,
+    chunk_size = 1000,
+    save_if = RMPI.is_mpi_root(),
+    return_df = false,
+    io = stdout,
+    compress = :zstd,
+)
+    # Note: This code uses undocumented internal features of Arrow.jl to initialise the
+    # compressor codecs and might break upon updates.
+    # A safer (but slower) way would be to pass the symbols :zstd or :lz4 to `Arrow.write`.
+    if !(compress isa Union{Nothing, Arrow.ZstdCompressor, Arrow.LZ4FrameCompressor})
+        if compress == :zstd
+            compress = Arrow.zstd_compressor()[]
+        elseif compress == :lz4
+            compress = Arrow.lz4_frame_compressor()[]
+        else
+            throw(ArgumentError("compress must be nothing, :zstd or :lz4"))
+        end
+    end
+    return ReportToFile(
+        filename,
+        reporting_interval,
+        chunk_size,
+        save_if,
+        return_df,
+        io,
+        compress,
+        nothing
+    )
+end
+
+# helper function to check if the writer is open
+_isopen(s::ReportToFile) = !isnothing(s.writer) && !s.writer.isclosed
+
 function refine_r_strat(s::ReportToFile)
     if s.save_if
         # If filename exists, add -1 to the end of it. If that exists as well,
@@ -230,7 +277,7 @@ function refine_r_strat(s::ReportToFile)
         end
         if s.filename ≠ new_filename
             println(s.io, "File `$(s.filename)` exists.")
-            s = @set s.filename = new_filename
+            s.filename = new_filename
         end
         println(s.io, "Saving report to `$(s.filename)`.")
     end
@@ -246,24 +293,26 @@ function report_after_step(s::ReportToFile, step, report, state)
         # Report some stats:
         print_stats(s.io, step, state)
 
-        if isfile(s.filename)
-            Arrow.append(s.filename, report.data)
-        else
-            Arrow.write(s.filename, report.data; file=false)
+        if !_isopen(s)
+            # If the writer is closed or absent, we need to create a new one
+            s.writer = open(Arrow.Writer, s.filename; compress=s.compress)
         end
+        Arrow.write(s.writer, report.data)
         empty!(report)
     end
 end
+# We rely on this function to be called to close the writer.
 function finalize_report!(s::ReportToFile, report)
     if s.save_if
         println(s.io, "Finalizing.")
         if !isempty(report)
-            if isfile(s.filename)
-                Arrow.append(s.filename, report.data)
-            else
-                Arrow.write(s.filename, report.data; file=false)
+            if !_isopen(s)
+                # If the writer is closed or absent, we need to create a new one
+                s.writer = open(Arrow.Writer, s.filename; compress=s.compress)
             end
+            Arrow.write(s.writer, report.data)
         end
+        close(s.writer) # close the writer
         if s.return_df
             return DataFrame(Arrow.Table(s.filename))
         end

--- a/src/strategies_and_params/reportingstrategy.jl
+++ b/src/strategies_and_params/reportingstrategy.jl
@@ -221,7 +221,7 @@ mutable struct ReportToFile{C} <: ReportingStrategy
     save_if::Bool
     return_df::Bool
     io::IO
-    compress::C # Arrow.ZstdCompressor, Arrow.LZ4FrameCompressor or nothing
+    compress::C # Symbol, Arrow.ZstdCompressor, Arrow.LZ4FrameCompressor or nothing
     writer::Union{Arrow.Writer, Nothing}
 end
 
@@ -234,15 +234,8 @@ function ReportToFile(;
     io = stdout,
     compress = :zstd,
 )
-    # Note: This code uses undocumented internal features of Arrow.jl to initialise the
-    # compressor codecs and might break upon updates.
-    # A safer (but slower) way would be to pass the symbols :zstd or :lz4 to `Arrow.write`.
     if !(compress isa Union{Nothing, Arrow.ZstdCompressor, Arrow.LZ4FrameCompressor})
-        if compress == :zstd
-            compress = Arrow.zstd_compressor()[]
-        elseif compress == :lz4
-            compress = Arrow.lz4_frame_compressor()[]
-        else
+        if !(compress == :zstd || compress == :lz4)
             throw(ArgumentError("compress must be nothing, :zstd or :lz4"))
         end
     end

--- a/test/lomc.jl
+++ b/test/lomc.jl
@@ -311,24 +311,30 @@ using Logging
             rm("test-report-1.arrow"; force=true)
             rm("test-report-2.arrow"; force=true)
             rm("test-report-3.arrow"; force=true)
+            rm("test-report-nc.arrow"; force=true)
+            rm("test-report-lz4.arrow"; force=true)
 
             r_strat = ReportToFile(filename="test-report.arrow", io=devnull, save_if=false)
             df = lomc!(H, copy(dv); r_strat, laststep=100).df
             @test !isfile("test-report.arrow")
+            @test Rimu._isopen(r_strat) == false
 
             r_strat = ReportToFile(filename="test-report.arrow", io=devnull)
             df = lomc!(H, copy(dv); r_strat, laststep=100).df
             @test isempty(df)
+            @test Rimu._isopen(r_strat) == false
             df1 = RimuIO.load_df("test-report.arrow")
 
             r_strat = ReportToFile(filename="test-report.arrow", io=devnull, chunk_size=5)
             df = lomc!(H, copy(dv); r_strat, laststep=100).df
             @test isempty(df)
+            @test Rimu._isopen(r_strat) == false
             df2 = RimuIO.load_df("test-report-1.arrow")
 
             r_strat = ReportToFile(filename="test-report.arrow", io=devnull, return_df=true)
             df3 = lomc!(H, copy(dv); r_strat, laststep=100).df
             @test isempty(df)
+            @test Rimu._isopen(r_strat) == false
             df4 = RimuIO.load_df("test-report-2.arrow")
 
             @test df1.shift ≈ df2.shift
@@ -345,11 +351,39 @@ using Logging
             @test df6.shift ≈ df5.shift
             @test df6.norm ≈ df5.norm
 
+            # ReportToFile with compression
+            @test_throws ArgumentError ReportToFile(compress=false)
+
+            r_strat = ReportToFile(
+                filename="test-report-nc.arrow", io=devnull, return_df=true,
+                compress=nothing
+            )
+            df7 = lomc!(H, copy(dv); r_strat, laststep=100).df
+            @test isempty(df)
+            @test Rimu._isopen(r_strat) == false
+            @test df7 == RimuIO.load_df("test-report-nc.arrow")
+
+
+            r_strat = ReportToFile(
+                filename="test-report-lz4.arrow", io=devnull, return_df=true,
+                compress=:lz4
+            )
+            df8 = lomc!(H, copy(dv); r_strat, laststep=100).df
+            @test isempty(df)
+            @test Rimu._isopen(r_strat) == false
+            @test df8 == RimuIO.load_df("test-report-lz4.arrow")
+
+            @test filesize("test-report-lz4.arrow") < filesize("test-report-nc.arrow")
+            @test filesize("test-report.arrow") < filesize("test-report-lz4.arrow")
+            # The default compression `:zstd` produces the smallest files.
+
             # Clean up.
             rm("test-report.arrow"; force=true)
             rm("test-report-1.arrow"; force=true)
             rm("test-report-2.arrow"; force=true)
             rm("test-report-3.arrow"; force=true)
+            rm("test-report-nc.arrow"; force=true)
+            rm("test-report-lz4.arrow"; force=true)
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -88,6 +88,17 @@ end
         @test df == df2
 
         rm(file)
+
+        # test compression
+        r = 10_005
+        df2 = DataFrame(a = collect(1:r), b = rand(1:30,r))
+        RimuIO.save_df(file, df2)
+        compressed = filesize(file)
+        rm(file)
+        RimuIO.save_df(file, df2, compress=nothing)
+        uncompressed = filesize(file)
+        rm(file)
+        @test compressed < uncompressed
     end
     @testset "save_dvec, load_dvec" begin
         # BSON is currently broken on 1.8


### PR DESCRIPTION
Adds options to allow writing compressed `Arrow` files for time series data with `save_df` and `ReportToFile`. 

Time series data is now saved in compressed `Arrow` format files by default using the [`zstd`](https://en.wikipedia.org/wiki/Zstd) compression codec. This leads to impressively reduced file size (factor 8.6 in benchmarks).
