### PR TITLE
Use caching in GH actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -34,7 +34,7 @@ jobs:
       - name: "Load cache"
         uses: julia-actions/cache@v1
       - name: "Build"
-        uses: julia-actions/julia-buildpkg@latest
+        uses: julia-actions/julia-buildpkg@v1
       - name: "Run tests"
         run: |
           julia --color=yes --project=@. -t2 -e "using Pkg; Pkg.test(\"Rimu\"; coverage=true);"
@@ -58,7 +58,7 @@ jobs:
           mpiexecjl -n 2 julia --code-coverage=user --depwarn=yes --project=test test/mpi_runtests.jl
 
       - name: "Process coverage"
-        uses: julia-actions/julia-processcoverage@latest
+        uses: julia-actions/julia-processcoverage@v1
       - name: "Coveralls"
         uses: coverallsapp/github-action@v2
         with:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -25,12 +25,14 @@ jobs:
       fail-fast: false
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: "Setup Julia"
         uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.julia-version }}
           arch: ${{ matrix.julia-arch }}
+      - name: "Load cache"
+        uses: julia-actions/cache@v1
       - name: "Build"
         uses: julia-actions/julia-buildpkg@latest
       - name: "Run tests"

--- a/.github/workflows/allocations.yml
+++ b/.github/workflows/allocations.yml
@@ -17,12 +17,13 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: "Set up Julia"
         uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.julia-version }}
           arch: ${{ matrix.julia-arch }}
+      - uses: julia-actions/cache@v1
       - name: "Run test"
         run: |
           julia --project=@. -e "using Pkg; Pkg.instantiate(); Pkg.build()"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -6,11 +6,12 @@ jobs:
   run:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@latest
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v1
         with:
           version: 1
-      - uses: julia-actions/julia-buildpkg@latest
+      - uses: julia-actions/cache@v1
+      - uses: julia-actions/julia-buildpkg@v1
       - name: Install dependencies
         run: julia -e 'using Pkg; pkg"add PkgBenchmark BenchmarkTools BenchmarkCI@0.1"'
       - name: Run benchmarks

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,10 +21,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@latest
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v1
         with:
           version: '1.7'
+      - uses: julia-actions/cache@v1
       - name: Install dependencies
         run: |
           export JULIA_PROJECT=@.


### PR DESCRIPTION
According to [this post](https://discourse.julialang.org/t/this-month-in-julia-world-2024-01/109549), it should dramatically improve the speed of CI. 
* updated the checkout action to v4. Not sure what the differences are, but probably won't hurt.
* added [dependabot](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot) to keep GH actions up to date