### PR TITLE
Simplify lomc! arguments

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -44,7 +44,11 @@ end
 
 makedocs(;
     modules=[Rimu,Rimu.RimuIO],
-    format=Documenter.HTML(prettyurls = false),
+    format=Documenter.HTML(
+        prettyurls = false,
+        size_threshold=500_000, # 500 kB
+        size_threshold_warn=200_000, # 200 kB
+    ),
     pages=[
         "Guide" => "index.md",
         "Examples" => EXAMPLES_PAIRS[sortperm(EXAMPLES_NUMS)],
@@ -69,7 +73,7 @@ makedocs(;
     sitename="Rimu.jl",
     authors="Joachim Brand <j.brand@massey.ac.nz>",
     checkdocs=:exports,
-    doctest=false # Doctests are done while testing.
+    doctest=false, # Doctests are done while testing.
 )
 
 deploydocs(

--- a/scripts/BHM-example.jl
+++ b/scripts/BHM-example.jl
@@ -11,103 +11,109 @@
 # `Rimu` for FCIQMC calculation;
 
 using Rimu
-using Random
+using Plots # for plotting
+
+# ## Setting up the model
 
 # Now we define the physical problem:
-# Setting the number of lattice sites `m = 6`;
-# and the number of particles `n = 6`:
-m = n = 6
-# Generating a configuration that particles are evenly distributed:
-aIni = near_uniform(BoseFS{n,m})
-# where `BoseFS` is used to create a bosonic system.
-# The Hamiltonian is defined based on the configuration `aIni`,
-# with additional onsite interaction strength `u = 6.0`
-# and the hopping strength `t = 1.0`:
+# Generating a configuration where 6 particles are evenly distributed in 6 lattice sites:
+aIni = near_uniform(BoseFS{6,6})
+# where `BoseFS` is used to create a bosonic Fock state.
+# The Hamiltonian is defined by specifying the model and the parameters.
+# Here we use the Bose Hubbard model in one dimension and real space:
 Ĥ = HubbardReal1D(aIni; u = 6.0, t = 1.0)
 
+# ## Parameters of the calculation
 
-# Now let's setup the Monte Carlo settings.
-# The number of walkers to use in this Monte Carlo run:
-targetwalkers = 1_000
-# The number of time steps before doing statistics,
-# i.e. letting the walkers to sample Hilbert and to equilibrate:
-steps_equilibrate = 1_000
-# And the number of time steps used for getting statistics,
-# e.g. time-average of shift, projected energy, walker numbers, etc.:
-steps_measure = 2_000
+# Now let's setup the Monte Carlo calculation.
+# We need to decide the number of walkers to use in this Monte Carlo run, which is
+# equivalent to the average one-norm of the coefficient vector:
+targetwalkers = 1_000;
 
+# It is good practice to equilibrate the time series before taking statistics.
+steps_equilibrate = 1_000;
+steps_measure = 2_000;
 
-# Set the size of a time step
-dτ = 0.001
-# and we report QMC data every k-th step,
-# set the interval to record QMC data:
-reporting_interval = 1
+# The appropriate size of the time step is problem dependent.
+dτ = 0.001;
 
-# Now we prepare initial state and allocate memory.
-# The initial address is defined above as `aIni = near_uniform(Ĥ)`.
-# Putting one of walkers into the initial address `aIni`
-svec = DVec(aIni => 1)
-# Let's plant a seed for the random number generator to get consistent result:
-Random.seed!(17)
+# ## Defining an observable
 
-# Now let's setup all the FCIQMC strategies.
+# Now let's set up an observable to measure. Here we will measure the projected energy.
+# In additon to the `shift`, the projected energy is a second estimator for the energy.
 
-# Passing dτ and total number of time steps into params:
-params = RunTillLastStep(dτ = dτ, laststep = steps_equilibrate + steps_measure)
-# Strategy for updating the shift:
-s_strat = DoubleLogUpdate(targetwalkers = targetwalkers, ζ = 0.08)
-# Strategy for reporting info:
-r_strat = ReportDFAndInfo(reporting_interval = reporting_interval, info_interval = 100)
-# Strategy for updating dτ:
-τ_strat = ConstantTimeStep()
-# set up the calculation and reporting of the projected energy
-# in this case we are projecting onto the starting vector,
-# which contains a single configuration
-post_step = ProjectedEnergy(Ĥ, copy(svec))
+# We first need to define a projector. Here we use the function `default_starting_vector`
+# to generate a vector with only a single occupied configuration, the same vector that we
+# will use as starting vector for the FCIQMC calculation.
+svec = default_starting_vector(aIni; style=IsStochasticInteger())
+# The choice of the `style` argument already determines the FCIQMC algorithm to use
+# (while it is irrelevant for the projected energy).
 
-# Print out info about what we are doing:
-println("Finding ground state for:")
-println(Ĥ)
-println("Strategies for run:")
-println(params, s_strat)
-println(τ_strat)
+# Observables are passed into the `lomc!` function with the `post_step` keyword argument.
+post_step = ProjectedEnergy(Ĥ, svec)
+
+# ## Running the calculation
+
+# Seeding the random number generator is sometimes useful in order to get reproducible
+# results
+using Random
+Random.seed!(17);
 
 # Finally, we can start the main FCIQMC loop:
-df, state = lomc!(Ĥ,svec;
-            params,
-            laststep = steps_equilibrate + steps_measure,
-            s_strat,
-            r_strat,
-            τ_strat,
+df, state = lomc!(Ĥ, svec;
+            laststep = steps_equilibrate + steps_measure, # total number of steps
+            dτ,
+            targetwalkers,
             post_step,
 );
 
-# Here is how to save the output data stored in `df` into a `.arrow` file,
-# which can be read in later:
-println("Writing data to disk...")
-save_df("fciqmcdata.arrow", df)
+# `df` is a `DataFrame` containing the time series data.
 
-# Now let's look at the calculated energy from the shift.
-# Loading the equilibrated data
-qmcdata = last(df,steps_measure);
+# ## Analysing the results
 
-# compute the average shift and its standard error
-se = shift_estimator(qmcdata)
+# We can plot the norm of the coefficient vector as a function of the number of steps:
+hline([targetwalkers], label="targetwalkers", color=:red, linestyle=:dash)
+plot!(df.steps, df.norm, label="norm", ylabel="norm", xlabel="steps")
+# After some equilibriation steps, the norm fluctuates around the target number of walkers.
+
+# Now let's look at estimating the energy from the shift.
+# The mean of the shift is a useful estimator of the shift. Calculating the error bars
+# is a bit more involved as correlations have to be removed from the time series.
+# The following code does that:
+se = shift_estimator(df; skip=steps_equilibrate)
 
 # For the projected energy, it a bit more complicated as it's a ratio of two means:
-pe = projected_energy(qmcdata)
+pe = projected_energy(df; skip=steps_equilibrate)
 
 # The result is a ratio distribution. Let's get its median and lower and upper error bars
 # for a 95% confidence interval
 v = val_and_errs(pe; p=0.95)
 
-println("Energy from $steps_measure steps with $targetwalkers walkers:
-         Shift: $(se.mean) ± $(se.err);
-         Projected Energy: $(v.val) ± ($(v.val_l), $(v.val_u))")
+# Let's visualise these estimators together with the time series of the shift
+plot(df.steps, df.shift, ylabel="energy", xlabel="steps", label="shift")
 
-# Finished!
+plot!(x->se.mean, df.steps[steps_equilibrate+1:end], ribbon=se.err, label="shift mean")
+plot!(
+    x -> v.val, df.steps[steps_equilibrate+1:end], ribbon=(v.val_l,v.val_u),
+    label="projected_energy",
+)
+# In this case the projected energy and the shift are close to each other an the error bars
+# are hard to see on this scale.
+
+# The problem was just a toy example, as the dimension of the Hamiltonian is rather small:
+dimension(Ĥ)
+
+# In this case is easy (and more efficient) to calculate the exact ground state energy
+# using standard linear algebra:
+using LinearAlgebra
+exact_energy = eigvals(Matrix(Ĥ))[1]
+
+# Comparing our results for the energy:
+println("Energy from $steps_measure steps with $targetwalkers walkers:
+         Shift: $(se.mean) ± $(se.err)
+         Projected Energy: $(v.val) ± ($(v.val_l), $(v.val_u))
+         Exact Energy: $exact_energy")
+
 
 using Test                                      #hide
-@test isfile("fciqmcdata.arrow")                #hide
-@test se.mean ≈ -4.0215 rtol=0.1                #hide
-rm("fciqmcdata.arrow", force=true)              #hide
+@test se.mean ≈ -4.0215 rtol=0.1;               #hide

--- a/scripts/BHM-example.jl
+++ b/scripts/BHM-example.jl
@@ -79,10 +79,11 @@ plot!(df.steps, df.norm, label="norm", ylabel="norm", xlabel="steps")
 # Now let's look at estimating the energy from the shift.
 # The mean of the shift is a useful estimator of the shift. Calculating the error bars
 # is a bit more involved as correlations have to be removed from the time series.
-# The following code does that:
+# The following code does that with blocking transformations:
 se = shift_estimator(df; skip=steps_equilibrate)
 
-# For the projected energy, it a bit more complicated as it's a ratio of two means:
+# For the projected energy, it a bit more complicated as it's a ratio of fluctuationg
+# quantities:
 pe = projected_energy(df; skip=steps_equilibrate)
 
 # The result is a ratio distribution. Let's get its median and lower and upper error bars
@@ -107,6 +108,8 @@ dimension(Ĥ)
 # using standard linear algebra:
 using LinearAlgebra
 exact_energy = eigvals(Matrix(Ĥ))[1]
+# Read more about `Rimu.jl`s capabilities for exact diagonalisation in the example
+# "Exact diagonalisation".
 
 # Comparing our results for the energy:
 println("Energy from $steps_measure steps with $targetwalkers walkers:

--- a/scripts/G2-example.jl
+++ b/scripts/G2-example.jl
@@ -53,21 +53,14 @@ targetwalkers = 100;
 
 # Other FCIQMC parameters and strategies are the same as before
 dτ = 0.001
-reporting_interval = 1
 svec = DVec(aIni => 1)
-Random.seed!(17)
-params = RunTillLastStep(dτ = dτ, laststep = steps_equilibrate + steps_measure)
-s_strat = DoubleLogUpdate(targetwalkers = targetwalkers, ζ = 0.08)
-r_strat = ReportDFAndInfo(reporting_interval = reporting_interval, info_interval = 100)
-τ_strat = ConstantTimeStep();
+Random.seed!(17);
 
 # Now we run the main FCIQMC loop:
 df, state = lomc!(H, svec;
-            params,
+            dτ,
             laststep = steps_equilibrate + steps_measure,
-            s_strat,
-            r_strat,
-            τ_strat,
+            targetwalkers,
             replica,
 );
 

--- a/src/Rimu.jl
+++ b/src/Rimu.jl
@@ -49,6 +49,7 @@ include("StatsTools/StatsTools.jl")
 @reexport using .StatsTools
 
 export lomc!
+export default_starting_vector
 export FciqmcRunStrategy, RunTillLastStep
 export ShiftStrategy, LogUpdate, LogUpdateAfterTargetWalkers
 export DontUpdate, DoubleLogUpdate, DoubleLogUpdateAfterTargetWalkers

--- a/src/lomc.jl
+++ b/src/lomc.jl
@@ -418,12 +418,7 @@ function lomc!(
     address=starting_address(ham),
     kwargs...
 )
-    v = default_starting_vector(ham; style, threading, address)
-    if Threads.nthreads() > 1 && (threading ≠ false) || threading == true
-        v = PDVec(address => 10; style)
-    else
-        v = DVec(address => 10; style)
-    end
+    v = default_starting_vector(address; style, threading)
     return lomc!(ham, v; address, kwargs...) # pass address for setting the default shift
 end
 # For continuation, you can pass a QMCState and a DataFrame

--- a/src/lomc.jl
+++ b/src/lomc.jl
@@ -298,8 +298,11 @@ v = DVec(starting_address => 10; style)
 ```
 otherwise. See [`PDVec`](@ref), [`DVec`](@ref) and [`StochasticStyle`](@ref).
 """
-function default_starting_vector(hamiltonian::AbstractHamiltonian; kwargs...)
-    return default_starting_vector(starting_address(hamiltonian); kwargs...)
+function default_starting_vector(
+    hamiltonian::AbstractHamiltonian;
+    address=starting_address(hamiltonian), kwargs...
+)
+    return default_starting_vector(address; kwargs...)
 end
 function default_starting_vector(address;
     style=IsStochasticInteger(),

--- a/src/lomc.jl
+++ b/src/lomc.jl
@@ -293,13 +293,12 @@ Alternatively, a `QMCState` can be passed in to continue a previous simulation.
 
 * `laststep = 100` - controls the number of steps.
 * `dτ = 0.01` - time step.
-* `shift = diagonal_element(ham, starting_address(ham))` - initial value of shift.
 * `targetwalkers = 1000` - target for the 1-norm of the coefficient vector.
+* `address = starting_address(ham)` - set starting address for default `v`.
 * `style = IsStochasticInteger()` - set [`StochasticStyle`](@ref) for default `v`; unused
   if `v` is specified.
-* `address = starting_address(ham)` - set starting address for default `v`; unused
-  if `v` is specified.
 * `threading = true` - use multithreading if available; unused if `v` is specified.
+* `shift = diagonal_element(ham, starting_address)` - initial value of shift.
 * `post_step::NTuple{N,<:PostStepStrategy} = ()` - extract observables (e.g.
   [`ProjectedEnergy`](@ref)), see [`PostStepStrategy`](@ref).
 * `replica::ReplicaStrategy = NoStats(1)` - run several synchronised simulations, see

--- a/src/lomc.jl
+++ b/src/lomc.jl
@@ -289,12 +289,12 @@ end
 Return a default starting vector for [`lomc!`](@ref). The default choice for the starting
 vector is
 ```julia
-v = PDVec(starting_address => 10; style)
+v = PDVec(address => 10; style)
 ```
 if threading is available or
 
 ```julia
-v = DVec(starting_address => 10; style)
+v = DVec(address => 10; style)
 ```
 otherwise. See [`PDVec`](@ref), [`DVec`](@ref) and [`StochasticStyle`](@ref).
 """
@@ -404,7 +404,8 @@ julia> metadata(df2, "hamiltonian") # some metadata is automatically added
 
 The default choice for the starting vector is
 `v = default_starting_vector(; address, style, threading)`.
-See [`default_starting_vector`](@ref).
+See [`default_starting_vector`](@ref), [`PDVec`](@ref), [`DVec`](@ref), and
+[`StochasticStyle`](@ref).
 """
 function lomc!(ham, v; df=DataFrame(), name="lomc!", metadata=nothing, kwargs...)
     state = QMCState(ham, v; kwargs...)

--- a/src/strategies_and_params/poststepstrategy.jl
+++ b/src/strategies_and_params/poststepstrategy.jl
@@ -24,8 +24,10 @@ abstract type PostStepStrategy end
 """
     post_step(::PostStepStrategy, ::ReplicaState) -> kvpairs
 
-Compute statistics after FCIQMC step. Should return a tuple of `:key => value` pairs. 
-This function is only called every [`reporting_interval`](@ref) steps, as defined by the `ReportingStrategy`. 
+Compute statistics after FCIQMC step. Should return a tuple of `:key => value` pairs.
+This function is only called every [`reporting_interval`](@ref) steps, as defined by the
+`ReportingStrategy`.
+
 See also [`PostStepStrategy`](@ref), [`ReportingStrategy`](@ref).
 """
 post_step

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -1425,7 +1425,7 @@ end
         Lz = AxialAngularMomentumHO(S; addr)
         Ly = AxialAngularMomentumHO(S; z_dim=2, addr)
         Lx = AxialAngularMomentumHO(S; z_dim=1, addr)
-        
+
         Lz_vals = eigvals(Matrix(BasisSetRep(Lz)))
         Ly_vals = eigvals(Matrix(BasisSetRep(Ly)))
         Lx_vals = eigvals(Matrix(BasisSetRep(Lx)))
@@ -1467,8 +1467,8 @@ end
         df = get_all_blocks(H; save_to_file = "test_block_df.arrow")
         df_file = load_df("test_block_df.arrow")
         @test df[!,[1,2,3,5]] == df_file[!,[1,2,3,5]]
-        
-        # HOCartesianContactInteractions requires a valid energy restriction 
+
+        # HOCartesianContactInteractions requires a valid energy restriction
         @test_throws ArgumentError get_all_blocks(HOCartesianContactInteractions(addr; S))
 
         # block_by_level = false
@@ -1492,7 +1492,7 @@ end
 
         @test Hamiltonians.index((3,2,1)) == 1
         @test Hamiltonians.index((5,4,3)) == 10
-    end    
+    end
 
     @testset "HO utilities" begin
         S = (4,4)

--- a/test/lomc.jl
+++ b/test/lomc.jl
@@ -48,7 +48,7 @@ using DataFrames
         add = BoseFS{5,2}((2,3))
         H = HubbardReal1D(add; u=0.1)
         dv = DVec(add => 1; style=IsStochasticInteger())
-        df, state = lomc!(H, v; laststep=0, shift=23.1, dτ=0.002)
+        df, state = lomc!(H, dv; laststep=0, shift=23.1, dτ=0.002)
         @test state.replicas[1].params.dτ == state.dτ == 0.002
         @test state.replicas[1].params.shift == state.shift == 23.1
         state.dτ = 0.004

--- a/test/lomc.jl
+++ b/test/lomc.jl
@@ -61,6 +61,8 @@ using DataFrames
         addr = BoseFS{5,2}((2,3))
         H = HubbardReal1D(addr; u=0.1)
         @test default_starting_vector(H) == default_starting_vector(addr)
+        addr2 = BoseFS{5,2}((3, 2))
+        @test default_starting_vector(H, address=addr2) == default_starting_vector(addr2)
         @test default_starting_vector(addr; threading=false) isa DVec
         @test default_starting_vector(addr; threading=true) isa PDVec
         v = default_starting_vector(addr; threading=true)

--- a/test/lomc.jl
+++ b/test/lomc.jl
@@ -44,6 +44,19 @@ using DataFrames
         @test df.steps == [1:100; 1:100]
     end
 
+    @testset "Setting dτ and shift" begin
+        add = BoseFS{5,2}((2,3))
+        H = HubbardReal1D(add; u=0.1)
+        dv = DVec(add => 1; style=IsStochasticInteger())
+        df, state = lomc!(H, v; laststep=0, shift=23.1, dτ=0.002)
+        @test state.replicas[1].params.dτ == state.dτ == 0.002
+        @test state.replicas[1].params.shift == state.shift == 23.1
+        state.dτ = 0.004
+        @test state.replicas[1].params.dτ == state.dτ == 0.004
+        state.shift = 5.0
+        @test state.replicas[1].params.shift == state.shift == 5.0
+        @test state.replica == NoStats{1}() # uses getfield method
+    end
     @testset "Setting walkernumber" begin
         add = BoseFS{2,5}((0,0,2,0,0))
         H = HubbardMom1D(add; u=0.5)
@@ -64,6 +77,9 @@ using DataFrames
         s_strat = DoubleLogUpdate(ζ=0.05, ξ=0.05^2/4, targetwalkers=1000)
         walkers = lomc!(H, copy(dv); s_strat, laststep=1000).df.norm
         @test median(walkers) ≈ 1000 rtol=0.1
+
+        _, state = lomc!(H, copy(dv); targetwalkers=500, laststep=0)
+        @test state.s_strat.targetwalkers == 500
     end
 
     @testset "Replicas" begin

--- a/test/lomc.jl
+++ b/test/lomc.jl
@@ -57,6 +57,16 @@ using DataFrames
         @test state.replicas[1].params.shift == state.shift == 5.0
         @test state.replica == NoStats{1}() # uses getfield method
     end
+    @testset "default_starting_vector" begin
+        addr = BoseFS{5,2}((2,3))
+        H = HubbardReal1D(addr; u=0.1)
+        @test default_starting_vector(H) == default_starting_vector(addr)
+        @test default_starting_vector(addr; threading=false) isa DVec
+        @test default_starting_vector(addr; threading=true) isa PDVec
+        v = default_starting_vector(addr; threading=true)
+        @test_logs (:warn, Regex("(Starting)")) lomc!(H, v; laststep=0, threading=false)
+        @test_logs (:warn, Regex("(Starting)")) lomc!(H, v; laststep=0, style=IsStochasticInteger())
+    end
     @testset "Setting walkernumber" begin
         add = BoseFS{2,5}((0,0,2,0,0))
         H = HubbardMom1D(add; u=0.5)


### PR DESCRIPTION
# Simplify keyword arguments for `lomc!()`

A non-breaking restructure of the keyword arguments for `lomc!()`. More parameters of an FCIQMC calculation can be passed directly as keyword arguments to `lomc!()` reducing the need to pre-construct the initial vector and strategy-type arguments. 

The script `BHM-example.jl` is redone.

## New and modified keyword arguments to `lomc!()`
- `address` (new) - used for starting vector and initial shift 
- `threading` (reinstated) - controls parallelism and is used for initial starting vector
- `shift` (new) - initial value of shift 
- `dτ` (now documented) - initial time step 
- `targetwalkers` (new) - target norm for `DoubleLogUpdate`

## New functions
- `default_starting_vector` - the default starting vector for `lomc!`

The keyword argument `params::FciqmcRunStrategy` is now obsolete (though still accepted). In practice it should now rarely be necessary to explicitly construct the starting vector `v` and the `s_strat::ShiftStrategy=DoubleLogUpdate` keyword argument.
