### PR TITLE
FroehlichPolaron and number non-conserving Fock states

### DIFF
--- a/docs/src/addresses.md
+++ b/docs/src/addresses.md
@@ -8,7 +8,7 @@ implementations for Bosonic, Fermionic, and mixed [Fock
 States](https://en.wikipedia.org/wiki/Fock_state).
 
 When implementing a new address type, care must be taken to make them space-efficient and
-stack-allocated - avoid using arrays to represent your addresses at all costs!
+stack-allocated - avoid using (heap-allocated) arrays to represent your addresses at all costs!
 
 ## Fock addresses
 
@@ -19,7 +19,7 @@ straightforward to implement efficient Hamiltonians.
 
 ```@autodocs
 Modules = [BitStringAddresses]
-Pages = ["fockaddress.jl","bosefs.jl","fermifs.jl","multicomponent.jl"]
+Pages = ["fockaddress.jl","bosefs.jl","fermifs.jl","multicomponent.jl","onrfs.jl"]
 Private = false
 ```
 

--- a/docs/src/addresses.md
+++ b/docs/src/addresses.md
@@ -12,8 +12,13 @@ stack-allocated - avoid using (heap-allocated) arrays to represent your addresse
 
 ## Fock addresses
 
-Rimu provides a variety of address implementations (see below) that should make it
-straightforward to implement efficient Hamiltonians.
+Rimu provides a variety of address implementations that should make it
+straightforward to implement efficient Hamiltonians. Examples are:
+
+- [`BoseFS`](@ref) Single-component bosonic Fock state with fixed particle and mode number.
+- [`FermiFS`](@ref) Single-component fermionic Fock state with fixed particle and mode number.
+- [`CompositeFS`](@ref) Multi-component Fock state composed of the above types.
+- [`ONRFS`](@ref) Single-component bosonic Fock state with a fixed number of modes. The number of particles is not part of the type and can be changed by operators.
 
 ### Fock address API
 

--- a/docs/src/hamiltonians.md
+++ b/docs/src/hamiltonians.md
@@ -73,6 +73,7 @@ HOCartesianCentralImpurity
 ```@docs
 MatrixHamiltonian
 Transcorrelated1D
+FroehlichPolaron
 ```
 
 ### Convenience functions

--- a/src/BitStringAddresses/BitStringAddresses.jl
+++ b/src/BitStringAddresses/BitStringAddresses.jl
@@ -14,6 +14,7 @@ using Base.Cartesian
 
 export AbstractFockAddress, SingleComponentFockAddress, BoseFS, BoseFS2C, FermiFS
 export CompositeFS, FermiFS2C, time_reverse
+export ONRFS
 export BoseFSIndex, FermiFSIndex
 export BitString, SortedParticleList
 export num_particles, num_modes, num_components
@@ -28,5 +29,6 @@ include("sortedparticlelist.jl")
 include("bosefs.jl")
 include("fermifs.jl")
 include("multicomponent.jl")
+include("onrfs.jl")
 
 end

--- a/src/BitStringAddresses/bosefs.jl
+++ b/src/BitStringAddresses/bosefs.jl
@@ -98,6 +98,8 @@ function BoseFS(onr::Union{AbstractArray,Tuple})
     N = sum(onr)
     return BoseFS{N,M}(onr)
 end
+BoseFS(vals::Integer...) = BoseFS(vals)
+BoseFS{N,M}(vals::Integer...) where {N,M} = BoseFS{N,M}(vals)
 
 BoseFS(M::Integer, pairs::Pair...) = BoseFS(M, pairs)
 BoseFS(M::Integer, pairs) = BoseFS(sparse_to_onr(M, pairs))
@@ -112,7 +114,7 @@ function print_address(io::IO, b::BoseFS{N,M}; compact=false) where {N,M}
     elseif b.bs isa SortedParticleList
         print(io, "BoseFS{$N,$M}(", onr_sparse_string(onr(b)), ")")
     else
-        print(io, "BoseFS{$N,$M}(", tuple(onr(b)...), ")")
+        print(io, "BoseFS{$N,$M}", tuple(onr(b)...))
     end
 end
 

--- a/src/BitStringAddresses/fermifs.jl
+++ b/src/BitStringAddresses/fermifs.jl
@@ -98,6 +98,8 @@ function FermiFS(onr::Union{AbstractArray,Tuple})
     N = sum(onr)
     return FermiFS{N,M}(onr)
 end
+FermiFS(vals::Integer...) = FermiFS(vals)
+FermiFS{N,M}(vals::Integer...) where {N,M} = FermiFS{N,M}(vals)
 
 # Sparse constructors
 FermiFS(M::Integer, pairs::Pair...) = FermiFS(M, pairs)
@@ -113,7 +115,7 @@ function print_address(io::IO, f::FermiFS{N,M}; compact=false) where {N,M}
     elseif f.bs isa SortedParticleList
         print(io, "FermiFS{$N,$M}(", onr_sparse_string(onr(f)), ")")
     else
-        print(io, "FermiFS{$N,$M}(", tuple(onr(f)...), ")")
+        print(io, "FermiFS{$N,$M}", tuple(onr(f)...))
     end
 end
 

--- a/src/BitStringAddresses/fockaddress.jl
+++ b/src/BitStringAddresses/fockaddress.jl
@@ -186,65 +186,6 @@ See [`SingleComponentFockAddress`](@ref).
 """
 excitation
 
-# Non-optimized version generic version that accepts integer creation and destruction
-# indices
-function excitation(
-    fs::SingleComponentFockAddress, c::NTuple{<:Any,Int}, d::NTuple{<:Any,Int}
-)
-    return onr_excitation(onr(fs), fs, c, d)
-end
-
-"""
-    onr_excitation(onrep, fs::ONRFS, c::NTuple{<:Any,Int}, d::NTuple{<:Any,Int})
-
-Apply the creation and destruction operators to the Fock state defined by the occupation
-number representation `onrep` and `typeof(fs)` and return the new address and the
-prefactor of the resulting state. This type of excitation may change the particle number
-if the address type `typeof(fs)` is not number conserving.
-"""
-function onr_excitation(
-    onrep, fs::T, c::NTuple{<:Any,Int}, d::NTuple{<:Any,Int}
-) where {BITS, T<:ONRFS{BITS}}
-    num_ds, onrep_d_applied = destroy_from_onr(onrep, d)
-    iszero(num_ds) && return fs, 0.0 # annihilation of vacuum
-
-    num_cs, onrep_c_applied = create_from_onr(onrep_d_applied, c)
-    all(x -> x < 1<<BITS, onrep_c_applied) || return fs, 0.0 # illegal address
-
-    return T(onrep_c_applied), sqrt(num_cs * num_ds)
-end
-# TODO: optimize and remove allocations
-
-"""
-    destroy_from_onr(onr, destructions) -> factor, new_onr
-
-Apply destruction operators to an occupation number representation `onr`.
-"""
-@inline function destroy_from_onr(onr, destructions)
-    monr = MVector(onr)
-    factor = 1
-    for i in destructions
-        factor *= monr[i]
-        monr[i] -= 1
-    end
-    return factor, SVector(monr)
-end
-
-"""
-    create_from_onr(onr, creations) -> factor, new_onr
-
-Apply creation operators to an occupation number representation `onr`.
-"""
-@inline function create_from_onr(onr, creations)
-    monr = MVector(onr)
-    factor = 1
-    for i in creations
-        monr[i] += 1
-        factor *= monr[i]
-    end
-    return factor, SVector(monr)
-end
-
 """
     OccupiedModeMap(add) <: AbstractVector
 

--- a/src/BitStringAddresses/fockaddress.jl
+++ b/src/BitStringAddresses/fockaddress.jl
@@ -210,7 +210,7 @@ function onr_excitation(onrep, fs::T, c::NTuple{<:Any,Int}, d::NTuple{<:Any,Int}
     num_cs = prod(onrep_c_applied[i] for i in c; init=1.0)
     return T(onrep_c_applied), sqrt(num_cs * num_ds)
 end
-
+# TODO: optimize and remove allocations
 
 """
     destroy_from_onr(onr, destructions)
@@ -449,7 +449,8 @@ julia> fs"|0 1 2 0⟩" => 1 # Copied from above printout
 BoseFS{3,4}((0, 1, 2, 0)) => 1
 ```
 
-See also [`FermiFS`](@ref), [`BoseFS`](@ref), [`CompositeFS`](@ref), [`FermiFS2C`](@ref).
+See also [`FermiFS`](@ref), [`BoseFS`](@ref), [`CompositeFS`](@ref), [`FermiFS2C`](@ref),
+[`ONRFS`](@ref).
 """
 macro fs_str(str)
     return parse_address(str)

--- a/src/BitStringAddresses/onrfs.jl
+++ b/src/BitStringAddresses/onrfs.jl
@@ -1,0 +1,67 @@
+"""
+    ONRFS{B,M,S} <: SingleComponentFockAddress{missing,M}
+
+Address type that represents a bosonic Fock state with an indeterminate number of particles
+in `M` modes. Each mode can be occupied by at most ``2^B-2`` particles. The number of
+particles can be obtained by [`num_particles`](@ref) but is runtime information and not part
+of the type, in contrast to [`BoseFS`](@ref). This makes this type suitable for representing
+Fock states with number-nonconcerving Hamiltonians.
+"""
+struct ONRFS{BITS,M,S} <: SingleComponentFockAddress{missing,M}
+    bs::S
+end
+
+@inline function ONRFS{BITS}(onr::Union{SVector{M},MVector{M},NTuple{M}}) where {BITS,M}
+    bs = onrbs_from_onr(onr, Val(BITS))
+    return ONRFS{BITS,M,typeof(bs)}(bs)
+end
+
+function ONRFS(onr, max_n)
+    BITS = ceil(Int, log2(max_n+1))
+    return ONRFS{BITS}(onr)
+end
+
+@inline function onrbs_from_onr(
+    onr::Union{SVector{M},MVector{M},NTuple{M}}, ::Val{BITS}
+) where {M,BITS}
+    B = BITS * M # number of bits in the bitstring
+    if B ≤ 8
+        T = UInt8
+    elseif B ≤ 16
+        T = UInt16
+    elseif B ≤ 32
+        T = UInt32
+    elseif B ≤ 64
+        T = UInt64
+    elseif B ≤ 128
+        T = UInt128
+    else
+        T = BigInt
+    end
+    val = zero(T)
+    for i in 1:M
+        val |= T(onr[i]) << (BITS*(i-1))
+    end
+    return BitString{B}(val)
+end
+
+function onr(ofs::ONRFS{BITS,M,S}) where {BITS,M,B,C,S<:BitString{B,C}}
+    # onr = SVector{M}(ofs.bs >> (BITS * (i - 1)) & (2^BITS - 1) for i in 1:M)
+    @assert BITS * M == B
+    onr = MVector{M,Int32}(undef)
+    bs = ofs.bs
+    for i in 1:M
+        onr[i] = bs.chunks[C] & (2^BITS - 1)
+        bs >>= BITS
+    end
+    return SVector(onr)
+end
+
+function print_address(io::IO, ofs::ONRFS{BITS,M,S}; compact=false) where {BITS,M,S}
+    if compact
+        print(io, BITS, "|", join(onr(ofs), ' '), "⟩")
+    else
+        print(io, "ONRFS{", BITS, "}(", tuple(onr(ofs)...), ")")
+    end
+    # print(io, "ONRFS{", BITS, "}(", tuple(onr(ofs)...), ")")
+end

--- a/src/BitStringAddresses/onrfs.jl
+++ b/src/BitStringAddresses/onrfs.jl
@@ -2,25 +2,45 @@
     ONRFS{B,M,S} <: SingleComponentFockAddress{missing,M}
 
 Address type that represents a bosonic Fock state with an indeterminate number of particles
-in `M` modes. Each mode can be occupied by at most ``2^B-2`` particles. The number of
+in `M` modes. Each mode can be occupied by at most ``2^B-1`` particles. The number of
 particles can be obtained by [`num_particles`](@ref) but is runtime information and not part
 of the type, in contrast to [`BoseFS`](@ref). This makes this type suitable for representing
 Fock states with number-nonconcerving Hamiltonians.
+
+## Constructors
+
+* `ONRFS{B}(onr)` constructs an `ONRFS`  with `M` modes and `B` bits per mode from an
+    occupation number representation `onr` of length `M`. The occupation number
+    representation is a tuple of integers, each of which is less than `2^B`.
+* `ONRFS(onr, max_n)` constructs an `ONRFS` from an occupation number representation
+    `onr` with `M` modes. The maximum occupation number `max_n` is used to determine the
+    number of bits per mode. The number of bits per mode is the smallest integer `B` such
+    that `2^B > max_n`.
 """
 struct ONRFS{BITS,M,S} <: SingleComponentFockAddress{missing,M}
     bs::S
 end
 
+# typestable constructor from occupation number representation
 @inline function ONRFS{BITS}(onr::Union{SVector{M},MVector{M},NTuple{M}}) where {BITS,M}
     bs = onrbs_from_onr(onr, Val(BITS))
     return ONRFS{BITS,M,typeof(bs)}(bs)
 end
 
+# constructor required for `onr_excitation`
+@inline function ONRFS{BITS,M,B}(onr::Union{SVector{M},MVector{M},NTuple{M}}) where {BITS,M,B}
+    bs = onrbs_from_onr(onr, Val(BITS))::B
+    return ONRFS{BITS,M,B}(bs)
+end
+
+# type-unstable constructor from occupation number representation
 function ONRFS(onr, max_n)
     BITS = ceil(Int, log2(max_n+1))
     return ONRFS{BITS}(onr)
 end
 
+# create bitstring for ONRFS from occupation number representation
+# TODO: optimize
 @inline function onrbs_from_onr(
     onr::Union{SVector{M},MVector{M},NTuple{M}}, ::Val{BITS}
 ) where {M,BITS}
@@ -59,9 +79,32 @@ end
 
 function print_address(io::IO, ofs::ONRFS{BITS,M,S}; compact=false) where {BITS,M,S}
     if compact
-        print(io, BITS, "|", join(onr(ofs), ' '), "⟩")
+        print(io, "|", join(onr(ofs), ' '), "⟩{", BITS, "}")
     else
         print(io, "ONRFS{", BITS, "}(", tuple(onr(ofs)...), ")")
     end
     # print(io, "ONRFS{", BITS, "}(", tuple(onr(ofs)...), ")")
 end
+
+# Baseline version for now. TODO: optimize
+function Base.getindex(ofs::ONRFS, i::Int)
+    return onr(ofs)[i]
+end
+
+function Base.length(ofs::ONRFS{<:Any,M}) where {M}
+    return M
+end
+
+function Base.iterate(ofs::ONRFS{<:Any,M}, state=1) where {M}
+    if state > M
+        return nothing
+    else
+        return ofs[state], state+1
+    end
+end
+
+num_occupied_modes(ofs::ONRFS) = mapreduce(!iszero, +, onr(ofs))
+
+num_particles(ofs::ONRFS) = mapreduce(identity, +, onr(ofs))
+
+# TODO: Custom fast `excitation` for `ONRFS`

--- a/src/BitStringAddresses/onrfs.jl
+++ b/src/BitStringAddresses/onrfs.jl
@@ -5,7 +5,8 @@ Address type that represents a bosonic Fock state with an indeterminate number o
 in `M` modes. Each mode can be occupied by at most ``2^B-1`` particles. The number of
 particles can be obtained by [`num_particles`](@ref) but is runtime information and not part
 of the type, in contrast to [`BoseFS`](@ref). This makes this type suitable for representing
-Fock states with number-nonconcerving Hamiltonians.
+Fock states with number-nonconcerving Hamiltonians. [`excitation`](@ref)s can change the
+particle number and use integer mode indices.
 
 ## Constructors
 
@@ -16,6 +17,28 @@ Fock states with number-nonconcerving Hamiltonians.
     `onr` with `M` modes. The maximum occupation number `max_n` is used to determine the
     number of bits per mode. The number of bits per mode is the smallest integer `B` such
     that `2^B > max_n`.
+* [`@fs_str`](@ref): Addresses are sometimes printed in a compact manner. This
+  representation can also be used as a constructor. See the example below.
+
+## Examples
+
+```jldoctest
+julia> ofs = ONRFS((0, 1, 5, 1, 0), 5)
+ONRFS{3}((0, 1, 5, 1, 0))
+
+julia> ONRFS{3}((0, 1, 5, 1, 0)) == ofs
+true
+
+julia> fs"|0 1 5 1 0⟩{3}" == ofs
+true
+
+julia> num_particles(ofs)
+7
+
+julia> excitation(ofs, (1,2), (3,))
+(ONRFS{3}((1, 2, 4, 1, 0)), 3.1622776601683795)
+```
+See also: [`SingleComponentFockAddress`](@ref), [`BoseFS`](@ref).
 """
 struct ONRFS{BITS,M,S} <: SingleComponentFockAddress{missing,M}
     bs::S

--- a/src/BitStringAddresses/onrfs.jl
+++ b/src/BitStringAddresses/onrfs.jl
@@ -131,3 +131,60 @@ num_occupied_modes(ofs::ONRFS) = mapreduce(!iszero, +, onr(ofs))
 num_particles(ofs::ONRFS) = mapreduce(identity, +, onr(ofs))
 
 # TODO: Custom fast `excitation` for `ONRFS`
+
+# Non-optimized generic version of `excitation` via occupation number representation
+# that accepts integer creation and destruction indices
+function excitation(fs::ONRFS, c::NTuple{<:Any,Int}, d::NTuple{<:Any,Int})
+    return onr_excitation(onr(fs), fs, c, d)
+end
+
+"""
+    onr_excitation(onrep, fs::ONRFS, c::NTuple{<:Any,Int}, d::NTuple{<:Any,Int})
+
+Apply the creation and destruction operators to the Fock state defined by the occupation
+number representation `onrep` and `typeof(fs)` and return the new address and the
+prefactor of the resulting state. This type of excitation may change the particle number
+if the address type `typeof(fs)` is not number conserving.
+"""
+function onr_excitation(
+    onrep, fs::T, c::NTuple{<:Any,Int}, d::NTuple{<:Any,Int}
+) where {BITS,T<:ONRFS{BITS}}
+    num_ds, onrep_d_applied = destroy_from_onr(onrep, d)
+    iszero(num_ds) && return fs, 0.0 # annihilation of vacuum
+
+    num_cs, onrep_c_applied = create_from_onr(onrep_d_applied, c)
+    all(x -> x < 1 << BITS, onrep_c_applied) || return fs, 0.0 # illegal address
+
+    return T(onrep_c_applied), sqrt(num_cs * num_ds)
+end
+# TODO: optimize and remove allocations
+
+"""
+    destroy_from_onr(onr, destructions) -> factor, new_onr
+
+Apply destruction operators to an occupation number representation `onr`.
+"""
+@inline function destroy_from_onr(onr, destructions)
+    monr = MVector(onr)
+    factor = 1
+    for i in destructions
+        factor *= monr[i]
+        monr[i] -= 1
+    end
+    return factor, SVector(monr)
+end
+
+"""
+    create_from_onr(onr, creations) -> factor, new_onr
+
+Apply creation operators to an occupation number representation `onr`.
+"""
+@inline function create_from_onr(onr, creations)
+    monr = MVector(onr)
+    factor = 1
+    for i in creations
+        monr[i] += 1
+        factor *= monr[i]
+    end
+    return factor, SVector(monr)
+end

--- a/src/Hamiltonians/FroehlichPolaron.jl
+++ b/src/Hamiltonians/FroehlichPolaron.jl
@@ -10,18 +10,19 @@
 The Froehlich polaron Hamiltonian is given by
 
 ```math
-H = (P̂_f - P)^2 + N̂ + Σₖ νₖ (âₖ^† + â_{-k}) +
+H = (P̂_f - P)^2 + N̂ + Σₖ νₖ (âₖ^† + â_{-k})
 ```
 
 where ``P`` is the total momentum `total_mom`, ``P̂_f = Σ_k k âₖ^† âₖ`` is the momentum
-operator for the bosons, ``N̂  Σ_k âₖ^† âₖ`` is the number operator for the bosons, and
-``νₖ = √α/|k|`` is the coupling strength determined by the coupling parameter `alpha`.
+operator for the bosons, ``N̂ = Σ_k âₖ^† âₖ`` is the number operator for the bosons, and
+``νₖ = \\sqrt{α}/|k|`` is the coupling strength determined by the coupling parameter
+`α == alpha`.
 
 The optional `geometry` argument specifies the geometry of the lattice for ``k``-space and
 should be of the type [`PeriodicBoundaries`](@ref). A simplified way of specifying the
 geometry is to provide the number of dimensions `num_dimensions`. In this case the
-[`num_modes(address)`](@ref) of `address` must be a perfect square for `num_dimensions=2`,
-or a perfect cube for `num_dimensions=3`.
+[`num_modes(address)`](@ref) of `address` must be a square number for `num_dimensions = 2`,
+or a cube number for `num_dimensions = 3`.
 
 The `address` must be of type [`ONRFS`](@ref).
 """

--- a/src/Hamiltonians/FroehlichPolaron.jl
+++ b/src/Hamiltonians/FroehlichPolaron.jl
@@ -1,0 +1,105 @@
+"""
+    FroehlichPolaron(
+        address;
+        alpha = 1.0,
+        total_mom = 0.0,
+        geometry = nothing,
+        num_dimensions = 1
+    )
+
+The Froehlich polaron Hamiltonian is given by
+
+```math
+H = (P̂_f - P)^2 + N̂ + Σₖ νₖ (âₖ^† + â_{-k}) +
+```
+
+where ``P`` is the total momentum `total_mom`, ``P̂_f = Σ_k k âₖ^† âₖ`` is the momentum
+operator for the bosons, ``N̂  Σ_k âₖ^† âₖ`` is the number operator for the bosons, and
+``νₖ = √α/|k|`` is the coupling strength determined by the coupling parameter `alpha`.
+
+The optional `geometry` argument specifies the geometry of the lattice for ``k``-space and
+should be of the type [`PeriodicBoundaries`](@ref). A simplified way of specifying the
+geometry is to provide the number of dimensions `num_dimensions`. In this case the
+[`num_modes(address)`](@ref) of `address` must be a perfect square for `num_dimensions=2`,
+or a perfect cube for `num_dimensions=3`.
+
+The `address` must be of type [`ONRFS`](@ref).
+"""
+struct FroehlichPolaron{
+    P, # total momentum
+    T, # eltype
+    A<:ONRFS, # address type
+    G # lattice type
+} <: AbstractHamiltonian{T}
+    add::A
+    alpha::T
+    geometry::G
+    # nu_k::Vector{T}
+    # p_squared_k::Vector{T}
+end
+
+function FroehlichPolaron(
+    addr::ONRFS{<:Any, M};
+    geometry=nothing,
+    alpha=1.0,
+    total_mom=0.0,
+    num_dimensions=1
+) where {M}
+    if isnothing(geometry)
+        if num_dimensions == 1
+            geometry = PeriodicBoundaries(M)
+        elseif num_dimensions == 2
+            sm = round(Int, sqrt(M))
+            if sm^2 == M
+                geometry = PeriodicBoundaries(sm, sm)
+            else
+                throw(ArgumentError("Number of modes $M is not a square. Specify geometry."))
+            end
+        elseif num_dimensions == 3
+            cm = round(Int, cbrt(M))
+            if cm^3 == M
+                geometry = PeriodicBoundaries(cm, cm, cm)
+            else
+                throw(ArgumentError("Number of modes $M is not a cube. Specify geometry."))
+            end
+        else
+            throw(ArgumentError("Invalid number of dimensions: $num_dimensions"))
+        end
+    end
+    geometry isa PeriodicBoundaries || throw(ArgumentError("Invalid geometry: $geometry"))
+    alpha, P = promote(float(alpha), float(total_mom))
+    return FroehlichPolaron{P,typeof(P),typeof(addr),typeof(geometry)}(addr, alpha, geometry)
+end
+
+function Base.show(io::IO, h::FroehlichPolaron)
+    print(io, "FroehlichPolaron($(h.add); alpha=$(h.alpha), total_mom=$(h.total_mom), ")
+    print(io, "geometry=$(h.geometry))")
+end
+
+function starting_address(h::FroehlichPolaron)
+    return getfield(h, :add)
+end
+
+LOStructure(::Type{<:FroehlichPolaron{<:Real}}) = IsHermitian()
+
+Base.getproperty(h::FroehlichPolaron, s::Symbol) = getproperty(h, Val(s))
+Base.getproperty(h::FroehlichPolaron, ::Val{:add}) = getfield(h, :add)
+Base.getproperty(h::FroehlichPolaron, ::Val{:alpha}) = getfield(h, :alpha)
+Base.getproperty(::FroehlichPolaron{P}, ::Val{:total_mom}) where P = P
+Base.getproperty(h::FroehlichPolaron, ::Val{:geometry}) = getfield(h, :geometry)
+
+num_dimensions(h::FroehlichPolaron) = num_dimensions(h.geometry)
+
+# function diagonal_element(h::FroehlichPolaron, addr::ONRFS)
+#     return (
+#         (-h.total_mom)^2 +
+#         num_particles(addr) +
+#         sum(νk(h, k) for k in momentum(h, addr))
+#     )
+# end
+
+# TODO: Sort out scales for momentum and energy; additional parameters?
+# TODO: pre-compute and store grid for p_squared_k (k.e.) and nu_k (coupling strength)
+# TODO: compute diagonal and off-diagonal elements
+# TODO: rest of AbstractHamiltonian interface
+# TODO: write unit tests for FroehlichPolaron

--- a/src/Hamiltonians/Hamiltonians.jl
+++ b/src/Hamiltonians/Hamiltonians.jl
@@ -73,6 +73,7 @@ export TimeReversalSymmetry
 export Stoquastic
 export Transcorrelated1D
 export hubbard_dispersion, continuum_dispersion
+export FroehlichPolaron
 
 export G2MomCorrelator, G2RealCorrelator, DensityMatrixDiagonal, Momentum
 
@@ -81,7 +82,7 @@ export num_neighbours, neighbour_site, num_dimensions
 
 export sparse # from SparseArrays
 
-export HOCartesianContactInteractions, HOCartesianEnergyConservedPerDim, HOCartesianCentralImpurity 
+export HOCartesianContactInteractions, HOCartesianEnergyConservedPerDim, HOCartesianCentralImpurity
 export AxialAngularMomentumHO
 export get_all_blocks, fock_to_cart
 
@@ -121,4 +122,5 @@ include("vertices.jl")
 include("ho-cart-tools.jl")
 include("angular_momentum.jl")
 
+include("FroehlichPolaron.jl")
 end

--- a/src/Hamiltonians/Hamiltonians.jl
+++ b/src/Hamiltonians/Hamiltonians.jl
@@ -26,6 +26,7 @@ Harmonic oscillator models
 Other
 - [`MatrixHamiltonian`](@ref)
 - [`Transcorrelated1D`](@ref)
+- [`FroehlichPolaron`](@ref)
 
 ## [Wrappers](#Hamiltonian-wrappers)
 - [`GutzwillerSampling`](@ref)

--- a/test/BitStringAddresses.jl
+++ b/test/BitStringAddresses.jl
@@ -460,3 +460,21 @@ end
             CompositeFS(BoseFS((1,2)), BoseFS((3,1)))
     end
 end
+
+@testset "ONRFS" begin
+    fs = ONRFS((1,2,3,0,1,20,3,2,5,0,1),100)
+    @test eval(Meta.parse(repr(fs))) == fs
+    @test parse_address(sprint(show, fs; context=:compact => true)) == fs
+
+    @test num_modes(fs) == 11
+    @test num_particles(fs) == 38
+    @test num_occupied_modes(fs) == 9
+    @test onr(fs) == [1,2,3,0,1,20,3,2,5,0,1]
+    @test collect(fs) == onr(fs)
+
+    @test excitation(fs, (), (4,5)) == (fs, 0.0)
+    nfs, amp = excitation(fs, (4,6), ())
+    @test num_particles(nfs) == num_particles(fs) + 2
+    @test amp == √(1 * 21)
+    @test onr(nfs) == [1,2,3,1,1,21,3,2,5,0,1]
+end

--- a/test/BitStringAddresses.jl
+++ b/test/BitStringAddresses.jl
@@ -472,9 +472,13 @@ end
     @test onr(fs) == [1,2,3,0,1,20,3,2,5,0,1]
     @test collect(fs) == onr(fs)
 
-    @test excitation(fs, (), (4,5)) == (fs, 0.0)
-    nfs, amp = excitation(fs, (4,6), ())
+    @test excitation(fs, (), (4,5)) == (fs, 0.0) # annihilation of vacuum
+    @test excitation(fs, (), (6, 6, 5)) == (fs"|1 2 3 0 0 18 3 2 5 0 1⟩{7}", √(20*19*1))
+    nfs, amp = excitation(fs, (4, 6), ())
     @test num_particles(nfs) == num_particles(fs) + 2
     @test amp == √(1 * 21)
     @test onr(nfs) == [1,2,3,1,1,21,3,2,5,0,1]
+
+    fs = ONRFS{3}((1, 7, 0))
+    @test excitation(fs, (2,), ()) == (fs, 0.0) # overflow, illegal address
 end

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -1425,7 +1425,7 @@ end
         Lz = AxialAngularMomentumHO(S; addr)
         Ly = AxialAngularMomentumHO(S; z_dim=2, addr)
         Lx = AxialAngularMomentumHO(S; z_dim=1, addr)
-        
+
         Lz_vals = eigvals(Matrix(BasisSetRep(Lz)))
         Ly_vals = eigvals(Matrix(BasisSetRep(Ly)))
         Lx_vals = eigvals(Matrix(BasisSetRep(Lx)))
@@ -1467,8 +1467,8 @@ end
         df = get_all_blocks(H; save_to_file = "test_block_df.arrow")
         df_file = load_df("test_block_df.arrow")
         @test df[!,[1,2,3,5]] == df_file[!,[1,2,3,5]]
-        
-        # HOCartesianContactInteractions requires a valid energy restriction 
+
+        # HOCartesianContactInteractions requires a valid energy restriction
         @test_throws ArgumentError get_all_blocks(HOCartesianContactInteractions(addr; S))
 
         # block_by_level = false
@@ -1492,7 +1492,7 @@ end
 
         @test Hamiltonians.index((3,2,1)) == 1
         @test Hamiltonians.index((5,4,3)) == 10
-    end    
+    end
 
     @testset "HO utilities" begin
         S = (4,4)
@@ -1505,4 +1505,15 @@ end
         null_addr = BoseFS(prod(S),)
         @test isempty(fock_to_cart(null_addr, S))
     end
+end
+
+@testset "FroehlichPolaron" begin
+    addr = ONRFS((0,0,0,0,1,0,0,0),20)
+    ham = FroehlichPolaron(addr; total_mom=3, alpha=6, num_dimensions=3)
+    @test num_dimensions(ham) == num_dimensions(ham.geometry) == 3
+    @test ham.geometry == PeriodicBoundaries(2, 2, 2)
+    @test eval(Meta.parse(repr(ham))) == ham
+    @test starting_address(ham) == ham.add == addr
+
+    # TODO: test the rest of the interface (add `FroehlichPolaron` to interface tests)
 end


### PR DESCRIPTION
- `ONRFS` Bosonic Fock states based on an occupation number representation. The particle number is not part of the type, so excitation operators can change the particle number in a type-stable way. The particle number per mode is restricted by the number of bits allocated to represent them. This provides an effective cutoff making Fock space finite.
- `FroehlichPolaron` Hamiltonian for the Froehlich Polaron problem in a natural momentum space Fock basis. The Hamiltonian doesn't conserve boson number and makes use of `ONRFS`

TODO:
- [ ] Finish the implementation of `FroehlichPolaron` (complete the `AbstractHamiltonian` interface with appropriate unit tests)
- [ ] Add common Fock state methods to `ONRFS`, e.g. `occupied_modes`, etc.
- [ ] (optimisation) Make methods to access `ONRFS` instances allocation-free
- [ ] (optimisation) Faster bit-twiddling methods for accessing and manipulating `ONRFS` instances 