### PR TITLE
FroehlichPolaron Hamiltonian

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Rimu"
 uuid = "c53c40cc-bd84-11e9-2cf4-a9fde2b9386e"
 authors = ["Joachim Brand <j.brand@massey.ac.nz>"]
-version = "0.11.0"
+version = "0.11.1"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/docs/src/hamiltonians.md
+++ b/docs/src/hamiltonians.md
@@ -73,6 +73,7 @@ HOCartesianCentralImpurity
 ```@docs
 MatrixHamiltonian
 Transcorrelated1D
+FroehlichPolaron
 ```
 
 ### Convenience functions

--- a/src/Hamiltonians/FroehlichPolaron.jl
+++ b/src/Hamiltonians/FroehlichPolaron.jl
@@ -1,28 +1,19 @@
 """
-    function FroehlichPolaron(
-        addr::OccupationNumberFS;
-         v=1.0,
-         mass=1.0,
-        omega=1.0,
-        l=1.0,
-        p=0.0,
-        momentum_cutoff=nothing,
-        mode_cutoff=100.0,
-    )
+    FroehlichPolaron(addr::OccupationNumberFS; v=1.0, mass=1.0, omega=1.0, l=1.0, kwargs...)
+    
 
 The 1D Froehlich polaron Hamiltonian is given by
 
 ```math
-H = \\frac{(P̂_f - P)^2}{m} + ωN̂ - v Σₖ(âₖ^† + â_{-k})
+H = \\frac{(p̂_f - p)^2}{m} + ωN̂ - v Σₖ(âₖ^† + â_{-k})
 ```
 
-where ``P`` is the total momentum `total_mom`, ``P̂_f = \\frac{M}{l}Σ_k k âₖ^† âₖ`` is the momentum operator for the bosons, ``N̂ = Σ_k âₖ^† âₖ`` is the number operator for the bosons, and ``v`` is the coupling strength. Here, ``M`` is the number of discrete momentum modes and ``l`` is the momentum scaling.
+where ``p`` is the total momentum and ``p̂_f = \\frac{M}{l}Σ_k k âₖ^† âₖ`` is the momentum operator for the bosons. ``N̂`` is the number operator for the bosons.
 
-The `address` must be of type [`OccupationNumberFS`](@ref).
 
 # Arguments
 
-* `addr`: the starting address.
+* `addr::OccupationNumberFS`: the starting address
 * `v`: the coupling strength
 * `mass`: the particle mass
 * `omega`: the oscillation frequency of the phonons
@@ -30,7 +21,6 @@ The `address` must be of type [`OccupationNumberFS`](@ref).
 * `p`: the total momentum
 * `momentum_cutoff`: the maximum total momentum allowed for a basis element
 * `mode_cutoff`: the maximum population in each momentum mode
-
 
 """
 struct FroehlichPolaron{

--- a/src/Hamiltonians/FroehlichPolaron.jl
+++ b/src/Hamiltonians/FroehlichPolaron.jl
@@ -1,30 +1,37 @@
 """
-    FroehlichPolaron(
-        address;
-        alpha = 1.0,
-        total_mom = 0.0,
-        geometry = nothing,
-        num_dimensions = 1
-    )
+function FroehlichPolaron(
+    addr::OccupationNumberFS;
+    v=1.0,
+    mass=1.0,
+    omega=1.0,
+    l=1.0,
+    p=0.0,
+    momentum_cutoff=nothing,
+    mode_cutoff=100.0,
+)
 
-The Froehlich polaron Hamiltonian is given by
+The 1D Froehlich polaron Hamiltonian is given by
 
 ```math
 H = \\frac{(P̂_f - P)^2}{m} + ωN̂ - ν Σₖ(âₖ^† + â_{-k})
 ```
 
-where ``P`` is the total momentum `total_mom`, ``P̂_f = \\frac{M}{L}Σ_k k âₖ^† âₖ`` is the momentum
-operator for the bosons, ``N̂ = Σ_k âₖ^† âₖ`` is the number operator for the bosons, and
-``νₖ = \\sqrt{α}/|k|`` is the coupling strength determined by the coupling parameter
-`α == alpha`.
-
-The optional `geometry` argument specifies the geometry of the lattice for ``k``-space and
-should be of the type [`PeriodicBoundaries`](@ref). A simplified way of specifying the
-geometry is to provide the number of dimensions `num_dimensions`. In this case the
-[`num_modes(address)`](@ref) of `address` must be a square number for `num_dimensions = 2`,
-or a cube number for `num_dimensions = 3`.
+where ``P`` is the total momentum `total_mom`, ``P̂_f = \\frac{M}{L}Σ_k k âₖ^† âₖ`` is the momentum operator for the bosons, ``N̂ = Σ_k âₖ^† âₖ`` is the number operator for the bosons, and ``ν`` is the coupling strength. Here, ``M`` is the number of discrete momentum modes and ```L`` is the momentum scaling.
 
 The `address` must be of type [`OccupationNumberFS`](@ref).
+
+# Arguments
+
+* `addr`: the starting address.
+* `v`: the coupling strength
+* `mass`: the particle mass
+* `omega`: the oscillation frequency of the phonons
+* `l`: the next-neighbor interaction
+* `p`: the total momentum
+* `momentum_cutoff`: the maximum total momentum allowed for a basis element
+* `mode_cutoff`: the maximum population in each momentum mode
+
+
 """
 struct FroehlichPolaron{
     T, # eltype
@@ -51,8 +58,12 @@ function FroehlichPolaron(
     l=1.0,
     p=0.0,
     momentum_cutoff=nothing,
-    mode_cutoff=100.0,
+    mode_cutoff=10.0,
 )
+    if _exceed_mode_cutoff(mode_cutoff,addr)
+        throw(ArgumentError("Starting address cannot have occupations that exceed mode_cutoff"))
+    end
+
     M = num_modes(addr) # this is compile-time information
     if isnothing(momentum_cutoff)
         v, p, mass, omega, l, mode_cutoff = promote(float(v), float(p), float(mass), float(omega), float(l), float(mode_cutoff))
@@ -68,6 +79,14 @@ function FroehlichPolaron(
     end
     kr = range(start; step = step, length = M)
     ks = SVector{M}(kr)
+
+    if !isnothing(momentum_cutoff)
+        momentum = (M/l) * dot(ks,onr(addr))
+        if momentum > momentum_cutoff
+            throw(ArgumentError("Starting address has momentum $momentum which cannot exceed momentum_cutoff $momentum_cutoff"))
+        end
+    end
+
     return FroehlichPolaron(addr, v, mass, omega, l, p, ks, momentum_cutoff, mode_cutoff)
 end
 
@@ -82,19 +101,15 @@ end
 
 LOStructure(::Type{<:FroehlichPolaron{<:Real}}) = IsHermitian()
 
-# Base.getproperty(h::FroehlichPolaron, s::Symbol) = getproperty(h, Val(s))
-# Base.getproperty(h::FroehlichPolaron, ::Val{:ks}) = getfield(h, :ks)
-# Base.getproperty(h::FroehlichPolaron, ::Val{:addr}) = getfield(h, :addr)
-# Base.getproperty(h::FroehlichPolaron, ::Val{:v}) = getfield(h, :v)
-# Base.getproperty(h::FroehlichPolaron, ::Val{:mass}) = getfield(h, :mass)
-# Base.getproperty(h::FroehlichPolaron, ::Val{:omega}) = getfield(h, :omega)
-# Base.getproperty(h::FroehlichPolaron, ::Val{:l}) = getfield(h, :l)
-# Base.getproperty(h::FroehlichPolaron, ::Val{:p}) = getfield(h, :p)
+# The optional `geometry` argument specifies the geometry of the lattice for ``k``-space and
+# should be of the type [`PeriodicBoundaries`](@ref). A simplified way of specifying the
+# geometry is to provide the number of dimensions `num_dimensions`. In this case the
+# [`num_modes(address)`](@ref) of `address` must be a square number for `num_dimensions = 2`,
+# or a cube number for `num_dimensions = 3`.
 
 ks(h::FroehlichPolaron) = getfield(h, :ks)
 
 # TODO: Sort out scales for momentum and energy; additional parameters?
-# TODO: compute diagonal and off-diagonal elements
 # TODO: rest of AbstractHamiltonian interface
 # TODO: write unit tests for FroehlichPolaron
 
@@ -117,7 +132,7 @@ function get_offdiagonal(h::FroehlichPolaron{T,M,<:Any,T}, addr::OccupationNumbe
     naddress, value = _froehlich_offdiag(h,addr,chosen)
     
     new_p_tot = dot(h.ks, onr(naddress))
-    if new_p_tot > h.momentum_cutoff # check if momentum of new address exceeds momentum_cutoff
+    if (M/h.l) * new_p_tot > h.momentum_cutoff # check if momentum of new address exceeds momentum_cutoff
         return addr, 0.0
     else
         return naddress, - h.v * value
@@ -137,4 +152,8 @@ function _froehlich_offdiag(h, addr::OccupationNumberFS{M},chosen) where {M}
         naddress, value = excitation(addr, (),(chosen-M,))
         return naddress, - h.v * value
     end
+end
+
+function _exceed_mode_cutoff(mode_cutoff, addr::OccupationNumberFS{M}) where {M}
+    return any(x->x>mode_cutoff,onr(addr))
 end

--- a/src/Hamiltonians/FroehlichPolaron.jl
+++ b/src/Hamiltonians/FroehlichPolaron.jl
@@ -5,7 +5,7 @@
 The Froehlich polaron Hamiltonian for a 1D lattice with `M` momentum modes is given by
 
 ```math
-H = \\frac{(p̂_f - p)^2}{m} + ωN̂ - v Σₖ(âₖ^† + â_{-k})
+H = (p̂_f - p)^2/m + ωN̂ - v Σₖ(âₖ^† + â₋ₖ)
 ```
 
 where ``p`` is the total momentum, ``p̂_f = Σ_k k âₖ^† âₖ`` is the momentum operator for the
@@ -108,14 +108,14 @@ function num_offdiagonals(::FroehlichPolaron{<:Any,M}, ::OccupationNumberFS{M}) 
     return 2M #num_occupied_modes
 end
 
-function get_offdiagonal(h::FroehlichPolaron{<:Any,M,<:Any,<:Nothing}, addr::OccupationNumberFS{M},chosen) where {M}
+function get_offdiagonal(h::FroehlichPolaron{<:Any,M,<:Any,Nothing}, addr::OccupationNumberFS{M},chosen) where {M}
     # branch that bypasses momentum cutoff
-    return _froehlich_offdiag(h,addr,chosen)
+    return _froehlich_offdiag(h, addr, chosen)
 end
 
 function get_offdiagonal(h::FroehlichPolaron{T,M,<:Any,T}, addr::OccupationNumberFS{M}, chosen) where {M,T}
     # branch for checking momentum cutoff
-    naddress, value = _froehlich_offdiag(h,addr,chosen)
+    naddress, value = _froehlich_offdiag(h, addr, chosen)
 
     new_p_tot = dot(h.ks, onr(naddress))
     if (M/h.l) * new_p_tot > h.momentum_cutoff # check if momentum of new address exceeds momentum_cutoff
@@ -130,16 +130,16 @@ function _froehlich_offdiag(h, addr::OccupationNumberFS{M},chosen) where {M}
         if onr(addr)[chosen] ≥ h.mode_cutoff # check whether occupation exceeds cutoff
             return addr, 0.0
         else
-            naddress, value = excitation(addr, (chosen,),())
+            naddress, value = excitation(addr, (chosen,), ())
             return naddress, - h.v * value
         end
     else # remaining indices are destructions
 
-        naddress, value = excitation(addr, (),(chosen-M,))
+        naddress, value = excitation(addr, (), (chosen - M,))
         return naddress, - h.v * value
     end
 end
 
 function _exceed_mode_cutoff(mode_cutoff, addr::OccupationNumberFS{M}) where {M}
-    return any(x->x>mode_cutoff,onr(addr))
+    return any(x -> x > mode_cutoff, onr(addr))
 end

--- a/src/Hamiltonians/FroehlichPolaron.jl
+++ b/src/Hamiltonians/FroehlichPolaron.jl
@@ -105,7 +105,7 @@ end
 function Base.show(io::IO, h::FroehlichPolaron)
     print(io, "FroehlichPolaron(")
     show(IOContext(io, :compact => true), h.addr)
-    print("; v=$(h.v), mass=$(h.mass), omega=$(h.omega), l=$(h.l), p=$(h.p), ")
+    print(io, "; v=$(h.v), mass=$(h.mass), omega=$(h.omega), l=$(h.l), p=$(h.p), ")
     isnothing(h.momentum_cutoff) || print(io, "momentum_cutoff = $(h.momentum_cutoff), ")
     print(io, "mode_cutoff=$(h.mode_cutoff))")
 

--- a/src/Hamiltonians/FroehlichPolaron.jl
+++ b/src/Hamiltonians/FroehlichPolaron.jl
@@ -1,14 +1,14 @@
 """
-function FroehlichPolaron(
-    addr::OccupationNumberFS;
-    v=1.0,
-    mass=1.0,
-    omega=1.0,
-    l=1.0,
-    p=0.0,
-    momentum_cutoff=nothing,
-    mode_cutoff=100.0,
-)
+    function FroehlichPolaron(
+        addr::OccupationNumberFS;
+         v=1.0,
+         mass=1.0,
+        omega=1.0,
+        l=1.0,
+        p=0.0,
+        momentum_cutoff=nothing,
+        mode_cutoff=100.0,
+    )
 
 The 1D Froehlich polaron Hamiltonian is given by
 

--- a/src/Hamiltonians/FroehlichPolaron.jl
+++ b/src/Hamiltonians/FroehlichPolaron.jl
@@ -1,5 +1,5 @@
 """
-    FroehlichPolaron(addr::OccupationNumberFS; v=1.0, mass=1.0, omega=1.0, l=1.0, kwargs...)
+    FroehlichPolaron(addr::OccupationNumberFS; kwargs...)
     
 
 The Froehlich polaron Hamiltonian for a 1D lattice with ``M`` momentum modes is given by
@@ -11,7 +11,7 @@ H = \\frac{(p̂_f - p)^2}{m} + ωN̂ - v Σₖ(âₖ^† + â_{-k})
 where ``p`` is the total momentum and ``p̂_f = \\frac{M}{l}Σ_k k âₖ^† âₖ`` is the momentum operator for the bosons. ``N̂`` is the number operator for the bosons.
 
 
-# `Keyword Arguments
+# Keyword Arguments
 
 * `v=1.0`: the coupling strength, ``v``
 * `mass=1.0`: the particle mass, ``m``

--- a/src/Hamiltonians/FroehlichPolaron.jl
+++ b/src/Hamiltonians/FroehlichPolaron.jl
@@ -70,7 +70,7 @@ function FroehlichPolaron(
     ks = SVector{M}(kr)
 
     if !isnothing(momentum_cutoff)
-        momentum_cutoff = floor(Int, momentum_cutoff)::Int
+        momentum_cutoff = typeof(v)(momentum_cutoff)
         momentum = dot(ks,onr(addr))
         if momentum > momentum_cutoff
             throw(ArgumentError("Starting address has momentum $momentum which cannot exceed momentum_cutoff $momentum_cutoff"))
@@ -113,7 +113,7 @@ function get_offdiagonal(h::FroehlichPolaron{<:Any,M,<:Any,<:Nothing}, addr::Occ
     return _froehlich_offdiag(h,addr,chosen)
 end
 
-function get_offdiagonal(h::FroehlichPolaron{<:Any,M,<:Any,Int}, addr::OccupationNumberFS{M}, chosen) where {M}
+function get_offdiagonal(h::FroehlichPolaron{T,M,<:Any,T}, addr::OccupationNumberFS{M}, chosen) where {M,T}
     # branch for checking momentum cutoff
     naddress, value = _froehlich_offdiag(h,addr,chosen)
 

--- a/src/Hamiltonians/FroehlichPolaron.jl
+++ b/src/Hamiltonians/FroehlichPolaron.jl
@@ -16,7 +16,7 @@ The 1D Froehlich polaron Hamiltonian is given by
 H = \\frac{(P̂_f - P)^2}{m} + ωN̂ - ν Σₖ(âₖ^† + â_{-k})
 ```
 
-where ``P`` is the total momentum `total_mom`, ``P̂_f = \\frac{M}{L}Σ_k k âₖ^† âₖ`` is the momentum operator for the bosons, ``N̂ = Σ_k âₖ^† âₖ`` is the number operator for the bosons, and ``ν`` is the coupling strength. Here, ``M`` is the number of discrete momentum modes and ```L`` is the momentum scaling.
+where ``P`` is the total momentum `total_mom`, ``P̂_f = \\frac{M}{L}Σ_k k âₖ^† âₖ`` is the momentum operator for the bosons, ``N̂ = Σ_k âₖ^† âₖ`` is the number operator for the bosons, and ``ν`` is the coupling strength. Here, ``M`` is the number of discrete momentum modes and ``L`` is the momentum scaling.
 
 The `address` must be of type [`OccupationNumberFS`](@ref).
 

--- a/src/Hamiltonians/FroehlichPolaron.jl
+++ b/src/Hamiltonians/FroehlichPolaron.jl
@@ -103,10 +103,10 @@ function FroehlichPolaron(
 end
 
 function Base.show(io::IO, h::FroehlichPolaron)
-    print(io, "FroehlichPolaron(")
-    show(IOContext(io, :compact => true), h.addr)
-    print(io, "; v=$(h.v), mass=$(h.mass), omega=$(h.omega), l=$(h.l), p=$(h.p), ")
-    isnothing(h.momentum_cutoff) || print(io, "momentum_cutoff = $(h.momentum_cutoff), ")
+    compact_addr = repr(h.addr, context=:compact => true) # compact print address
+    print(io, "FroehlichPolaron($compact_addr; ")
+    print(io, "v=$(h.v), mass=$(h.mass), omega=$(h.omega), l=$(h.l), p=$(h.p), ")
+    isnothing(h.momentum_cutoff) || print(io, "momentum_cutoff=$(h.momentum_cutoff), ")
     print(io, "mode_cutoff=$(h.mode_cutoff))")
 
 end

--- a/src/Hamiltonians/FroehlichPolaron.jl
+++ b/src/Hamiltonians/FroehlichPolaron.jl
@@ -8,7 +8,9 @@ The Froehlich polaron Hamiltonian for a 1D lattice with ``M`` momentum modes is 
 H = \\frac{(p̂_f - p)^2}{m} + ωN̂ - v Σₖ(âₖ^† + â_{-k})
 ```
 
-where ``p`` is the total momentum and ``p̂_f = \\frac{M}{l}Σ_k k âₖ^† âₖ`` is the momentum operator for the bosons. ``N̂`` is the number operator for the bosons.
+where ``p`` is the total momentum, ``p̂_f = Σ_k k âₖ^† âₖ`` is the momentum operator for the 
+bosons, and ``k`` part of the momentum lattice with separation ``2π/l``. ``N̂`` is the number 
+operator for the bosons.
 
 
 # Keyword Arguments
@@ -16,7 +18,7 @@ where ``p`` is the total momentum and ``p̂_f = \\frac{M}{l}Σ_k k âₖ^† a�
 * `v=1.0`: the coupling strength, ``v``
 * `mass=1.0`: the particle mass, ``m``
 * `omega=1.0`: the oscillation frequency of the phonons, ``ω``
-* `l=1.0`: the scale parameter of the momentum lattice, ``l``
+* `l=1.0`: the box size in real space; provides scale parameter of the momentum lattice, ``l``
 * `p=0.0`: the total momentum, ``p``
 * `momentum_cutoff=nothing`: the maximum total momentum allowed for a basis element
 * `mode_cutoff=10.0`: the maximum population in each momentum mode
@@ -84,7 +86,7 @@ end
 
 function Base.show(io::IO, h::FroehlichPolaron)
     println(io, "FroehlichPolaron($(h.addr); v=$(h.v), mass=$(h.mass), omega=$(h.omega), l=$(h.l), p=$(h.p), ")
-    println("momentum_cutoff=$(h.momentum_cutoff), mode_cutoff=$(h.mode_cutoff))")
+    println(io, "momentum_cutoff=$(h.momentum_cutoff), mode_cutoff=$(h.mode_cutoff))")
 end
 
 function starting_address(h::FroehlichPolaron)
@@ -93,17 +95,8 @@ end
 
 LOStructure(::Type{<:FroehlichPolaron{<:Real}}) = IsHermitian()
 
-# The optional `geometry` argument specifies the geometry of the lattice for ``k``-space and
-# should be of the type [`PeriodicBoundaries`](@ref). A simplified way of specifying the
-# geometry is to provide the number of dimensions `num_dimensions`. In this case the
-# [`num_modes(address)`](@ref) of `address` must be a square number for `num_dimensions = 2`,
-# or a cube number for `num_dimensions = 3`.
 
-ks(h::FroehlichPolaron) = getfield(h, :ks)
 
-# TODO: Sort out scales for momentum and energy; additional parameters?
-# TODO: rest of AbstractHamiltonian interface
-# TODO: write unit tests for FroehlichPolaron
 
 function diagonal_element(h::FroehlichPolaron{<:Any,M}, addr::OccupationNumberFS{M}) where {M}
     map = onr(addr)

--- a/src/Hamiltonians/FroehlichPolaron.jl
+++ b/src/Hamiltonians/FroehlichPolaron.jl
@@ -2,7 +2,7 @@
     FroehlichPolaron(addr::OccupationNumberFS; v=1.0, mass=1.0, omega=1.0, l=1.0, kwargs...)
     
 
-The 1D Froehlich polaron Hamiltonian is given by
+The Froehlich polaron Hamiltonian for a 1D lattice with ``M`` momentum modes is given by
 
 ```math
 H = \\frac{(p̂_f - p)^2}{m} + ωN̂ - v Σₖ(âₖ^† + â_{-k})
@@ -11,16 +11,15 @@ H = \\frac{(p̂_f - p)^2}{m} + ωN̂ - v Σₖ(âₖ^† + â_{-k})
 where ``p`` is the total momentum and ``p̂_f = \\frac{M}{l}Σ_k k âₖ^† âₖ`` is the momentum operator for the bosons. ``N̂`` is the number operator for the bosons.
 
 
-# Arguments
+# `Keyword Arguments
 
-* `addr::OccupationNumberFS`: the starting address
-* `v`: the coupling strength
-* `mass`: the particle mass
-* `omega`: the oscillation frequency of the phonons
-* `l`: the scale parameter of the momentum lattice
-* `p`: the total momentum
-* `momentum_cutoff`: the maximum total momentum allowed for a basis element
-* `mode_cutoff`: the maximum population in each momentum mode
+* `v=1.0`: the coupling strength, ``v``
+* `mass=1.0`: the particle mass, ``m``
+* `omega=1.0`: the oscillation frequency of the phonons, ``ω``
+* `l=1.0`: the scale parameter of the momentum lattice, ``l``
+* `p=0.0`: the total momentum, ``p``
+* `momentum_cutoff=nothing`: the maximum total momentum allowed for a basis element
+* `mode_cutoff=10.0`: the maximum population in each momentum mode
 
 """
 struct FroehlichPolaron{

--- a/src/Hamiltonians/FroehlichPolaron.jl
+++ b/src/Hamiltonians/FroehlichPolaron.jl
@@ -1,0 +1,107 @@
+"""
+    FroehlichPolaron(
+        address;
+        alpha = 1.0,
+        total_mom = 0.0,
+        geometry = nothing,
+        num_dimensions = 1
+    )
+
+The Froehlich polaron Hamiltonian is given by
+
+```math
+H = (P̂_f - P)^2 + N̂ + Σₖ νₖ (âₖ^† + â_{-k})
+```
+
+where ``P`` is the total momentum `total_mom`, ``P̂_f = Σ_k k âₖ^† âₖ`` is the momentum
+operator for the bosons, ``N̂ = Σ_k âₖ^† âₖ`` is the number operator for the bosons, and
+``νₖ = \\sqrt{α}/|k|`` is the coupling strength determined by the coupling parameter
+`α == alpha`.
+
+The optional `geometry` argument specifies the geometry of the lattice for ``k``-space and
+should be of the type [`PeriodicBoundaries`](@ref). A simplified way of specifying the
+geometry is to provide the number of dimensions `num_dimensions`. In this case the
+[`num_modes(address)`](@ref) of `address` must be a square number for `num_dimensions = 2`,
+or a cube number for `num_dimensions = 3`.
+
+The `address` must be of type [`OccupationNumberFS`](@ref).
+"""
+struct FroehlichPolaron{
+    P, # total momentum
+    T, # eltype
+    A<:OccupationNumberFS, # address type
+    G # lattice type
+} <: AbstractHamiltonian{T}
+    addr::A
+    alpha::T
+    geometry::G
+    # nu_k::Vector{T}
+    # p_squared_k::Vector{T}
+end
+
+function FroehlichPolaron(
+    addr::OccupationNumberFS;
+    geometry=nothing,
+    alpha=1.0,
+    total_mom=0.0,
+    num_dimensions=1
+)
+    M = num_modes(addr) # this is compile-time information
+    if isnothing(geometry)
+        if num_dimensions == 1
+            geometry = PeriodicBoundaries(M)
+        elseif num_dimensions == 2
+            sm = round(Int, sqrt(M))
+            if sm^2 == M
+                geometry = PeriodicBoundaries(sm, sm)
+            else
+                throw(ArgumentError("Number of modes $M is not a square. Specify geometry."))
+            end
+        elseif num_dimensions == 3
+            cm = round(Int, cbrt(M))
+            if cm^3 == M
+                geometry = PeriodicBoundaries(cm, cm, cm)
+            else
+                throw(ArgumentError("Number of modes $M is not a cube. Specify geometry."))
+            end
+        else
+            throw(ArgumentError("Invalid number of dimensions: $num_dimensions"))
+        end
+    end
+    geometry isa PeriodicBoundaries || throw(ArgumentError("Invalid geometry: $geometry"))
+    alpha, P = promote(float(alpha), float(total_mom))
+    return FroehlichPolaron{P,typeof(P),typeof(addr),typeof(geometry)}(addr, alpha, geometry)
+end
+
+function Base.show(io::IO, h::FroehlichPolaron)
+    print(io, "FroehlichPolaron($(h.addr); alpha=$(h.alpha), total_mom=$(h.total_mom), ")
+    print(io, "geometry=$(h.geometry))")
+end
+
+function starting_address(h::FroehlichPolaron)
+    return getfield(h, :addr)
+end
+
+LOStructure(::Type{<:FroehlichPolaron{<:Real}}) = IsHermitian()
+
+Base.getproperty(h::FroehlichPolaron, s::Symbol) = getproperty(h, Val(s))
+Base.getproperty(h::FroehlichPolaron, ::Val{:addr}) = getfield(h, :addr)
+Base.getproperty(h::FroehlichPolaron, ::Val{:alpha}) = getfield(h, :alpha)
+Base.getproperty(::FroehlichPolaron{P}, ::Val{:total_mom}) where P = P
+Base.getproperty(h::FroehlichPolaron, ::Val{:geometry}) = getfield(h, :geometry)
+
+num_dimensions(h::FroehlichPolaron) = num_dimensions(h.geometry)
+
+# function diagonal_element(h::FroehlichPolaron, addr::OccupationNumberFS)
+#     return (
+#         (-h.total_mom)^2 +
+#         num_particles(addr) +
+#         sum(νk(h, k) for k in momentum(h, addr))
+#     )
+# end
+
+# TODO: Sort out scales for momentum and energy; additional parameters?
+# TODO: pre-compute and store grid for p_squared_k (k.e.) and nu_k (coupling strength)
+# TODO: compute diagonal and off-diagonal elements
+# TODO: rest of AbstractHamiltonian interface
+# TODO: write unit tests for FroehlichPolaron

--- a/src/Hamiltonians/GutzwillerSampling.jl
+++ b/src/Hamiltonians/GutzwillerSampling.jl
@@ -73,6 +73,10 @@ Base.getproperty(h::GutzwillerSampling, s::Symbol) = getproperty(h, Val(s))
 Base.getproperty(h::GutzwillerSampling{<:Any,<:Any,<:Any,G}, ::Val{:g}) where G = G
 Base.getproperty(h::GutzwillerSampling, ::Val{:hamiltonian}) = getfield(h, :hamiltonian)
 
+function Base.:(==)(a::GutzwillerSampling{A}, b::GutzwillerSampling{B}) where {A,B}
+    return A == B && a.g == b.g && a.hamiltonian == b.hamiltonian
+end
+
 # Forward some interface functions.
 num_offdiagonals(h::GutzwillerSampling, add) = num_offdiagonals(h.hamiltonian, add)
 diagonal_element(h::GutzwillerSampling, add) = diagonal_element(h.hamiltonian, add)

--- a/src/Hamiltonians/Hamiltonians.jl
+++ b/src/Hamiltonians/Hamiltonians.jl
@@ -24,6 +24,7 @@ Harmonic oscillator models
 - [`HOCartesianCentralImpurity`](@ref)
 
 Other
+- [`FroehlichPolaron`](@ref)
 - [`MatrixHamiltonian`](@ref)
 - [`Transcorrelated1D`](@ref)
 
@@ -73,6 +74,7 @@ export TimeReversalSymmetry
 export Stoquastic
 export Transcorrelated1D
 export hubbard_dispersion, continuum_dispersion
+export FroehlichPolaron
 
 export G2MomCorrelator, G2RealCorrelator, SuperfluidCorrelator, DensityMatrixDiagonal, Momentum
 export StringCorrelator
@@ -102,6 +104,7 @@ include("ExtendedHubbardReal1D.jl")
 
 include("BoseHubbardReal1D2C.jl")
 include("BoseHubbardMom1D2C.jl")
+include("FroehlichPolaron.jl")
 
 include("GutzwillerSampling.jl")
 include("GuidingVectorSampling.jl")

--- a/src/Hamiltonians/MatrixHamiltonian.jl
+++ b/src/Hamiltonians/MatrixHamiltonian.jl
@@ -31,7 +31,9 @@ LOStructure(::Type{<:MatrixHamiltonian{<:Any,<:Any,true}}) = IsHermitian()
 LOStructure(::Type{<:MatrixHamiltonian}) = AdjointKnown()
 LinearAlgebra.adjoint(mh::MatrixHamiltonian) = MatrixHamiltonian(mh.m')
 LinearAlgebra.adjoint(mh::MatrixHamiltonian{<:Any,<:Any,true}) = mh
-
+function Base.:(==)(a::MatrixHamiltonian, b::MatrixHamiltonian)
+    return a.m == b.m && a.starting_index == b.starting_index
+end
 
 starting_address(mh::MatrixHamiltonian) = mh.starting_index
 

--- a/src/Hamiltonians/abstract.jl
+++ b/src/Hamiltonians/abstract.jl
@@ -60,7 +60,7 @@ function dimension(::BoseFS{N,M}) where {N,M}
 end
 function dimension(::OccupationNumberFS{M,T}) where {M,T}
     n = typemax(T)
-    return binomial(BigInt(n + M - 1), BigInt(n))
+    return BigInt(n + 1)^BigInt(M)
 end
 function dimension(::FermiFS{N,M}) where {N,M}
     return binomial(BigInt(M), BigInt(N))

--- a/src/Hamiltonians/abstract.jl
+++ b/src/Hamiltonians/abstract.jl
@@ -724,3 +724,6 @@ TransformUndoer(k::AbstractHamiltonian) = TransformUndoer(k::AbstractHamiltonian
 # common methods
 starting_address(s::TransformUndoer) = starting_address(s.transform)
 dimension(s::TransformUndoer, addr) = dimension(s.transform, addr)
+function Base.:(==)(a::TransformUndoer, b::TransformUndoer)
+    return a.transform == b.transform && a.op == b.op
+end

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -1046,35 +1046,35 @@ end
     # test momentum_cutoff and mode_cutoff when initialising
     addr2 = OccupationNumberFS(1,2,3)
     @test_throws ArgumentError FroehlichPolaron(addr2; mode_cutoff=1.0)
-    @test_throws ArgumentError FroehlichPolaron(addr2; momentum_cutoff = 10.0)
+    @test_throws ArgumentError FroehlichPolaron(addr2; momentum_cutoff=10.0)
 
     addr3 = OccupationNumberFS(1,2,3,4)
     f2 = FroehlichPolaron(addr2)
-    f3 = FroehlichPolaron(addr3;mode_cutoff = 20.0)
+    f3 = FroehlichPolaron(addr3; mode_cutoff=20.0)
 
     @test starting_address(f2) == f2.addr == addr2
 
     # test ks vector
     step = (2π/3)
-    ks2 = (3/1)*range(-π*(1+1/3) +  step; step=step, length = 3)
+    ks2 = (3/1)*range(-π*(1+1/3) +  step; step=step, length=3)
     @test Vector(f2.ks) == ks2
     step = (2π/4)
-    ks3 = (4/1)*range(-π+step; step=step, length = 4)
+    ks3 = (4/1)*range(-π+step; step=step, length=4)
     @test Vector(f3.ks) == ks3
 
     # test num_offdiagonals
     @test num_offdiagonals(f2, addr1) == 2*3
 
     # test diagonal_element
-    f2_diag = f2.omega*6 + (1/f2.mass) * (f2.p - dot(f2.ks,onr(addr2)))^2
-    @test diagonal_element(f2,addr2) == f2_diag
+    f2_diag = f2.omega*6 + (1/f2.mass) * (f2.p - dot(f2.ks, onr(addr2)))^2
+    @test diagonal_element(f2, addr2) == f2_diag
 
     # test offdiagonal element
     f2_offdiag = (OccupationNumberFS(1,3,3), -f2.v*sqrt(3))
-    @test get_offdiagonal(f2, addr2,2) == f2_offdiag
+    @test get_offdiagonal(f2, addr2, 2) == f2_offdiag
 
     f3_offdiag = (OccupationNumberFS(1,2,3,3), -f3.v*sqrt(4))
-    @test get_offdiagonal(f3, addr3,8) == f3_offdiag
+    @test get_offdiagonal(f3, addr3, 8) == f3_offdiag
 
     # test mode_cutoff
     @test get_offdiagonal(f2, OccupationNumberFS(10,3,4), 1)[2] ≠ 0.0
@@ -1083,7 +1083,7 @@ end
     # test momentum_cutoff
     # addr2 has momentum 12.56
     addr4 = OccupationNumberFS(1,2,1)
-    f4 = FroehlichPolaron(addr4; momentum_cutoff = 10.0)
+    f4 = FroehlichPolaron(addr4; momentum_cutoff=10.0)
     @test get_offdiagonal(f4, addr2, 3)[2] == 0.0
 end
 

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -1021,9 +1021,9 @@ end
     # test num_offdiagonals
     @test num_offdiagonals(f, addr1) == 2*3
 
-    # test diagonal_element
+    #TODO:test diagonal_element
 
-    # test offdiagonal element
+    #TODO:test offdiagonal element
 end
 
 @testset "HubbardMom1D(FermiFS2C)" begin

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -880,7 +880,7 @@ end
     m = 6
     n1 = 4
     n2 = m
-    
+
     # unital refers to n̄=1
     non_unital_localised_state = BoseFS((n1,0,0,0,0,0))
     non_unital_uniform_state = near_uniform(non_unital_localised_state)
@@ -893,7 +893,7 @@ end
     S2 = StringCorrelator(2)
 
     @test num_offdiagonals(S0, localised_state) == 0
-    
+
     # non unital localised state
     @test @inferred diagonal_element(S0, non_unital_localised_state) ≈ 20/9
     @test @inferred diagonal_element(S1, non_unital_localised_state) ≈ (-4/9)*exp(im * -2pi/3)
@@ -918,7 +918,7 @@ end
     d = 5
     output = @capture_out print(StringCorrelator(d))
     @test output == "StringCorrelator($d)"
-    
+
 end
 
 @testset "Momentum" begin
@@ -1586,5 +1586,16 @@ end
 
         null_addr = BoseFS(prod(S), 1=>0)
         @test isempty(fock_to_cart(null_addr, S))
+    end
+
+    @testset "FroehlichPolaron" begin
+        addr = OccupationNumberFS(0, 0, 0, 0, 1, 0, 0, 0)
+        ham = FroehlichPolaron(addr; total_mom=3, alpha=6, num_dimensions=3)
+        @test num_dimensions(ham) == num_dimensions(ham.geometry) == 3
+        @test ham.geometry == PeriodicBoundaries(2, 2, 2)
+        @test eval(Meta.parse(repr(ham))) == ham
+        @test starting_address(ham) == ham.addr == addr
+
+        # TODO: test the rest of the interface (add `FroehlichPolaron` to interface tests)
     end
 end

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -1602,14 +1602,6 @@ end
     end
 
     @testset "FroehlichPolaron" begin
-        # TESTS FOR OLD IMPLEMENTATION
-        # addr = OccupationNumberFS(0, 0, 0, 0, 1, 0, 0, 0)
-        # ham = FroehlichPolaron(addr; total_mom=3, alpha=6, num_dimensions=3)
-        # @test num_dimensions(ham) == num_dimensions(ham.geometry) == 3
-        # @test ham.geometry == PeriodicBoundaries(2, 2, 2)
-        # @test eval(Meta.parse(repr(ham))) == ham
-        # @test starting_address(ham) == ham.addr == addr
-
         addr1 = OccupationNumberFS(1,1,1)
 
         # test momentum_cutoff and mode_cutoff when initialising

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -1046,15 +1046,15 @@ end
     # test momentum_cutoff and mode_cutoff when initialising
     addr2 = OccupationNumberFS(1,2,3)
     @test_throws ArgumentError FroehlichPolaron(addr2; mode_cutoff=1.0)
-    @test_throws ArgumentError FroehlichPolaron(addr2; momentum_cutoff = 10.0) 
-    
+    @test_throws ArgumentError FroehlichPolaron(addr2; momentum_cutoff = 10.0)
+
     addr3 = OccupationNumberFS(1,2,3,4)
     f2 = FroehlichPolaron(addr2)
     f3 = FroehlichPolaron(addr3;mode_cutoff = 20.0)
 
     @test starting_address(f2) == f2.addr == addr2
 
-    # test ks vector 
+    # test ks vector
     step = (2π/3)
     ks2 = (3/1)*range(-π*(1+1/3) +  step; step=step, length = 3)
     @test Vector(f2.ks) == ks2
@@ -1077,7 +1077,7 @@ end
     @test get_offdiagonal(f3, addr3,8) == f3_offdiag
 
     # test mode_cutoff
-    @test get_offdiagonal(f2, OccupationNumberFS(10,3,4), 1)[2] == 0.0
+    @test get_offdiagonal(f2, OccupationNumberFS(10,3,4), 1)[2] ≠ 0.0
     @test get_offdiagonal(f3, OccupationNumberFS(1,3,20,10), 3)[2] == 0.0
 
     # test momentum_cutoff

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -1040,6 +1040,53 @@ end
     end
 end
 
+@testset "FroehlichPolaron" begin
+    addr1 = OccupationNumberFS(1,1,1)
+
+    # test momentum_cutoff and mode_cutoff when initialising
+    addr2 = OccupationNumberFS(1,2,3)
+    @test_throws ArgumentError FroehlichPolaron(addr2; mode_cutoff=1.0)
+    @test_throws ArgumentError FroehlichPolaron(addr2; momentum_cutoff = 10.0) 
+    
+    addr3 = OccupationNumberFS(1,2,3,4)
+    f2 = FroehlichPolaron(addr2)
+    f3 = FroehlichPolaron(addr3;mode_cutoff = 20.0)
+
+    @test starting_address(f2) == f2.addr == addr2
+
+    # test ks vector 
+    step = (2π/3)
+    ks2 = (3/1)*range(-π*(1+1/3) +  step; step=step, length = 3)
+    @test Vector(f2.ks) == ks2
+    step = (2π/4)
+    ks3 = (4/1)*range(-π+step; step=step, length = 4)
+    @test Vector(f3.ks) == ks3
+
+    # test num_offdiagonals
+    @test num_offdiagonals(f2, addr1) == 2*3
+
+    # test diagonal_element
+    f2_diag = f2.omega*6 + (1/f2.mass) * (f2.p - dot(f2.ks,onr(addr2)))^2
+    @test diagonal_element(f2,addr2) == f2_diag
+
+    # test offdiagonal element
+    f2_offdiag = (OccupationNumberFS(1,3,3), -f2.v*sqrt(3))
+    @test get_offdiagonal(f2, addr2,2) == f2_offdiag
+
+    f3_offdiag = (OccupationNumberFS(1,2,3,3), -f3.v*sqrt(4))
+    @test get_offdiagonal(f3, addr3,8) == f3_offdiag
+
+    # test mode_cutoff
+    @test get_offdiagonal(f2, OccupationNumberFS(10,3,4), 1)[2] == 0.0
+    @test get_offdiagonal(f3, OccupationNumberFS(1,3,20,10), 3)[2] == 0.0
+
+    # test momentum_cutoff
+    # addr2 has momentum 12.56
+    addr4 = OccupationNumberFS(1,2,1)
+    f4 = FroehlichPolaron(addr4; momentum_cutoff = 10.0)
+    @test get_offdiagonal(f4, addr2, 3)[2] == 0.0
+end
+
 """
     compare_to_bethe(g, nf, m)
 
@@ -1601,52 +1648,6 @@ end
         @test isempty(fock_to_cart(null_addr, S))
     end
 
-    @testset "FroehlichPolaron" begin
-        addr1 = OccupationNumberFS(1,1,1)
-
-        # test momentum_cutoff and mode_cutoff when initialising
-        addr2 = OccupationNumberFS(1,2,3)
-        @test_throws ArgumentError FroehlichPolaron(addr2; mode_cutoff=1.0)
-        @test_throws ArgumentError FroehlichPolaron(addr2; momentum_cutoff = 10.0) 
-        
-        addr3 = OccupationNumberFS(1,2,3,4)
-        f2 = FroehlichPolaron(addr2)
-        f3 = FroehlichPolaron(addr3;mode_cutoff = 20.0)
-    
-        @test starting_address(f2) == f2.addr == addr2
-    
-        # test ks vector 
-        step = (2π/3)
-        ks2 = (3/1)*range(-π*(1+1/3) +  step; step=step, length = 3)
-        @test Vector(f2.ks) == ks2
-        step = (2π/4)
-        ks3 = (4/1)*range(-π+step; step=step, length = 4)
-        @test Vector(f3.ks) == ks3
-    
-        # test num_offdiagonals
-        @test num_offdiagonals(f2, addr1) == 2*3
-    
-        # test diagonal_element
-        f2_diag = f2.omega*6 + (1/f2.mass) * (f2.p - dot(f2.ks,onr(addr2)))^2
-        @test diagonal_element(f2,addr2) == f2_diag
-    
-        # test offdiagonal element
-        f2_offdiag = (OccupationNumberFS(1,3,3), -f2.v*sqrt(3))
-        @test get_offdiagonal(f2, addr2,2) == f2_offdiag
-    
-        f3_offdiag = (OccupationNumberFS(1,2,3,3), -f3.v*sqrt(4))
-        @test get_offdiagonal(f3, addr3,8) == f3_offdiag
-    
-        # test mode_cutoff
-        @test get_offdiagonal(f2, OccupationNumberFS(10,3,4), 1)[2] == 0.0
-        @test get_offdiagonal(f3, OccupationNumberFS(1,3,20,10), 3)[2] == 0.0
-    
-        # test momentum_cutoff
-        # addr2 has momentum 12.56
-        addr4 = OccupationNumberFS(1,2,1)
-        f4 = FroehlichPolaron(addr4; momentum_cutoff = 10.0)
-        @test get_offdiagonal(f4, addr2, 3)[2] == 0.0
-    end
 end
 
 @testset "dimension and multi-component addresses" begin

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -75,6 +75,10 @@ function test_hamiltonian_interface(H, addr=starting_address(H))
             @test number_of_nonzero_offdiagonals ≤ num_offdiagonals(H, addr)
             @test number_of_nonzero_offdiagonals ≤ dimension(H, addr)
         end
+        @testset "show" begin
+            # Check that the result of show can be pasted into the REPL
+            @test eval(Meta.parse(repr(H))) == H
+        end
     end
 end
 

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -189,7 +189,10 @@ end
 
         HOCartesianContactInteractions(BoseFS((2,0,0,0))),
         HOCartesianEnergyConservedPerDim(BoseFS((2,0,0,0))),
-        HOCartesianCentralImpurity(BoseFS((1,0,0,0,0)))
+        HOCartesianCentralImpurity(BoseFS((1,0,0,0,0))),
+
+        FroehlichPolaron(OccupationNumberFS(1,1,1)),
+        FroehlichPolaron(OccupationNumberFS(1,1,1); momentum_cutoff = 10.0)
     )
         test_hamiltonian_interface(H)
     end
@@ -993,6 +996,34 @@ end
     # ylabel!("Energy")
     # xlabel!("ho quantum number n")
     # title!("Harmonic oscillator in Hubbard, M = $m, l_0 = $l0")
+end
+
+@testset "FroehlichPolaron" begin
+    addr1 = OccupationNumberFS(1,1,1)
+
+    # Test momentum_cutoff and mode_cutoff
+    addr2 = OccupationNumberFS(1,2,3)
+    @test_throws ArgumentError FroehlichPolaron(addr2; mode_cutoff=1.0)
+    @test_throws ArgumentError FroehlichPolaron(addr2; momentum_cutoff = 10.0) 
+    
+    addr3 = OccupationNumberFS(1,2,3,4)
+    f2 = FroehlichPolaron(addr2)
+    f3 = FroehlichPolaron(addr3)
+
+    # test ks vector 
+    step = (2π/3)
+    ks2 = range(-π*(1+1/3) +  step; step=step, length = 3)
+    @test Vector(f2.ks) == ks2
+    step = (2π/4)
+    ks3 = range(-π+step; step=step, length = 4)
+    @test Vector(f3.ks) == ks3
+
+    # test num_offdiagonals
+    @test num_offdiagonals(f, addr1) == 2*3
+
+    # test diagonal_element
+
+    # test offdiagonal element
 end
 
 @testset "HubbardMom1D(FermiFS2C)" begin

--- a/test/lomc.jl
+++ b/test/lomc.jl
@@ -12,6 +12,7 @@ using Statistics
 using Logging
 using DataFrames
 
+Random.seed!(1234)
 @testset "lomc!/QMCState" begin
     @testset "Setting laststep + working memory" begin
         add = BoseFS{5,2}((2,3))


### PR DESCRIPTION
Implements the `FroehlichPolaron` Hamiltonian for the Froehlich Polaron problem in a natural momentum space Fock basis. The Hamiltonian doesn't conserve boson number and makes use of `OccupationNumberFS`

TODO:
- [x] Finish the implementation of `FroehlichPolaron` (complete the `AbstractHamiltonian` interface with appropriate unit tests)
- [x] `num_offdiagonals`
- [x] `get_offdiagonal`
- [x] `diagonal_element`
- [x] `starting_address`
- [x] support one spatial dimension
- [ ] support multiple spatial dimensions (2 and 3)