### PR TITLE
Skip docs and benchmarks on dependabot PRs

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,6 +1,9 @@
 name: Benchmarks
 
-on: pull_request
+on:
+  pull_request:
+    branches-ignore:
+    - 'dependabot/**'
 
 jobs:
   run:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,8 @@ on:
       - feature/github-actions
       - feature/doc-**
       - 'doc/**'
+    branches-ignore:
+      - 'dependabot/**'
     tags: '*'
   pull_request:
     branches:
@@ -16,6 +18,8 @@ on:
       - feature/github-actions
       - feature/doc-**
       - 'doc/**'
+    branches-ignore:
+      - 'dependabot/**'
 
 jobs:
   build:


### PR DESCRIPTION
I think this should fix the dependabot problems. Once merged, we can tell it to rebase its PRs to check.