### PR TITLE
Metadata support for reports

### DIFF
--- a/src/RimuIO/RimuIO.jl
+++ b/src/RimuIO/RimuIO.jl
@@ -59,7 +59,7 @@ function load_df(filename; propagate_metadata = true, add_filename = true)
     df = DataFrame(table)
     if propagate_metadata
         meta_data = Arrow.getmetadata(table)
-        for (key, val) in meta_data
+        isnothing(meta_data) || for (key, val) in meta_data
             metadata!(df, key, val)
         end
     end

--- a/src/lomc.jl
+++ b/src/lomc.jl
@@ -282,7 +282,7 @@ otherwise. It triggers the integer walker FCIQMC algorithm. See [`PDVec`](@ref),
   be passed into `lomc!` that will be pushed into
 * `name = "lomc!"` - name displayed in progress bar (via `ProgressLogging`)
 * `metadata` - metadata to be added to the report `df`. Must be an iterable of
-pairs or a `NamedTuple`, e.g. `metadata = ("key1" => "value1", "key2" => "value2")`.
+  pairs or a `NamedTuple`, e.g. `metadata = ("key1" => "value1", "key2" => "value2")`.
 
 # Return values
 

--- a/src/lomc.jl
+++ b/src/lomc.jl
@@ -236,6 +236,28 @@ function Base.show(io::IO, st::QMCState)
     end
 end
 
+function add_default_metadata!(report::Report, state::QMCState)
+    report_metadata!(report, "Rimu.PACKAGE_VERSION", Rimu.PACKAGE_VERSION)
+    # add metadata from state
+    report_metadata!(report, "laststep", state.laststep)
+    report_metadata!(report, "num_replicas", length(state.replicas))
+    report_metadata!(report, "hamiltonian", state.hamiltonian)
+    report_metadata!(report, "r_strat", state.r_strat)
+    report_metadata!(report, "s_strat", state.s_strat)
+    report_metadata!(report, "τ_strat", state.τ_strat)
+    params = state.replicas[1].params
+    report_metadata!(report, "params", params)
+    report_metadata!(report, "dτ", params.dτ)
+    report_metadata!(report, "step", params.step)
+    report_metadata!(report, "shift", params.shift)
+    report_metadata!(report, "shiftMode", params.shiftMode)
+    report_metadata!(report, "maxlength", state.maxlength[])
+    report_metadata!(report, "post_step", state.post_step)
+    report_metadata!(report, "v_summary", summary(state.replicas[1].v))
+    report_metadata!(report, "v_type", typeof(state.replicas[1].v))
+    return report
+end
+
 """
     lomc!(ham::AbstractHamiltonian, [v]; kwargs...) -> df, state
     lomc!(state::QMCState, [df]; kwargs...) -> df, state
@@ -283,6 +305,9 @@ otherwise. It triggers the integer walker FCIQMC algorithm. See [`PDVec`](@ref),
 * `name = "lomc!"` - name displayed in progress bar (via `ProgressLogging`)
 * `metadata` - metadata to be added to the report `df`. Must be an iterable of
   pairs or a `NamedTuple`, e.g. `metadata = ("key1" => "value1", "key2" => "value2")`.
+
+Some metadata is automatically added to the report `df` including
+[`Rimu.PACKAGE_VERSION`](@ref) and data from the `state`.
 
 # Return values
 
@@ -335,26 +360,7 @@ function lomc!(state::QMCState, df=DataFrame(); laststep=0, name="lomc!", metada
 
     # initialise report
     report = Report()
-
-    # add metadata to report
-    report_metadata!(report, "Rimu.PACKAGE_VERSION", Rimu.PACKAGE_VERSION)
-    # add metadata from state
-    report_metadata!(report, "laststep", state.laststep)
-    report_metadata!(report, "num_replicas", length(state.replicas))
-    report_metadata!(report, "hamiltonian", state.hamiltonian)
-    report_metadata!(report, "r_strat", state.r_strat)
-    report_metadata!(report, "s_strat", state.s_strat)
-    report_metadata!(report, "τ_strat", state.τ_strat)
-    params = state.replicas[1].params
-    report_metadata!(report, "params", params)
-    report_metadata!(report, "dτ", params.dτ)
-    report_metadata!(report, "step", params.step)
-    report_metadata!(report, "shift", params.shift)
-    report_metadata!(report, "shiftMode", params.shiftMode)
-    report_metadata!(report, "maxlength", state.maxlength[])
-    report_metadata!(report, "post_step", state.post_step)
-    report_metadata!(report, "v_summary", summary(state.replicas[1].v))
-    report_metadata!(report, "v_type", typeof(state.replicas[1].v))
+    add_default_metadata!(report, state)
     isnothing(metadata) || report_metadata!(report, metadata) # add user metadata
 
     # Sanity checks.

--- a/src/lomc.jl
+++ b/src/lomc.jl
@@ -236,7 +236,7 @@ function Base.show(io::IO, st::QMCState)
     end
 end
 
-function add_default_metadata!(report::Report, state::QMCState)
+function report_default_metadata!(report::Report, state::QMCState)
     report_metadata!(report, "Rimu.PACKAGE_VERSION", Rimu.PACKAGE_VERSION)
     # add metadata from state
     report_metadata!(report, "laststep", state.laststep)
@@ -303,11 +303,12 @@ otherwise. It triggers the integer walker FCIQMC algorithm. See [`PDVec`](@ref),
 * `df = DataFrame()` - when called with `AbstractHamiltonian` argument, a `DataFrame` can
   be passed into `lomc!` that will be pushed into
 * `name = "lomc!"` - name displayed in progress bar (via `ProgressLogging`)
-* `metadata` - metadata to be added to the report `df`. Must be an iterable of
+* `metadata` - user-supplied metadata to be added to the report `df`. Must be an iterable of
   pairs or a `NamedTuple`, e.g. `metadata = ("key1" => "value1", "key2" => "value2")`.
+  All metadata is converted to strings.
 
 Some metadata is automatically added to the report `df` including
-[`Rimu.PACKAGE_VERSION`](@ref) and data from the `state`.
+[`Rimu.PACKAGE_VERSION`](@ref) and data from `state`.
 
 # Return values
 
@@ -360,7 +361,7 @@ function lomc!(state::QMCState, df=DataFrame(); laststep=0, name="lomc!", metada
 
     # initialise report
     report = Report()
-    add_default_metadata!(report, state)
+    report_default_metadata!(report, state)
     isnothing(metadata) || report_metadata!(report, metadata) # add user metadata
 
     # Sanity checks.
@@ -404,7 +405,7 @@ function lomc!(state::QMCState, df=DataFrame(); laststep=0, name="lomc!", metada
     result_df = finalize_report!(state.r_strat, report)
     if !isempty(df)
         df = vcat(df, result_df) # metadata is not propagated
-        for (key, val) in report_metadata(report) # add metadata
+        for (key, val) in get_metadata(report) # add metadata
             DataFrames.metadata!(df, key, val)
         end
         return (; df, state)

--- a/src/strategies_and_params/reportingstrategy.jl
+++ b/src/strategies_and_params/reportingstrategy.jl
@@ -15,10 +15,10 @@ end
 function Base.show(io::IO, report::Report)
     print(io, "Report")
     if !isempty(report.data)
-        print(":")
+        print(io, ":")
         keywidth = maximum(length.(string.(keys(report.data))))
         for (k, v) in report.data
-            print("\n  $(lpad(k, keywidth)) => $v")
+            print(io, "\n  $(lpad(k, keywidth)) => $v")
         end
     end
 end

--- a/src/strategies_and_params/reportingstrategy.jl
+++ b/src/strategies_and_params/reportingstrategy.jl
@@ -3,7 +3,7 @@
 
 Internal structure that holds the temporary reported values as well as metadata.
 
-See [`report!`](@ref), [`report_metadata!`](@ref), [`report_metadata`](@ref).
+See [`report!`](@ref), [`report_metadata!`](@ref), [`get_metadata`](@ref).
 """
 struct Report
     data::LittleDict{Symbol,Vector}
@@ -28,7 +28,7 @@ Base.isempty(report::Report) = all(isempty, values(report.data))
 
 function DataFrames.DataFrame(report::Report)
     df = DataFrame(report.data; copycols=false)
-    for (key, val) in report_metadata(report) # add metadata
+    for (key, val) in get_metadata(report) # add metadata
         DataFrames.metadata!(df, key, val)
     end
     return df
@@ -43,7 +43,7 @@ Alternatively, an iterable of key-value pairs or a `NamedTuple` can be passed.
 
 Throws an error if `key` already exists.
 
-See also [`report_metadata`](@ref), [`report!`](@ref), [`Report`](@ref).
+See also [`get_metadata`](@ref), [`report!`](@ref), [`Report`](@ref).
 """
 function report_metadata!(report::Report, key, value)
     key = string(key)
@@ -62,16 +62,16 @@ function report_metadata!(report::Report, kvpairs::NamedTuple)
 end
 
 """
-    report_metadata(report::Report, key)
+    get_metadata(report::Report, key)
 
 Get metadata `key` from `report`. `key` is converted to a `String`.
 
 See also [`report_metadata!`](@ref), [`Report`](@ref), [`report!`](@ref).
 """
-function report_metadata(report::Report, key)
+function get_metadata(report::Report, key)
     return report.meta[string(key)]
 end
-function report_metadata(report::Report)
+function get_metadata(report::Report)
     return report.meta
 end
 

--- a/src/strategies_and_params/reportingstrategy.jl
+++ b/src/strategies_and_params/reportingstrategy.jl
@@ -1,12 +1,15 @@
 """
-    Report
+    Report()
 
-Internal structure that holds the temporary reported values. See [`report!`](@ref).
+Internal structure that holds the temporary reported values as well as metadata.
+
+See [`report!`](@ref), [`report_metadata!`](@ref), [`report_metadata`](@ref).
 """
 struct Report
     data::LittleDict{Symbol,Vector}
+    meta::LittleDict{String,String} # `String`s are required for Arrow metadata
 
-    Report() = new(Dict{Symbol,Vector}())
+    Report() = new(LittleDict{Symbol,Vector}(), LittleDict{String,String}())
 end
 
 function Base.show(io::IO, report::Report)
@@ -20,9 +23,57 @@ function Base.show(io::IO, report::Report)
     end
 end
 
-Base.empty!(report::Report) = foreach(empty!, values(report.data))
+Base.empty!(report::Report) = foreach(empty!, values(report.data)) # does not empty metadata
 Base.isempty(report::Report) = all(isempty, values(report.data))
-DataFrames.DataFrame(report::Report) = DataFrame(report.data; copycols=false)
+
+function DataFrames.DataFrame(report::Report)
+    df = DataFrame(report.data; copycols=false)
+    for (key, val) in report_metadata(report) # add metadata
+        DataFrames.metadata!(df, key, val)
+    end
+    return df
+end
+
+"""
+    report_metadata!(report::Report, key, value)
+    report_metadata!(report::Report, kvpairs)
+
+Set metadata `key` to `value` in `report`. `key` and `value` are converted to `String`s.
+Alternatively, an iterable of key-value pairs or a `NamedTuple` can be passed.
+
+Throws an error if `key` already exists.
+
+See also [`report_metadata`](@ref), [`report!`](@ref), [`Report`](@ref).
+"""
+function report_metadata!(report::Report, key, value)
+    key = string(key)
+    haskey(report.meta, key) && throw(ArgumentError("duplicate metadata key: $key"))
+    report.meta[key] = string(value)
+    return report
+end
+function report_metadata!(report::Report, kvpairs)
+    for (k, v) in kvpairs
+        report_metadata!(report, k, v)
+    end
+    return report
+end
+function report_metadata!(report::Report, kvpairs::NamedTuple)
+    return report_metadata!(report, pairs(kvpairs))
+end
+
+"""
+    report_metadata(report::Report, key)
+
+Get metadata `key` from `report`. `key` is converted to a `String`.
+
+See also [`report_metadata!`](@ref), [`Report`](@ref), [`report!`](@ref).
+"""
+function report_metadata(report::Report, key)
+    return report.meta[string(key)]
+end
+function report_metadata(report::Report)
+    return report.meta
+end
 
 const SymbolOrString = Union{Symbol,AbstractString}
 
@@ -148,9 +199,7 @@ reporting_interval(::ReportingStrategy) = 1
 Finalize the report. This function is called after all steps in [`lomc!`](@ref) have
 finished.
 """
-function finalize_report!(::ReportingStrategy, report)
-    DataFrame(report)
-end
+finalize_report!(::ReportingStrategy, report) = DataFrame(report)
 
 function print_stats(io::IO, step, state)
     print(io, "[ ", lpad(step, 11), " | ")
@@ -288,7 +337,10 @@ function report_after_step(s::ReportToFile, step, report, state)
 
         if !_isopen(s)
             # If the writer is closed or absent, we need to create a new one
-            s.writer = open(Arrow.Writer, s.filename; compress=s.compress)
+            s.writer = open(
+                Arrow.Writer, s.filename;
+                compress=s.compress, metadata=report.meta
+            )
         end
         Arrow.write(s.writer, report.data)
         empty!(report)
@@ -301,13 +353,16 @@ function finalize_report!(s::ReportToFile, report)
         if !isempty(report)
             if !_isopen(s)
                 # If the writer is closed or absent, we need to create a new one
-                s.writer = open(Arrow.Writer, s.filename; compress=s.compress)
+                s.writer = open(
+                    Arrow.Writer, s.filename;
+                    compress=s.compress, metadata=report.meta
+                )
             end
             Arrow.write(s.writer, report.data)
         end
         close(s.writer) # close the writer
         if s.return_df
-            return DataFrame(Arrow.Table(s.filename))
+            return RimuIO.load_df(s.filename)
         end
     end
     return DataFrame()

--- a/test/lomc.jl
+++ b/test/lomc.jl
@@ -404,7 +404,7 @@ using DataFrames
             Rimu.report!(rp, :b, 6)
             @test sprint(show, rp) == "Report:\n  b => [4, 6]"
             Rimu.report_metadata!(rp, :a, 1)
-            @test Rimu.report_metadata(rp, "a") == "1"
+            @test Rimu.get_metadata(rp, "a") == "1"
         end
     end
 

--- a/test/lomc.jl
+++ b/test/lomc.jl
@@ -398,6 +398,14 @@ using DataFrames
             rm("test-report-nc.arrow"; force=true)
             rm("test-report-lz4.arrow"; force=true)
         end
+        @testset "Report" begin
+            rp = Rimu.Report()
+            Rimu.report!(rp, :b, 4)
+            Rimu.report!(rp, :b, 6)
+            @test sprint(show, rp) == "Report:\n  b => [4, 6]"
+            Rimu.report_metadata!(rp, :a, 1)
+            @test Rimu.report_metadata(rp, "a") == "1"
+        end
     end
 
     @testset "Post step" begin


### PR DESCRIPTION
- Metadata from `lomc!` is added to `DataFrame` reports and propagated through `Arrow` files
- `save_df`, `load_df`, and `ReportToFile` propagate metadata between `DataFrame` and `Arrow` file
- Custom metadata can be added with keyword argument `metadata` in `lomc!`
- Some default metadata is saved automatically

### Example
```julia-repl
julia> add = BoseFS((1,2,3));

julia> hamiltonian = HubbardReal1D(add);

julia> df1, state = lomc!(hamiltonian; metadata = (; u=1.0));

julia> using DataFrames

julia> metadata(df1)
Dict{String, String} with 17 entries:
  "shift"                => "4.0"
  "num_replicas"         => "1"
  "τ_strat"              => "ConstantTimeStep()"
  "hamiltonian"          => "HubbardReal1D(BoseFS{6,3}((1, 2, 3)); u=1.0, t=1.0)"
  "v_type"               => "PDVec{BoseFS{6, 3, BitString{8, 1, UInt8}}, Int64, 5, IsStochasticInteger{Int64}, NonInitiator, Rimu.DictVectors.NotDistributed}"
  "s_strat"              => "DoubleLogUpdate{Int64}(1000, 0.08, 0.0016)"
  "step"                 => "0"
  "shiftMode"            => "false"
  "post_step"            => "()"
  "r_strat"              => "ReportDFAndInfo\n  reporting_interval: Int64 1\n  info_interval: Int64 100\n  io: Base.TTY\n  writeinfo: Bool false\n"
  "maxlength"            => "2100"
  "laststep"             => "100"
  "dτ"                   => "0.01"
  "params"               => "RunTillLastStep{Float64}\n  step: Int64 0\n  laststep: Int64 100\n  shiftMode: Bool false\n  shift: Float64 4.0\n  dτ: Float64 0.01\n"
  "Rimu.PACKAGE_VERSION" => "0.10.0"
  "v_summary"            => "1-element PDVec: style = IsStochasticInteger{Int64}()"
  "u"                    => "1.0"

julia> metadata(df1, "u")
"1.0"

julia> metadata(df1, "hamiltonian") |> Meta.parse |> eval == hamiltonian
true
```