### PR TITLE
Dependabot benchmark and doc ignores, reorganize what action is run when

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,18 +1,7 @@
 name: Run tests
 
 on:
-  push:
-    branches:
-      - master
-      - develop
-      - 'feature/**'
-      - 'bugfix/**'
-    # tags: '*'
-  pull_request:
-    branches:
-      - master
-      - develop
-      - feature/github-actions
+  push
 
 jobs:
   test:

--- a/.github/workflows/allocations.yml
+++ b/.github/workflows/allocations.yml
@@ -1,7 +1,9 @@
 name: Allocations
 
 on:
-  push
+  pull_request:
+    branches-ignore:
+    - 'doc/**'
 
 jobs:
   allocations:

--- a/.github/workflows/allocations.yml
+++ b/.github/workflows/allocations.yml
@@ -1,11 +1,7 @@
 name: Allocations
 
 on:
-  push:
-    branches:
-      - develop
-      - 'feature/**'
-      - 'bugfix/**'
+  push
 
 jobs:
   allocations:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,6 +1,14 @@
 name: Benchmarks
 
-on: pull_request
+on:
+  pull_request:
+    branches-ignore:
+    - 'dependabot/**'
+    - 'doc/**'
+  push:
+    branches-ignore:
+    - 'dependabot/**'
+    - 'doc/**'
 
 jobs:
   run:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -3,11 +3,6 @@ name: Benchmarks
 on:
   pull_request:
     branches-ignore:
-    - 'dependabot/**'
-    - 'doc/**'
-  push:
-    branches-ignore:
-    - 'dependabot/**'
     - 'doc/**'
 
 jobs:
@@ -53,13 +48,13 @@ jobs:
 
       # create/update comment
       - name: create comment
-        if: ${{ steps.fc.outputs.comment-id == 0 }}
+        if: ${{ steps.fc.outputs.comment-id == 0 }} && github.actor != 'dependabot[bot]'
         uses: peter-evans/create-or-update-comment@v1
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: ${{ steps.generate-result-markdown.outputs.body }}
       - name: update comment
-        if: ${{ steps.fc.outputs.comment-id != 0 }}
+        if: ${{ steps.fc.outputs.comment-id != 0 }} && github.actor != 'dependabot[bot]'
         uses: peter-evans/create-or-update-comment@v1
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - develop
-    tags: '*'
   pull_request
 
 jobs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,23 +3,9 @@ name: Documentation
 on:
   push:
     branches:
-      - master
       - develop
-      - feature/github-actions
-      - feature/doc-**
-      - 'doc/**'
-    branches-ignore:
-      - 'dependabot/**'
     tags: '*'
-  pull_request:
-    branches:
-      - master
-      - develop
-      - feature/github-actions
-      - feature/doc-**
-      - 'doc/**'
-    branches-ignore:
-      - 'dependabot/**'
+  pull_request
 
 jobs:
   build:
@@ -42,6 +28,7 @@ jobs:
           julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
           julia --project=docs/ -e 'using Rimu'
       - name: Build and deploy
+        if: github.actor != 'dependabot[bot]'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: julia --project=docs/ docs/make.jl

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,7 +1,12 @@
 name: Documentation
 
 on:
-  push
+  push:
+    branches:
+      - develop
+  pull_request:
+    branches:
+      - '*'
 
 jobs:
   build:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,10 +1,7 @@
 name: Documentation
 
 on:
-  push:
-    branches:
-      - develop
-  pull_request
+  push
 
 jobs:
   build:


### PR DESCRIPTION
Another attempt to disable the benchmark and docs workflows with dependabot.
It turns out that you can't use `branches-ignore` with jobs that run on pull requests as the filtering works on the target branch only.

I also included that following changes to the actions:
- docs run every push to `develop`, and on pull requests.
- benchmarks and allocations run on pull requests, except if it's a `doc` branch.
- tests run on push for every branch. It used to run on pull request too, which resulted in the tests being run twice on each PR.
- doc deployment and benchmark comment are only performed if it's not authored by dependabot