### PR TITLE
Rework Geometry, add new G2 correlator

### DIFF
--- a/docs/src/hamiltonians.md
+++ b/docs/src/hamiltonians.md
@@ -161,7 +161,6 @@ Lattices in higher dimensions are defined here for [`HubbardRealSpace`](@ref) an
 
 ```@docs
 Geometry
-num_dimensions
 Hamiltonians.UnitVectors
 Hamiltonians.Offsets
 Hamiltonians.neighbor_site

--- a/docs/src/hamiltonians.md
+++ b/docs/src/hamiltonians.md
@@ -164,6 +164,9 @@ Geometry
 Hamiltonians.UnitVectors
 Hamiltonians.Offsets
 Hamiltonians.neighbor_site
+PeriodicBoundaries
+HardwallBoundaries
+LadderBoundaries
 ```
 
 ## Harmonic Oscillator

--- a/docs/src/hamiltonians.md
+++ b/docs/src/hamiltonians.md
@@ -102,8 +102,9 @@ Observables are [`AbstractHamiltonian`](@ref)s that represent a physical
 observable. Their ground state expectation values can be sampled by passing
 them into [`AllOverlaps`](@ref).
 ```@docs
-G2MomCorrelator
 G2RealCorrelator
+G2RealSpace
+G2MomCorrelator
 SuperfluidCorrelator
 StringCorrelator
 DensityMatrixDiagonal
@@ -155,20 +156,18 @@ Hamiltonians.number_conserving_fermi_dimension
 ```
 
 ## Geometry
-Lattices in higher dimensions are defined here for [`HubbardRealSpace`](@ref).
+Lattices in higher dimensions are defined here for [`HubbardRealSpace`](@ref) and [`G2RealSpace`](@ref).
 
 ```@docs
-LatticeGeometry
-PeriodicBoundaries
-HardwallBoundaries
-LadderBoundaries
-num_neighbours
+Geometry
 num_dimensions
-neighbour_site
+Hamiltonians.UnitVectors
+Hamiltonians.Offsets
+Hamiltonians.neighbor_site
 ```
 
 ## Harmonic Oscillator
-Useful utilities for harmonic oscillator in Cartesian basis, see [`HOCartesianContactInteractions`](@ref) 
+Useful utilities for harmonic oscillator in Cartesian basis, see [`HOCartesianContactInteractions`](@ref)
 and [`HOCartesianEnergyConservedPerDim`](@ref).
 ```@docs
 get_all_blocks

--- a/docs/src/hamiltonians.md
+++ b/docs/src/hamiltonians.md
@@ -157,11 +157,12 @@ Hamiltonians.number_conserving_fermi_dimension
 ```
 
 ## Geometry
+
 Lattices in higher dimensions are defined here for [`HubbardRealSpace`](@ref) and [`G2RealSpace`](@ref).
 
 ```@docs
-Geometry
-Hamiltonians.UnitVectors
+CubicGrid
+Hamiltonians.Directions
 Hamiltonians.Offsets
 Hamiltonians.neighbor_site
 PeriodicBoundaries

--- a/docs/src/hamiltonians.md
+++ b/docs/src/hamiltonians.md
@@ -163,7 +163,7 @@ Lattices in higher dimensions are defined here for [`HubbardRealSpace`](@ref) an
 ```@docs
 CubicGrid
 Hamiltonians.Directions
-Hamiltonians.Offsets
+Hamiltonians.Displacements
 Hamiltonians.neighbor_site
 PeriodicBoundaries
 HardwallBoundaries

--- a/src/DictVectors/abstractdvec.jl
+++ b/src/DictVectors/abstractdvec.jl
@@ -296,7 +296,8 @@ Internal function evaluates the 3-argument `dot()` function in order from right
 to left.
 """
 function dot_from_right(w, op, v::AbstractDVec)
-    result = zero(promote_type(valtype(w), eltype(op), valtype(v)))
+    T = typeof(zero(valtype(w)) * zero(eltype(op)) * zero(valtype(v)))
+    result = zero(T)
     for (key, val) in pairs(v)
         result += conj(w[key]) * diagonal_element(op, key) * val
         for (add, elem) in offdiagonals(op, key)

--- a/src/DictVectors/communicators.jl
+++ b/src/DictVectors/communicators.jl
@@ -47,7 +47,7 @@ is_distributed(::Communicator) = true
 
 Merge the results of reductions over MPI. By default, it uses `MPI.Allreduce`.
 """
-merge_remote_reductions(c::Communicator, op, x) = only(MPI.Allreduce!([x], op, mpi_comm(c)))
+merge_remote_reductions(c::Communicator, op, x) = MPI.Allreduce!(Ref(x), op, mpi_comm(c))[]
 
 """
     total_num_segments(c::Communicator, n) -> Int

--- a/src/DictVectors/communicators.jl
+++ b/src/DictVectors/communicators.jl
@@ -47,7 +47,7 @@ is_distributed(::Communicator) = true
 
 Merge the results of reductions over MPI. By default, it uses `MPI.Allreduce`.
 """
-merge_remote_reductions(c::Communicator, op, x) = MPI.Allreduce(x, op, mpi_comm(c))
+merge_remote_reductions(c::Communicator, op, x) = only(MPI.Allreduce!([x], op, mpi_comm(c)))
 
 """
     total_num_segments(c::Communicator, n) -> Int

--- a/src/DictVectors/pdvec.jl
+++ b/src/DictVectors/pdvec.jl
@@ -769,7 +769,7 @@ end
 function LinearAlgebra.dot(
     ::IsDiagonal, t::PDVec, op::AbstractHamiltonian, u::PDVec, w=nothing
 )
-    T = promote_type(valtype(t), eltype(op), valtype(u))
+    T = typeof(zero(valtype(t)) * zero(valtype(u)) * zero(eltype(op)))
     return sum(pairs(u); init=zero(T)) do (k, v)
         T(conj(t[k]) * diagonal_element(op, k) * v)
     end
@@ -809,7 +809,8 @@ function LinearAlgebra.dot(
 end
 
 function dot_from_right(target, op, source::PDVec)
-    T = promote_type(valtype(target), valtype(source), eltype(op))
+    T = typeof(zero(valtype(target)) * zero(valtype(source)) * zero(eltype(op)))
+
     result = sum(pairs(source); init=zero(T)) do (k, v)
         res = conj(target[k]) * diagonal_element(op, k) * v
         for (k_off, v_off) in offdiagonals(op, k)

--- a/src/Hamiltonians/GutzwillerSampling.jl
+++ b/src/Hamiltonians/GutzwillerSampling.jl
@@ -135,7 +135,7 @@ function TransformUndoer(k::GutzwillerSampling, op::Union{Nothing,AbstractHamilt
     if isnothing(op)
         T = eltype(k)
     else
-        T = promote_type(eltype(k), eltype(op))
+        T = typeof(zero(eltype(k)) * zero(eltype(op)))
     end
     return TransformUndoer{T,typeof(k),typeof(op)}(k, op)
 end

--- a/src/Hamiltonians/Hamiltonians.jl
+++ b/src/Hamiltonians/Hamiltonians.jl
@@ -88,7 +88,6 @@ export G2MomCorrelator, G2RealCorrelator, G2RealSpace, SuperfluidCorrelator, Den
 export StringCorrelator
 
 export Geometry, PeriodicBoundaries, HardwallBoundaries, LadderBoundaries
-export num_neighbours, neighbour_site, num_dimensions
 
 export sparse # from SparseArrays
 

--- a/src/Hamiltonians/Hamiltonians.jl
+++ b/src/Hamiltonians/Hamiltonians.jl
@@ -58,7 +58,7 @@ using Parameters: Parameters, @unpack
 using Setfield: Setfield
 using SparseArrays: SparseArrays, nnz, nzrange, sparse
 using SpecialFunctions: SpecialFunctions, gamma
-using StaticArrays: StaticArrays, SA, SMatrix, SVector, SArray
+using StaticArrays: StaticArrays, SA, SMatrix, SVector, SArray, setindex
 using TupleTools: TupleTools
 
 using ..BitStringAddresses

--- a/src/Hamiltonians/Hamiltonians.jl
+++ b/src/Hamiltonians/Hamiltonians.jl
@@ -84,10 +84,10 @@ export Transcorrelated1D
 export hubbard_dispersion, continuum_dispersion
 export FroehlichPolaron
 
-export G2MomCorrelator, G2RealCorrelator, SuperfluidCorrelator, DensityMatrixDiagonal, Momentum
+export G2MomCorrelator, G2RealCorrelator, G2RealSpace, SuperfluidCorrelator, DensityMatrixDiagonal, Momentum
 export StringCorrelator
 
-export LatticeGeometry, PeriodicBoundaries, HardwallBoundaries, LadderBoundaries
+export Geometry, PeriodicBoundaries, HardwallBoundaries, LadderBoundaries
 export num_neighbours, neighbour_site, num_dimensions
 
 export sparse # from SparseArrays

--- a/src/Hamiltonians/Hamiltonians.jl
+++ b/src/Hamiltonians/Hamiltonians.jl
@@ -58,7 +58,7 @@ using Parameters: Parameters, @unpack
 using Setfield: Setfield
 using SparseArrays: SparseArrays, nnz, nzrange, sparse
 using SpecialFunctions: SpecialFunctions, gamma
-using StaticArrays: StaticArrays, SA, SMatrix, SVector
+using StaticArrays: StaticArrays, SA, SMatrix, SVector, SArray
 using TupleTools: TupleTools
 
 using ..BitStringAddresses

--- a/src/Hamiltonians/Hamiltonians.jl
+++ b/src/Hamiltonians/Hamiltonians.jl
@@ -37,8 +37,9 @@ Other
 
 ## [Observables](#Observables)
 - [`ParticleNumberOperator`](@ref)
-- [`G2MomCorrelator`](@ref)
 - [`G2RealCorrelator`](@ref)
+- [`G2RealSpace`](@ref)
+- [`G2MomCorrelator`](@ref)
 - [`DensityMatrixDiagonal`](@ref)
 - [`Momentum`](@ref)
 - [`AxialAngularMomentumHO`](@ref)

--- a/src/Hamiltonians/Hamiltonians.jl
+++ b/src/Hamiltonians/Hamiltonians.jl
@@ -89,7 +89,7 @@ export ParticleNumberOperator
 export G2MomCorrelator, G2RealCorrelator, G2RealSpace, SuperfluidCorrelator, DensityMatrixDiagonal, Momentum
 export StringCorrelator
 
-export Geometry, PeriodicBoundaries, HardwallBoundaries, LadderBoundaries
+export CubicGrid, PeriodicBoundaries, HardwallBoundaries, LadderBoundaries
 
 export sparse # from SparseArrays
 

--- a/src/Hamiltonians/HubbardRealSpace.jl
+++ b/src/Hamiltonians/HubbardRealSpace.jl
@@ -18,10 +18,10 @@ See also [`BoseFS`](@ref), [`FermiFS`](@ref), [`CompositeFS`](@ref).
 local_interaction(b::SingleComponentFockAddress, u) = u * bose_hubbard_interaction(b) / 2
 local_interaction(f::FermiFS, _) = 0
 function local_interaction(a::SingleComponentFockAddress, b::SingleComponentFockAddress, u)
-    u * dot(occupied_modes(a), occupied_modes(b))
+    return u * dot(occupied_modes(a), occupied_modes(b))
 end
 function local_interaction(fs::CompositeFS, u)
-    _interactions(fs.components, u)
+    return _interactions(fs.components, u)
 end
 
 """
@@ -140,7 +140,7 @@ is produced if `address`is incompatible with the interaction parameters `u`.
 
 ## Geometries
 
-Implemented [`LatticeGeometry`](@ref)s for keyword `geometry`
+Implemented [`Geometry`](@ref)s for keyword `geometry`
 
 * [`PeriodicBoundaries`](@ref)
 * [`HardwallBoundaries`](@ref)
@@ -163,7 +163,7 @@ number of sites `M` inferred from the number of modes in `address`.
 struct HubbardRealSpace{
     C, # components
     A<:AbstractFockAddress,
-    G<:LatticeGeometry,
+    G<:Geometry,
     D, # dimension
     # The following need to be type params.
     T<:SVector{C,Float64},
@@ -181,7 +181,7 @@ end
 
 function HubbardRealSpace(
     address::AbstractFockAddress;
-    geometry::LatticeGeometry=PeriodicBoundaries((num_modes(address),)),
+    geometry::Geometry=PeriodicBoundaries((num_modes(address),)),
     t=ones(num_components(address)),
     u=ones(num_components(address), num_components(address)),
     v=zeros(num_components(address), num_dimensions(geometry))
@@ -313,7 +313,7 @@ struct HubbardRealSpaceCompOffdiagonals{G,A} <: AbstractOffdiagonals{A,Float64}
 end
 
 function offdiagonals(h::HubbardRealSpace, comp, add)
-    neighbours = num_neighbours(h.geometry)
+    neighbours = 2 * num_dimensions(h.geometry)
     return HubbardRealSpaceCompOffdiagonals(
         h.geometry, add, h.t[comp], num_occupied_modes(add) * neighbours
     )
@@ -322,10 +322,10 @@ end
 Base.size(o::HubbardRealSpaceCompOffdiagonals) = (o.length,)
 
 @inline function Base.getindex(o::HubbardRealSpaceCompOffdiagonals, chosen)
-    neighbours = num_neighbours(o.geometry)
+    neighbours = 2 * num_dimensions(o.geometry)
     particle, neigh = fldmod1(chosen, neighbours)
     src_index = find_occupied_mode(o.address, particle)
-    neigh = neighbour_site(o.geometry, src_index.mode, neigh)
+    neigh = neighbor_site(o.geometry, src_index.mode, neigh)
 
     if neigh == 0
         return o.address, 0.0

--- a/src/Hamiltonians/HubbardRealSpace.jl
+++ b/src/Hamiltonians/HubbardRealSpace.jl
@@ -140,7 +140,7 @@ is produced if `address`is incompatible with the interaction parameters `u`.
 
 ## Geometries
 
-Implemented [`Geometry`](@ref)s for keyword `geometry`
+Implemented [`CubicGrid`](@ref)s for keyword `geometry`
 
 * [`PeriodicBoundaries`](@ref)
 * [`HardwallBoundaries`](@ref)
@@ -163,7 +163,7 @@ number of sites `M` inferred from the number of modes in `address`.
 struct HubbardRealSpace{
     C, # components
     A<:AbstractFockAddress,
-    G<:Geometry,
+    G<:CubicGrid,
     D, # dimension
     # The following need to be type params.
     T<:SVector{C,Float64},
@@ -181,7 +181,7 @@ end
 
 function HubbardRealSpace(
     address::AbstractFockAddress;
-    geometry::Geometry=PeriodicBoundaries((num_modes(address),)),
+    geometry::CubicGrid=PeriodicBoundaries((num_modes(address),)),
     t=ones(num_components(address)),
     u=ones(num_components(address), num_components(address)),
     v=zeros(num_components(address), num_dimensions(geometry))

--- a/src/Hamiltonians/correlation_functions.jl
+++ b/src/Hamiltonians/correlation_functions.jl
@@ -154,10 +154,10 @@ num_offdiagonals(g2::G2RealSpace, _) = 0
 
         # Case of n_i(n_i - 1) on the same component
         if A == B && all(==(0), δ_vec)
-            v2_offset = max.(v2 .- 1, 0)
-            result = setindex(result, dot(v1, v2_offset), i)
+            v1_offset = max.(v1 .- 1, 0)
+            result = setindex(result, dot(v2, v1_offset), i)
         else
-            result = setindex(result, circshift_dot(v1, v2, δ_vec), i)
+            result = setindex(result, circshift_dot(v2, v1, δ_vec), i)
         end
     end
     return result ./ length(geo)

--- a/src/Hamiltonians/correlation_functions.jl
+++ b/src/Hamiltonians/correlation_functions.jl
@@ -110,7 +110,7 @@ Two-body operator for density-density correlation for all displacements ``d`` in
 specified geometry.
 
 ```math
-    \\hat{G}^{(2)}(d) = \\frac{1}{M} ∑_i^M \\hat{n}_{σ,i} (\\hat{n}_{τ,i+d} - δ_{0,d}δ_{σ,τ}).
+    \\hat{G}^{(2)}_{σ,τ}(d) = \\frac{1}{M} ∑_i^M \\hat{n}_{σ,i} (\\hat{n}_{τ,i+d} - δ_{0,d}δ_{σ,τ}).
 ```
 
 For multicomponent addresses, `σ` and `τ` control the components involved. Alternatively, `sum_components` can be set to `true`, which treats all particles as

--- a/src/Hamiltonians/correlation_functions.jl
+++ b/src/Hamiltonians/correlation_functions.jl
@@ -147,6 +147,9 @@ end
 function Base.show(io::IO, g2::G2RealSpace{A,B}) where {A,B}
     print(io, "G2RealSpace($(g2.geometry), $A,$B)")
 end
+function Base.show(io::IO, g2::G2RealSpace{0,0})
+    print(io, "G2RealSpace($(g2.geometry); sum_components=true)")
+end
 
 LOStructure(::Type{<:G2RealSpace}) = IsDiagonal()
 

--- a/src/Hamiltonians/correlation_functions.jl
+++ b/src/Hamiltonians/correlation_functions.jl
@@ -166,7 +166,7 @@ num_offdiagonals(g2::G2RealSpace, _) = 0
         displacement = Offsets(geo)[i]
 
         # Case of n_i(n_i - 1) on the same component
-        if A == B && is_zero(displacement)
+        if A == B && iszero(displacement)
             onr1_minus_1 = max.(onr1 .- 1, 0)
             result = setindex(result, dot(onr2, onr1_minus_1), i)
         else

--- a/src/Hamiltonians/correlation_functions.jl
+++ b/src/Hamiltonians/correlation_functions.jl
@@ -60,6 +60,7 @@ equivalent to stacking all components into a single Fock state.
 # See also
 
 * [`HubbardReal1D`](@ref)
+* [`G2RealSpace`](@ref)
 * [`G2MomCorrelator`](@ref)
 * [`AbstractHamiltonian`](@ref)
 * [`AllOverlaps`](@ref)
@@ -103,17 +104,22 @@ num_offdiagonals(::G2RealCorrelator, ::SingleComponentFockAddress) = 0
 num_offdiagonals(::G2RealCorrelator, ::CompositeFS) = 0
 
 """
-    G2RealSpace(g::Geometry) <: AbstractHamiltonian{SArray}
+    G2RealSpace(::Geometry, σ=1, τ=1; sum_components=false) <: AbstractHamiltonian{SArray}
 
-Two-body operator for density-density correlation for all displacements.
+Two-body operator for density-density correlation for all displacements ``d`` in the
+specified geometry.
 
 ```math
-    \\hat{G}^{(2)}(d) = \\frac{1}{M} ∑_i^M∑_v \\hat{n}_i (\\hat{n}_{i+v} - \\delta_{0d}).
+    \\hat{G}^{(2)}(d) = \\frac{1}{M} ∑_i^M∑_v \\hat{n}_{σ,i} (\\hat{n}_{τ,i+v} - δ_{0,v}δ_{σ,τ}).
 ```
+
+For multicomponent addresses, `σ` and `τ` control the components involved. Alternatively, `sum_components` can be set to true, which treats all particles as
+belonging to the same component.
 
 # See also
 
-* [`HubbardReal1D`](@ref)
+* [`Geometry`](@ref)
+* [`HubbardRealSpace`](@ref)
 * [`G2MomCorrelator`](@ref)
 * [`G2RealCorrelator`](@ref)
 * [`AbstractHamiltonian`](@ref)
@@ -123,23 +129,19 @@ struct G2RealSpace{A,B,G<:Geometry,S} <: AbstractHamiltonian{S}
     geometry::G
     init::S
 end
-function G2RealSpace(
-    geometry::Geometry, source::Int=1, target::Int=source; sum_components=false
-)
-    if source < 1 || target < 1
-        throw(ArgumentError("`source` and `target` must be positive integers"))
+function G2RealSpace(geometry::Geometry, σ::Int=1, τ::Int=σ; sum_components=false)
+    if σ < 1 || τ < 1
+        throw(ArgumentError("`σ` and `τ` must be positive integers"))
     end
     if sum_components
-        if source ≠ 1 || target ≠ 1
-            throw(
-                ArgumentError("`source` or `target` can't be set if `sum_components=true`")
-            )
+        if σ ≠ 1 || τ ≠ 1
+            throw(ArgumentError("`σ` or `τ` can't be set if `sum_components=true`"))
         end
-        source = target = 0
+        σ = τ = 0
     end
 
     init = zeros(SArray{Tuple{size(geometry)...}})
-    return G2RealSpace{source,target,typeof(geometry),typeof(init)}(geometry, init)
+    return G2RealSpace{σ,τ,typeof(geometry),typeof(init)}(geometry, init)
 end
 
 function Base.show(io::IO, g2::G2RealSpace{A,B}) where {A,B}
@@ -158,14 +160,14 @@ num_offdiagonals(g2::G2RealSpace, _) = 0
 
     @inbounds for i in eachindex(result)
         res_i = 0.0
-        δ_vec = Offsets(geo)[i]
+        displacement = Offsets(geo)[i]
 
         # Case of n_i(n_i - 1) on the same component
-        if A == B && all(==(0), δ_vec)
-            onr1_offset = max.(onr1 .- 1, 0)
-            result = setindex(result, dot(onr2, onr1_offset), i)
+        if A == B && is_zero(displacement)
+            onr1_minus_1 = max.(onr1 .- 1, 0)
+            result = setindex(result, dot(onr2, onr1_minus_1), i)
         else
-            result = setindex(result, circshift_dot(onr2, onr1, δ_vec), i)
+            result = setindex(result, circshift_dot(onr2, onr1, displacement), i)
         end
     end
     return result ./ length(geo)
@@ -225,6 +227,7 @@ and let it be the default value.
 * [`BoseHubbardMom1D2C`](@ref)
 * [`BoseFS2C`](@ref)
 * [`G2RealCorrelator`](@ref)
+* [`G2RealSpace`](@ref)
 * [`AbstractHamiltonian`](@ref)
 * [`AllOverlaps`](@ref)
 """

--- a/src/Hamiltonians/correlation_functions.jl
+++ b/src/Hamiltonians/correlation_functions.jl
@@ -107,14 +107,15 @@ num_offdiagonals(::G2RealCorrelator, ::CompositeFS) = 0
     G2RealSpace(::Geometry, σ=1, τ=1; sum_components=false) <: AbstractHamiltonian{SArray}
 
 Two-body operator for density-density correlation for all displacements ``d`` in the
-specified geometry.
+specified geometry (see [`Offsets`](@ref)).
 
 ```math
     \\hat{G}^{(2)}_{σ,τ}(d) = \\frac{1}{M} ∑_i^M \\hat{n}_{σ,i} (\\hat{n}_{τ,i+d} - δ_{0,d}δ_{σ,τ}).
 ```
 
-For multicomponent addresses, `σ` and `τ` control the components involved. Alternatively, `sum_components` can be set to `true`, which treats all particles as
-belonging to the same component.
+For multicomponent addresses, `σ` and `τ` control the components involved. Alternatively,
+`sum_components` can be set to `true`, which treats all particles as belonging to the same
+component.
 
 # See also
 

--- a/src/Hamiltonians/correlation_functions.jl
+++ b/src/Hamiltonians/correlation_functions.jl
@@ -8,7 +8,7 @@ dot(arr1, circshift(arr2, inds))
 ```
 """
 function circshift_dot(arr1, arr2, inds)
-    _circshift_dot!(arr1, (), arr2, (), axes(arr2), inds)
+    _circshift_dot!(arr1, (), arr2, (), axes(arr2), Tuple(inds))
 end
 
 # The following is taken from Julia's implementation of circshift.
@@ -136,7 +136,7 @@ LOStructure(::Type{<:G2RealSpace}) = IsDiagonal()
 
 num_offdiagonals(g2::G2RealSpace, _) = 0
 
-function diagonal_element(
+@inline function diagonal_element(
     g2::G2RealSpace{A,B}, addr1::SingleComponentFockAddress, addr2::SingleComponentFockAddress
 ) where {A, B}
     geo = g2.geometry

--- a/src/Hamiltonians/correlation_functions.jl
+++ b/src/Hamiltonians/correlation_functions.jl
@@ -104,7 +104,7 @@ num_offdiagonals(::G2RealCorrelator, ::SingleComponentFockAddress) = 0
 num_offdiagonals(::G2RealCorrelator, ::CompositeFS) = 0
 
 """
-    G2RealSpace(::Geometry, σ=1, τ=1; sum_components=false) <: AbstractHamiltonian{SArray}
+    G2RealSpace(::CubicGrid, σ=1, τ=1; sum_components=false) <: AbstractHamiltonian{SArray}
 
 Two-body operator for density-density correlation for all displacements ``d`` in the
 specified geometry (see [`Offsets`](@ref)).
@@ -119,18 +119,18 @@ component.
 
 # See also
 
-* [`Geometry`](@ref)
+* [`CubicGrid`](@ref)
 * [`HubbardRealSpace`](@ref)
 * [`G2MomCorrelator`](@ref)
 * [`G2RealCorrelator`](@ref)
 * [`AbstractHamiltonian`](@ref)
 * [`AllOverlaps`](@ref)
 """
-struct G2RealSpace{A,B,G<:Geometry,S} <: AbstractHamiltonian{S}
+struct G2RealSpace{A,B,G<:CubicGrid,S} <: AbstractHamiltonian{S}
     geometry::G
     init::S
 end
-function G2RealSpace(geometry::Geometry, σ::Int=1, τ::Int=σ; sum_components=false)
+function G2RealSpace(geometry::CubicGrid, σ::Int=1, τ::Int=σ; sum_components=false)
     if σ < 1 || τ < 1
         throw(ArgumentError("`σ` and `τ` must be positive integers"))
     end

--- a/src/Hamiltonians/correlation_functions.jl
+++ b/src/Hamiltonians/correlation_functions.jl
@@ -110,10 +110,10 @@ Two-body operator for density-density correlation for all displacements ``d`` in
 specified geometry.
 
 ```math
-    \\hat{G}^{(2)}(d) = \\frac{1}{M} ∑_i^M∑_v \\hat{n}_{σ,i} (\\hat{n}_{τ,i+v} - δ_{0,v}δ_{σ,τ}).
+    \\hat{G}^{(2)}(d) = \\frac{1}{M} ∑_i^M \\hat{n}_{σ,i} (\\hat{n}_{τ,i+d} - δ_{0,d}δ_{σ,τ}).
 ```
 
-For multicomponent addresses, `σ` and `τ` control the components involved. Alternatively, `sum_components` can be set to true, which treats all particles as
+For multicomponent addresses, `σ` and `τ` control the components involved. Alternatively, `sum_components` can be set to `true`, which treats all particles as
 belonging to the same component.
 
 # See also

--- a/src/Hamiltonians/correlation_functions.jl
+++ b/src/Hamiltonians/correlation_functions.jl
@@ -84,7 +84,7 @@ function diagonal_element(::G2RealCorrelator{D}, add::SingleComponentFockAddress
     M = num_modes(add)
     d = mod(D, M)
     v = onr(add)
-    return circshift_dot(v, v, (d,))
+    return circshift_dot(v, v, (d,)) / M
 end
 
 function diagonal_element(::G2RealCorrelator{0}, add::CompositeFS)
@@ -96,7 +96,7 @@ function diagonal_element(::G2RealCorrelator{D}, add::CompositeFS) where {D}
     M = num_modes(add)
     d = mod(D, M)
     v = sum(map(onr, add.components))
-    return circshift_dot(v, v, (d,))
+    return circshift_dot(v, v, (d,)) / M
 end
 
 num_offdiagonals(::G2RealCorrelator, ::SingleComponentFockAddress) = 0

--- a/src/Hamiltonians/geometry.jl
+++ b/src/Hamiltonians/geometry.jl
@@ -1,5 +1,5 @@
 """
-    Geometry(dims::NTuple{D,Int}, fold::NTuple{D,Bool})
+    CubicGrid(dims::NTuple{D,Int}, fold::NTuple{D,Bool})
 
 Represents a `D`-dimensional grid. Used to define a cubic lattice and boundary conditions
 for some [`AbstractHamiltonian`](@ref)s. The type instance can be used to convert between
@@ -12,8 +12,8 @@ with vectors, it folds them back into the grid if the out-of-bounds dimension is
   case of momentum space).
 
 ```julia
-julia> geo = Geometry((2,3), (true,false))
-Geometry{2}((2, 3), (true, false))
+julia> geo = CubicGrid((2,3), (true,false))
+CubicGrid{2}((2, 3), (true, false))
 
 julia> geo[1]
 (1, 1)
@@ -40,75 +40,75 @@ julia> geo[(3,4)] # returns 0 if out of bounds
 See also [`PeriodicBoundaries`](@ref), [`HardwallBoundaries`](@ref) and
 [`LadderBoundaries`](@ref) for special-case constructors.
 """
-struct Geometry{D,Dims,Fold}
-    function Geometry(
+struct CubicGrid{D,Dims,Fold}
+    function CubicGrid(
         dims::NTuple{D,Int}, fold::NTuple{D,Bool}=ntuple(Returns(true), Val(D))
     ) where {D}
         return new{D,dims,fold}()
     end
 end
-Geometry(args::Vararg{Int}) = Geometry(args)
+CubicGrid(args::Vararg{Int}) = CubicGrid(args)
 
 """
-    PeriodicBoundaries(dims...) -> Geometry
-    PeriodicBoundaries(dims) -> Geometry
+    PeriodicBoundaries(dims...) -> CubicGrid
+    PeriodicBoundaries(dims) -> CubicGrid
 
-Return `Geometry` with all dimensions periodic. Equivalent to `Geometry(dims)`.
+Return `CubicGrid` with all dimensions periodic. Equivalent to `CubicGrid(dims)`.
 """
 function PeriodicBoundaries(dims::NTuple{D,Int}) where {D}
-    return Geometry(dims, ntuple(Returns(true), Val(D)))
+    return CubicGrid(dims, ntuple(Returns(true), Val(D)))
 end
 PeriodicBoundaries(dims::Vararg{Int}) = PeriodicBoundaries(dims)
 
 """
-    HardwallBoundaries(dims...) -> Geometry
-    HardwallBoundaries(dims) -> Geometry
+    HardwallBoundaries(dims...) -> CubicGrid
+    HardwallBoundaries(dims) -> CubicGrid
 
-Return `Geometry` with all dimensions non-periodic. Equivalent to
-`Geometry(dims, (false, false, ...))`.
+Return `CubicGrid` with all dimensions non-periodic. Equivalent to
+`CubicGrid(dims, (false, false, ...))`.
 """
 function HardwallBoundaries(dims::NTuple{D,Int}) where {D}
-    return Geometry(dims, ntuple(Returns(false), Val(D)))
+    return CubicGrid(dims, ntuple(Returns(false), Val(D)))
 end
 HardwallBoundaries(dims::Vararg{Int}) = HardwallBoundaries(dims)
 
 """
-    LadderBoundaries(dims...) -> Geometry
-    LadderBoundaries(dims) -> Geometry
+    LadderBoundaries(dims...) -> CubicGrid
+    LadderBoundaries(dims) -> CubicGrid
 
-Return `Geometry` where the first dimension is dimensions non-periodic and the rest are
-periodic. Equivalent to `Geometry(dims, (true, false, ...))`.
+Return `CubicGrid` where the first dimension is dimensions non-periodic and the rest are
+periodic. Equivalent to `CubicGrid(dims, (true, false, ...))`.
 """
 function LadderBoundaries(dims::NTuple{D,Int}) where {D}
-    return Geometry(dims, ntuple(>(1), Val(D)))
+    return CubicGrid(dims, ntuple(>(1), Val(D)))
 end
 LadderBoundaries(dims::Vararg{Int}) = LadderBoundaries(dims)
 
-function Base.show(io::IO, g::Geometry{<:Any,Dims,Fold}) where {Dims,Fold}
-    print(io, "Geometry($Dims, $Fold)")
+function Base.show(io::IO, g::CubicGrid{<:Any,Dims,Fold}) where {Dims,Fold}
+    print(io, "CubicGrid($Dims, $Fold)")
 end
 
-Base.size(g::Geometry{<:Any,Dims}) where {Dims} = Dims
-Base.size(g::Geometry{<:Any,Dims}, i) where {Dims} = Dims[i]
-Base.length(g::Geometry) = prod(size(g))
-fold(g::Geometry{<:Any,<:Any,Fold}) where {Fold} = Fold
+Base.size(g::CubicGrid{<:Any,Dims}) where {Dims} = Dims
+Base.size(g::CubicGrid{<:Any,Dims}, i) where {Dims} = Dims[i]
+Base.length(g::CubicGrid) = prod(size(g))
+fold(g::CubicGrid{<:Any,<:Any,Fold}) where {Fold} = Fold
 
 """
-    num_dimensions(geom::LatticeGeometry)
+    num_dimensions(geom::LatticeCubicGrid)
 
 Return the number of dimensions of the lattice in this geometry.
 """
-num_dimensions(::Geometry{D}) where {D} = D
+num_dimensions(::CubicGrid{D}) where {D} = D
 
 """
-    fold_vec(g::Geometry{D}, vec::SVector{D,Int}) -> SVector{D,Int}
+    fold_vec(g::CubicGrid{D}, vec::SVector{D,Int}) -> SVector{D,Int}
 
-Use the Geometry to fold the `vec` in each dimension. If folding is disabled in a
+Use the CubicGrid to fold the `vec` in each dimension. If folding is disabled in a
 dimension, and the vector is allowed to go out of bounds.
 
 ```julia
-julia> geo = Geometry((2,3), (true,false))
-Geometry{2}((2, 3), (true, false))
+julia> geo = CubicGrid((2,3), (true,false))
+CubicGrid{2}((2, 3), (true, false))
 
 julia> fold_vec(geo, (3,1))
 (1, 1)
@@ -117,7 +117,7 @@ julia> fold_vec(geo, (3,4))
 (1, 4)
 ```
 """
-function fold_vec(g::Geometry{D}, vec::SVector{D,Int}) where {D}
+function fold_vec(g::CubicGrid{D}, vec::SVector{D,Int}) where {D}
     (_fold_vec(Tuple(vec), fold(g), size(g)))
 end
 @inline _fold_vec(::Tuple{}, ::Tuple{}, ::Tuple{}) = ()
@@ -126,20 +126,20 @@ end
     return (x, _fold_vec(xs, fs, ds)...)
 end
 
-function Base.getindex(g::Geometry{D}, vec::Union{NTuple{D,Int},SVector{D,Int}}) where {D}
+function Base.getindex(g::CubicGrid{D}, vec::Union{NTuple{D,Int},SVector{D,Int}}) where {D}
     return get(LinearIndices(size(g)), fold_vec(g, SVector(vec)), 0)
 end
-Base.getindex(g::Geometry, i::Int) = SVector(Tuple(CartesianIndices(size(g))[i]))
+Base.getindex(g::CubicGrid, i::Int) = SVector(Tuple(CartesianIndices(size(g))[i]))
 
 """
-    DirectionVectors(D) <: AbstractVector{SVector{D,Int}}
-    DirectionVectors(geometry::Geometry) <: AbstractVector{SVector{D,Int}}
+    Directions(D) <: AbstractVector{SVector{D,Int}}
+    Directions(geometry::CubicGrid) <: AbstractVector{SVector{D,Int}}
 
 Iterate over axis-aligned direction vectors in `D` dimensions.
 
-```jldoctest; setup=:(using Rimu.Hamiltonians: DirectionVectors)
-julia> DirectionVectors(3)
-6-element DirectionVectors{3}:
+```jldoctest; setup=:(using Rimu.Hamiltonians: Directions)
+julia> Directions(3)
+6-element Directions{3}:
  [1, 0, 0]
  [0, 1, 0]
  [0, 0, 1]
@@ -149,16 +149,16 @@ julia> DirectionVectors(3)
 
 ```
 
-See also [`Geometry`](@ref).
+See also [`CubicGrid`](@ref).
 """
-struct DirectionVectors{D} <: AbstractVector{SVector{D,Int}} end
+struct Directions{D} <: AbstractVector{SVector{D,Int}} end
 
-DirectionVectors(D) = DirectionVectors{D}()
-DirectionVectors(::Geometry{D}) where {D} = DirectionVectors{D}()
+Directions(D) = Directions{D}()
+Directions(::CubicGrid{D}) where {D} = Directions{D}()
 
-Base.size(::DirectionVectors{D}) where {D} = (2D,)
+Base.size(::Directions{D}) where {D} = (2D,)
 
-function Base.getindex(uv::DirectionVectors{D}, i) where {D}
+function Base.getindex(uv::Directions{D}, i) where {D}
     @boundscheck 0 < i ≤ length(uv) || throw(BoundsError(uv, i))
     if i ≤ D
         return SVector(_unit_vec(Val(D), i, 1))
@@ -174,13 +174,13 @@ end
 end
 
 """
-    Offsets(geometry::Geometry) <: AbstractVector{SVector{D,Int}}
+    Offsets(geometry::CubicGrid) <: AbstractVector{SVector{D,Int}}
 
-Return all valid offset vectors in a [`Geometry`](@ref). If `center=true` the (0,0) displacement is
+Return all valid offset vectors in a [`CubicGrid`](@ref). If `center=true` the (0,0) displacement is
 placed at the centre of the array.
 
 ```jldoctest; setup=:(using Rimu.Hamiltonians: Offsets)
-julia> geometry = Geometry((3,4));
+julia> geometry = CubicGrid((3,4));
 
 julia> reshape(Offsets(geometry), (3,4))
 3×4 reshape(::Offsets{2}, 3, 4) with eltype StaticArraysCore.SVector{2, Int64}:
@@ -197,7 +197,7 @@ julia> reshape(Offsets(geometry; center=true), (3,4))
 ```
 """
 struct Offsets{D} <: AbstractVector{SVector{D,Int}}
-    geometry::Geometry{D}
+    geometry::CubicGrid{D}
     center::Bool
 end
 Offsets(geometry; center=false) = Offsets(geometry, center)
@@ -216,17 +216,17 @@ Base.size(off::Offsets) = (length(off.geometry),)
 end
 
 """
-    neighbor_site(geom::Geometry, site, i)
+    neighbor_site(geom::CubicGrid, site, i)
 
 Find the `i`-th neighbor of `site` in the geometry. If the move is illegal, return 0.
 """
-function neighbor_site(g::Geometry{D}, mode, chosen) where {D}
-    return g[g[mode] + DirectionVectors(D)[chosen]]
+function neighbor_site(g::CubicGrid{D}, mode, chosen) where {D}
+    return g[g[mode] + Directions(D)[chosen]]
 end
 
-function BitStringAddresses.onr(address, geom::Geometry{<:Any,S}) where {S}
+function BitStringAddresses.onr(address, geom::CubicGrid{<:Any,S}) where {S}
     return SArray{Tuple{S...}}(onr(address))
 end
-function BitStringAddresses.onr(address::CompositeFS, geom::Geometry)
+function BitStringAddresses.onr(address::CompositeFS, geom::CubicGrid)
     return map(fs -> onr(fs, geom), address.components)
 end

--- a/src/Hamiltonians/geometry.jl
+++ b/src/Hamiltonians/geometry.jl
@@ -171,6 +171,9 @@ end
 """
     Offsets(geometry::Geometry) <: AbstractVector{SVector{D,Int}}
 
+Return all valid offset vectors in a `Geometry`. If `center=true` the (0,0) displacement is
+palced at the centre of the array.
+
 ```jldoctest; setup=:(using Rimu.Hamiltonians: Offsets)
 julia> geometry = Geometry((3,4));
 

--- a/src/Hamiltonians/geometry.jl
+++ b/src/Hamiltonians/geometry.jl
@@ -174,37 +174,37 @@ end
 end
 
 """
-    Offsets(geometry::CubicGrid) <: AbstractVector{SVector{D,Int}}
+    Displacements(geometry::CubicGrid) <: AbstractVector{SVector{D,Int}}
 
 Return all valid offset vectors in a [`CubicGrid`](@ref). If `center=true` the (0,0) displacement is
 placed at the centre of the array.
 
-```jldoctest; setup=:(using Rimu.Hamiltonians: Offsets)
+```jldoctest; setup=:(using Rimu.Hamiltonians: Displacements)
 julia> geometry = CubicGrid((3,4));
 
-julia> reshape(Offsets(geometry), (3,4))
-3×4 reshape(::Offsets{2}, 3, 4) with eltype StaticArraysCore.SVector{2, Int64}:
+julia> reshape(Displacements(geometry), (3,4))
+3×4 reshape(::Displacements{2}, 3, 4) with eltype StaticArraysCore.SVector{2, Int64}:
  [0, 0]  [0, 1]  [0, 2]  [0, 3]
  [1, 0]  [1, 1]  [1, 2]  [1, 3]
  [2, 0]  [2, 1]  [2, 2]  [2, 3]
 
-julia> reshape(Offsets(geometry; center=true), (3,4))
-3×4 reshape(::Offsets{2}, 3, 4) with eltype StaticArraysCore.SVector{2, Int64}:
+julia> reshape(Displacements(geometry; center=true), (3,4))
+3×4 reshape(::Displacements{2}, 3, 4) with eltype StaticArraysCore.SVector{2, Int64}:
  [-1, -1]  [-1, 0]  [-1, 1]  [-1, 2]
  [0, -1]   [0, 0]   [0, 1]   [0, 2]
  [1, -1]   [1, 0]   [1, 1]   [1, 2]
 
 ```
 """
-struct Offsets{D} <: AbstractVector{SVector{D,Int}}
+struct Displacements{D} <: AbstractVector{SVector{D,Int}}
     geometry::CubicGrid{D}
     center::Bool
 end
-Offsets(geometry; center=false) = Offsets(geometry, center)
+Displacements(geometry; center=false) = Displacements(geometry, center)
 
-Base.size(off::Offsets) = (length(off.geometry),)
+Base.size(off::Displacements) = (length(off.geometry),)
 
-@inline function Base.getindex(off::Offsets{D}, i) where {D}
+@inline function Base.getindex(off::Displacements{D}, i) where {D}
     @boundscheck 0 < i ≤ length(off) || throw(BoundsError(off, i))
     geo = off.geometry
     vec = geo[i]

--- a/src/Hamiltonians/geometry.jl
+++ b/src/Hamiltonians/geometry.jl
@@ -92,7 +92,9 @@ julia> fold_vec(geo, (3,4))
 (1, 4)
 ```
 """
-fold_vec(g::Geometry{D}, vec::NTuple{D,Int}) where {D} = _fold_vec(vec, fold(g), size(g))
+function fold_vec(g::Geometry{D}, vec::NTuple{D,Int}) where {D}
+    return SVector(_fold_vec(vec, fold(g), size(g)))
+end
 @inline _fold_vec(::Tuple{}, ::Tuple{}, ::Tuple{}) = ()
 @inline function _fold_vec((x, xs...), (f, fs...), (d, ds...))
     x = f ? mod1(x, d) : x
@@ -110,7 +112,7 @@ Base.getindex(g::Geometry, i::Int) = Tuple(CartesianIndices(size(g))[i])
 
 Iterate over unit vectors in `D` dimensions.
 
-```jldoctest
+```jldoctest; setup=:(using Rimu.Hamiltonians: UnitVectors)
 julia> UnitVectors(3)
 6-element UnitVectors{3}:
  (1, 0, 0)
@@ -146,7 +148,7 @@ end
 """
     Offsets(geometry::Geometry) <: AbstractVector{NTuple{D,Int}}
 
-```jldoctest
+```jldoctest; setup=:(using Rimu.Hamiltonians: Offsets)
 julia> geometry = Geometry((3,4));
 
 julia> reshape(Offsets(geometry), (3,4))

--- a/src/Hamiltonians/geometry.jl
+++ b/src/Hamiltonians/geometry.jl
@@ -164,7 +164,9 @@ julia> reshape(Offsets(geometry), (3,4))
 """
 struct Offsets{D} <: AbstractVector{SVector{D,Int}}
     geometry::Geometry{D}
+    center::Bool
 end
+Offsets(geometry; center=false) = Offsets(geometry, center)
 
 Base.size(off::Offsets) = (length(off.geometry),)
 
@@ -172,7 +174,11 @@ Base.size(off::Offsets) = (length(off.geometry),)
     @boundscheck 0 < i ≤ length(off) || throw(BoundsError(off, i))
     geo = off.geometry
     vec = geo[i]
-    return vec - ones(SVector{D,Int})#+ SVector(ntuple(i -> -cld(size(geo, i), 2), Val(D)))
+    if !off.center
+        return vec - ones(SVector{D,Int})
+    else
+        return vec - SVector(ntuple(i -> cld(size(geo, i), 2), Val(D)))
+    end
 end
 
 """

--- a/src/Hamiltonians/geometry.jl
+++ b/src/Hamiltonians/geometry.jl
@@ -46,16 +46,36 @@ struct Geometry{D,Dims,Fold}
 end
 Geometry(args::Vararg{Int}) = Geometry(args)
 
+"""
+    PeriodicBoundaries(dims...) -> Geometry
+    PeriodicBoundaries(dims) -> Geometry
+
+Return `Geometry` with all dimensions periodic. Equivalent to `Geometry(dims)`.
+"""
 function PeriodicBoundaries(dims::NTuple{D,Int}) where {D}
     return Geometry(dims, ntuple(Returns(true), Val(D)))
 end
 PeriodicBoundaries(dims::Vararg{Int}) = PeriodicBoundaries(dims)
 
+"""
+    HardwallBoundaries(dims...) -> Geometry
+    HardwallBoundaries(dims) -> Geometry
+
+Return `Geometry` with all dimensions non-periodic. Equivalent to
+`Geometry(dims, (false, false, ...))`.
+"""
 function HardwallBoundaries(dims::NTuple{D,Int}) where {D}
     return Geometry(dims, ntuple(Returns(false), Val(D)))
 end
 HardwallBoundaries(dims::Vararg{Int}) = HardwallBoundaries(dims)
 
+"""
+    LadderBoundaries(dims...) -> Geometry
+    LadderBoundaries(dims) -> Geometry
+
+Return `Geometry` where the first dimension is dimensions non-periodic and the rest are
+periodic. Equivalent to `Geometry(dims, (true, false, ...))`.
+"""
 function LadderBoundaries(dims::NTuple{D,Int}) where {D}
     return Geometry(dims, ntuple(>(1), Val(D)))
 end

--- a/src/Hamiltonians/geometry.jl
+++ b/src/Hamiltonians/geometry.jl
@@ -1,12 +1,12 @@
 """
     Geometry(dims::NTuple{D,Int}, fold::NTuple{D,Bool})
 
-Represents a D-dimensional grid. Used to convert between cartesian vector indices (tuples)
-and linear indices (integers).
+Represents a `D`-dimensional grid. Used to convert between cartesian vector indices (tuples
+or `SVector`s) and linear indices (integers).
 
-* `dims` controls the size of the grid in each dimension
+* `dims` controls the size of the grid in each dimension.
 * `fold` controls whether the boundaries in each dimension are periodic (or folded in the
-  case of momentum space)
+  case of momentum space).
 
 `Base.getindex` can be used to convert between linear indices and vectors.
 
@@ -32,7 +32,8 @@ julia> geo[(3,2)] # 3 is folded back into 1
 julia> geo[(3,3)]
 5
 
-julia> geo[(3,4)] # returns nothing if out of bounds
+julia> geo[(3,4)] # returns 0 if out of bounds
+0
 
 ```
 """
@@ -43,6 +44,7 @@ struct Geometry{D,Dims,Fold}
         return new{D,dims,fold}()
     end
 end
+Geometry(args::Vararg{Int}) = Geometry(args)
 
 function PeriodicBoundaries(dims::NTuple{D,Int}) where {D}
     return Geometry(dims, ntuple(Returns(true), Val(D)))
@@ -170,7 +172,7 @@ Base.size(off::Offsets) = (length(off.geometry),)
     @boundscheck 0 < i ≤ length(off) || throw(BoundsError(off, i))
     geo = off.geometry
     vec = geo[i]
-    return vec + SVector(ntuple(i -> -cld(size(geo, i), 2), Val(D)))
+    return vec - ones(SVector{D,Int})#+ SVector(ntuple(i -> -cld(size(geo, i), 2), Val(D)))
 end
 
 """

--- a/src/Hamiltonians/geometry.jl
+++ b/src/Hamiltonians/geometry.jl
@@ -44,6 +44,9 @@ struct CubicGrid{D,Dims,Fold}
     function CubicGrid(
         dims::NTuple{D,Int}, fold::NTuple{D,Bool}=ntuple(Returns(true), Val(D))
     ) where {D}
+        if any(≤(1), dims)
+            throw(ArgumentError("All dimensions must be at least 2 in size"))
+        end
         return new{D,dims,fold}()
     end
 end
@@ -221,6 +224,7 @@ end
 Find the `i`-th neighbor of `site` in the geometry. If the move is illegal, return 0.
 """
 function neighbor_site(g::CubicGrid{D}, mode, chosen) where {D}
+    # TODO: reintroduce LadderBoundaries small dimensions
     return g[g[mode] + Directions(D)[chosen]]
 end
 

--- a/src/Hamiltonians/geometry.jl
+++ b/src/Hamiltonians/geometry.jl
@@ -156,6 +156,12 @@ julia> geometry = Geometry((3,4));
 
 julia> reshape(Offsets(geometry), (3,4))
 3×4 reshape(::Offsets{2}, 3, 4) with eltype StaticArraysCore.SVector{2, Int64}:
+ [0, 0]  [0, 1]  [0, 2]  [0, 3]
+ [1, 0]  [1, 1]  [1, 2]  [1, 3]
+ [2, 0]  [2, 1]  [2, 2]  [2, 3]
+
+julia> reshape(Offsets(geometry; center=true), (3,4))
+3×4 reshape(::Offsets{2}, 3, 4) with eltype StaticArraysCore.SVector{2, Int64}:
  [-1, -1]  [-1, 0]  [-1, 1]  [-1, 2]
  [0, -1]   [0, 0]   [0, 1]   [0, 2]
  [1, -1]   [1, 0]   [1, 1]   [1, 2]

--- a/src/Hamiltonians/geometry.jl
+++ b/src/Hamiltonians/geometry.jl
@@ -1,10 +1,11 @@
 """
     Geometry(dims::NTuple{D,Int}, fold::NTuple{D,Bool})
 
-Represents a `D`-dimensional grid. Used to convert between cartesian vector indices (tuples
-or `SVector`s) and linear indices (integers). When indexed with vectors, it folds them back
-into the grid if the out-of-bounds dimension is periodic and 0 otherwise (see example
-below).
+Represents a `D`-dimensional grid. Used to define a cubic lattice and boundary conditions 
+for some [`AbstractHamiltonian`](@ref)s. The type instance can be used to convert between 
+cartesian vector indices (tuples or `SVector`s) and linear indices (integers). When indexed 
+with vectors, it folds them back into the grid if the out-of-bounds dimension is periodic and 
+0 otherwise (see example below).
 
 * `dims` controls the size of the grid in each dimension.
 * `fold` controls whether the boundaries in each dimension are periodic (or folded in the
@@ -171,8 +172,8 @@ end
 """
     Offsets(geometry::Geometry) <: AbstractVector{SVector{D,Int}}
 
-Return all valid offset vectors in a `Geometry`. If `center=true` the (0,0) displacement is
-palced at the centre of the array.
+Return all valid offset vectors in a [`Geometry`](@ref). If `center=true` the (0,0) displacement is
+placed at the centre of the array.
 
 ```jldoctest; setup=:(using Rimu.Hamiltonians: Offsets)
 julia> geometry = Geometry((3,4));
@@ -219,9 +220,9 @@ function neighbor_site(g::Geometry{D}, mode, chosen) where {D}
     return g[g[mode] + UnitVectors(D)[chosen]]
 end
 
-function BitStringAddresses.onr(add, geom::Geometry{<:Any,S}) where {S}
-    return SArray{Tuple{S...}}(onr(add))
+function BitStringAddresses.onr(address, geom::Geometry{<:Any,S}) where {S}
+    return SArray{Tuple{S...}}(onr(address))
 end
-function BitStringAddresses.onr(add::CompositeFS, geom::Geometry)
-    return map(fs -> onr(fs, geom), add.components)
+function BitStringAddresses.onr(address::CompositeFS, geom::Geometry)
+    return map(fs -> onr(fs, geom), address.components)
 end

--- a/src/Hamiltonians/geometry.jl
+++ b/src/Hamiltonians/geometry.jl
@@ -2,13 +2,13 @@
     Geometry(dims::NTuple{D,Int}, fold::NTuple{D,Bool})
 
 Represents a `D`-dimensional grid. Used to convert between cartesian vector indices (tuples
-or `SVector`s) and linear indices (integers).
+or `SVector`s) and linear indices (integers). When indexed with vectors, it folds them back
+into the grid if the out-of-bounds dimension is periodic and 0 otherwise (see example
+below).
 
 * `dims` controls the size of the grid in each dimension.
 * `fold` controls whether the boundaries in each dimension are periodic (or folded in the
   case of momentum space).
-
-`Base.getindex` can be used to convert between linear indices and vectors.
 
 ```julia
 julia> geo = Geometry((2,3), (true,false))

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -150,7 +150,7 @@ using Rimu.Hamiltonians: momentum_transfer_excitation
     end
 end
 
-using Rimu.Hamiltonians: Directions, Offsets
+using Rimu.Hamiltonians: Directions, Displacements
 
 @testset "CubicGrid" begin
     @testset "construtors and basic properties" begin
@@ -192,13 +192,13 @@ using Rimu.Hamiltonians: Directions, Offsets
         @test_throws BoundsError Directions(1)[15]
     end
 
-    @testset "Offsets" begin
-        @test collect(Offsets(CubicGrid(3), center=false)) == [[0], [1], [2]]
-        @test collect(Offsets(CubicGrid(3), center=true)) == [[-1], [0], [1]]
+    @testset "Displacements" begin
+        @test collect(Displacements(CubicGrid(3), center=false)) == [[0], [1], [2]]
+        @test collect(Displacements(CubicGrid(3), center=true)) == [[-1], [0], [1]]
 
-        @test collect(Offsets(CubicGrid(2,2))) == [[0,0], [1,0], [0,1], [1,1]]
-        @test collect(Offsets(CubicGrid(2,3))) == [[0,0], [1,0], [0,1], [1,1], [0,2], [1,2]]
-        @test collect(Offsets(CubicGrid(2,3); center=true)) == [
+        @test collect(Displacements(CubicGrid(2,2))) == [[0,0], [1,0], [0,1], [1,1]]
+        @test collect(Displacements(CubicGrid(2,3))) == [[0,0], [1,0], [0,1], [1,1], [0,2], [1,2]]
+        @test collect(Displacements(CubicGrid(2,3); center=true)) == [
             [0,-1], [1,-1], [0,0], [1,0], [0,1], [1,1]
         ]
     end

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -808,15 +808,40 @@ using Rimu.Hamiltonians: circshift_dot
     end
 
     @testset "G2RealSpace" begin
-        @testset "1D" begin
+        @testset "1D G2RealCorrelator comparison" begin
+            addr = near_uniform(BoseFS{6,6})
+            H = HubbardReal1D(addr)
+            v = normalize!(H * (H * (H * DVec(addr => 1.0))))
 
+            g2 = dot(v, G2RealSpace(Geometry(6)), v)
+            for d in 0:5
+                @test g2[d + 1] ≈ dot(v, G2RealCorrelator(d), v)
+            end
+        end
+
+        @testset "2-component" begin
+            c1 = BoseFS(1, 0, 0, 0, 0, 0)
+            c2 = BoseFS(1, 2, 3, 4, 5, 6)
+            addr = CompositeFS(c1, c2)
+            geom = Geometry((3, 2))
+
+            g2_11 = G2RealSpace(geom, 1, 1)
+            g2_12 = G2RealSpace(geom, 1, 2)
+            g2_21 = G2RealSpace(geom, 2, 1)
+            g2_22 = G2RealSpace(geom, 2, 2)
+
+            @test sum(diagonal_element(g2_11, addr)) == 0
+            @test sum(diagonal_element(g2_12, addr)) == 3.5
+            @test sum(diagonal_element(g2_21, addr)) == 3.5
+            @test sum(diagonal_element(g2_22, addr)) == 70
+            @test diagonal_element(g2_12, addr) == [1 4; 2 5; 3 6] ./ 6
         end
     end
 
     @testset "G2MomCorrelator" begin
         # v0 is the exact ground state from BoseHubbardMom1D2C(aIni;ua=0,ub=0,v=0.1)
-        bfs1=BoseFS([0,2,0])
-        bfs2=BoseFS([0,1,0])
+        bfs1 = BoseFS([0, 2, 0])
+        bfs2 = BoseFS([0, 1, 0])
         aIni = BoseFS2C(bfs1,bfs2)
         v0 = DVec(
             BoseFS2C((0, 2, 0), (0, 1, 0)) => 0.9999389545691221,

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -338,19 +338,6 @@ end
         od_nonzeros = filter(!iszero, od_values)
         @test length(od_values) == 12
         @test length(od_nonzeros) == 4
-
-        H = HubbardRealSpace(f, geometry=LadderBoundaries(2, 6))
-        od_values = last.(offdiagonals(H, f))
-        od_nonzeros = filter(!iszero, od_values)
-        @test length(od_values) == 9
-        @test length(od_nonzeros) == 5
-
-        hard_ladder = LadderBoundaries(2, 6, subgeometry=HardwallBoundaries)
-        H = HubbardRealSpace(f, geometry=hard_ladder)
-        od_values = last.(offdiagonals(H, f))
-        od_nonzeros = filter(!iszero, od_values)
-        @test length(od_values) == 9
-        @test length(od_nonzeros) == 3
     end
     @testset "1D Bosons (single)" begin
         H1 = HubbardReal1D(BoseFS((1, 1, 1, 1, 1, 0)); u=2, t=3)
@@ -510,24 +497,19 @@ end
             )
             @test exact_energy(H3) < -16
         end
-        @testset "hardwall and ladder" begin
-            geom1 = LadderBoundaries(2, 3, subgeometry=HardwallBoundaries)
-            geom2 = HardwallBoundaries(2, 3)
-            geom3 = HardwallBoundaries(3, 2)
+        @testset "Hardwall" begin
+            geom1 = HardwallBoundaries(2, 3)
+            geom2 = HardwallBoundaries(3, 2)
             bose = BoseFS((1, 1, 1, 0, 0, 0))
             fermi = FermiFS((1, 0, 0, 0, 1, 0))
 
             H1 = HubbardRealSpace(bose, geometry=geom1)
             H2 = HubbardRealSpace(bose, geometry=geom2)
-            H3 = HubbardRealSpace(bose, geometry=geom3)
-            @test exact_energy(H1) == exact_energy(H2)
-            @test exact_energy(H1) ≈ exact_energy(H3)
+            @test exact_energy(H1) ≈ exact_energy(H2)
 
             H1 = HubbardRealSpace(fermi, geometry=geom1)
             H2 = HubbardRealSpace(fermi, geometry=geom2)
-            H3 = HubbardRealSpace(fermi, geometry=geom3)
-            @test exact_energy(H1) == exact_energy(H2)
-            @test exact_energy(H1) ≈ exact_energy(H3)
+            @test exact_energy(H1) ≈ exact_energy(H2)
         end
     end
 end

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -866,6 +866,23 @@ using Rimu.Hamiltonians: circshift_dot
 
     @testset "G2RealSpace" begin
         @testset "1D G2RealCorrelator comparison" begin
+            @testset "constructors" begin
+                g2_1 = G2RealSpace(Geometry(2, 2, 3), 1, 3) isa G2RealSpace{1,3}
+                g2_2 = G2RealSpace(Geometry(2, 2), 2) isa G2RealSpace{2,2}
+                g2_3 = G2RealSpace(Geometry(2, 2); sum_components=true) isa G2RealSpace{0,0}
+                @test g2_1 isa G2RealSpace{1,3}
+                @test g2_2 isa G2RealSpace{2,2}
+                @test g2_3 isa G2RealSpace{0,0}
+
+                @test eval(Meta.parse(repr(g2_1))) == g2_1
+                @test eval(Meta.parse(repr(g2_2))) == g2_2
+                @test eval(Meta.parse(repr(g2_3))) == g2_3
+
+                @test_throws ArgumentError G2RealSpace(Geometry(3), 1, 0)
+                @test_throws ArgumentError G2RealSpace(Geometry(2, 2), 0, 0)
+                @test_throws ArgumentError G2RealSpace(Geometry(1, 2, 3), -1, 2)
+                @test_throws ArgumentError G2RealSpace(Geometry(12), 3; sum_components=true)
+            end
             @testset "single components" begin
                 addr = near_uniform(BoseFS{6,6})
                 H = HubbardReal1D(addr)

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -943,9 +943,9 @@ using Rimu.Hamiltonians: circshift_dot
 
             g2 = dot(v0, G2RealSpace(geom), v0)
 
-            @test sum(g2) == 3 * 2 / 18
-            @test g2[:,2,:] == g2[:,3,:]
-            @test g2[:,:,2] == g2[:,:,3]
+            @test sum(g2) ≈ 3 * 2 / 18
+            @test g2[:,2,:] ≈ g2[:,3,:]
+            @test g2[:,:,2] ≈ g2[:,:,3]
             @test minimum(g2) == first(g2)
         end
     end

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -150,18 +150,18 @@ using Rimu.Hamiltonians: momentum_transfer_excitation
     end
 end
 
-using Rimu.Hamiltonians: UnitVectors, Offsets
+using Rimu.Hamiltonians: Directions, Offsets
 
-@testset "Geometry" begin
+@testset "CubicGrid" begin
     @testset "construtors and basic properties" begin
-        @test PeriodicBoundaries(3, 3) == Geometry(3, 3)
-        @test HardwallBoundaries(3, 4, 5) == Geometry((3, 4, 5), (false, false, false))
-        @test LadderBoundaries(2, 3, 4) == Geometry((2, 3, 4), (false, true, true))
+        @test PeriodicBoundaries(3, 3) == CubicGrid(3, 3)
+        @test HardwallBoundaries(3, 4, 5) == CubicGrid((3, 4, 5), (false, false, false))
+        @test LadderBoundaries(2, 3, 4) == CubicGrid((2, 3, 4), (false, true, true))
 
         for (dims, fold) in (
             ((4,), (false,)), ((2, 5), (true, false)), ((5, 6, 7), (true, true, false))
         )
-            geom = Geometry(dims, fold)
+            geom = CubicGrid(dims, fold)
             @test size(geom) == dims
             @test length(geom) == prod(dims)
             @test Rimu.Hamiltonians.fold(geom) == fold
@@ -170,7 +170,7 @@ using Rimu.Hamiltonians: UnitVectors, Offsets
     end
 
     @testset "getindex" begin
-        g = Geometry((2,3,4), (false,true,false))
+        g = CubicGrid((2,3,4), (false,true,false))
         for i in 1:length(g)
             v = SVector(Tuple(CartesianIndices((2,3,4))[i])...)
             @test g[i] == v
@@ -185,7 +185,7 @@ using Rimu.Hamiltonians: UnitVectors, Offsets
 
     @testset "UnitVectors" begin
         @test UnitVectors(1) == [[1], [-1]]
-        @test UnitVectors(Geometry(2,3)) == [[1,0], [0,1], [-1,0], [0,-1]]
+        @test UnitVectors(CubicGrid(2,3)) == [[1,0], [0,1], [-1,0], [0,-1]]
         @test UnitVectors(3) == [[1,0,0], [0,1,0], [0,0,1], [-1,0,0], [0,-1,0], [0,0,-1]]
         @test_throws BoundsError UnitVectors(3)[0]
         @test_throws BoundsError UnitVectors(2)[5]
@@ -193,12 +193,12 @@ using Rimu.Hamiltonians: UnitVectors, Offsets
     end
 
     @testset "Offsets" begin
-        @test collect(Offsets(Geometry(3), center=false)) == [[0], [1], [2]]
-        @test collect(Offsets(Geometry(3), center=true)) == [[-1], [0], [1]]
+        @test collect(Offsets(CubicGrid(3), center=false)) == [[0], [1], [2]]
+        @test collect(Offsets(CubicGrid(3), center=true)) == [[-1], [0], [1]]
 
-        @test collect(Offsets(Geometry(2,2))) == [[0,0], [1,0], [0,1], [1,1]]
-        @test collect(Offsets(Geometry(2,3))) == [[0,0], [1,0], [0,1], [1,1], [0,2], [1,2]]
-        @test collect(Offsets(Geometry(2,3); center=true)) == [
+        @test collect(Offsets(CubicGrid(2,2))) == [[0,0], [1,0], [0,1], [1,1]]
+        @test collect(Offsets(CubicGrid(2,3))) == [[0,0], [1,0], [0,1], [1,1], [0,2], [1,2]]
+        @test collect(Offsets(CubicGrid(2,3); center=true)) == [
             [0,-1], [1,-1], [0,0], [1,0], [0,1], [1,1]
         ]
     end
@@ -867,9 +867,9 @@ using Rimu.Hamiltonians: circshift_dot
     @testset "G2RealSpace" begin
         @testset "1D G2RealCorrelator comparison" begin
             @testset "constructors" begin
-                g2_1 = G2RealSpace(Geometry(2, 2, 3), 1, 3)
-                g2_2 = G2RealSpace(Geometry(2, 2), 2)
-                g2_3 = G2RealSpace(Geometry(2, 2); sum_components=true)
+                g2_1 = G2RealSpace(CubicGrid(2, 2, 3), 1, 3)
+                g2_2 = G2RealSpace(CubicGrid(2, 2), 2)
+                g2_3 = G2RealSpace(CubicGrid(2, 2); sum_components=true)
                 @test g2_1 isa G2RealSpace{1,3}
                 @test g2_2 isa G2RealSpace{2,2}
                 @test g2_3 isa G2RealSpace{0,0}
@@ -878,17 +878,17 @@ using Rimu.Hamiltonians: circshift_dot
                 @test eval(Meta.parse(repr(g2_2))) == g2_2
                 @test eval(Meta.parse(repr(g2_3))) == g2_3
 
-                @test_throws ArgumentError G2RealSpace(Geometry(3), 1, 0)
-                @test_throws ArgumentError G2RealSpace(Geometry(2, 2), 0, 0)
-                @test_throws ArgumentError G2RealSpace(Geometry(1, 2, 3), -1, 2)
-                @test_throws ArgumentError G2RealSpace(Geometry(12), 3; sum_components=true)
+                @test_throws ArgumentError G2RealSpace(CubicGrid(3), 1, 0)
+                @test_throws ArgumentError G2RealSpace(CubicGrid(2, 2), 0, 0)
+                @test_throws ArgumentError G2RealSpace(CubicGrid(1, 2, 3), -1, 2)
+                @test_throws ArgumentError G2RealSpace(CubicGrid(12), 3; sum_components=true)
             end
             @testset "single components" begin
                 addr = near_uniform(BoseFS{6,6})
                 H = HubbardReal1D(addr)
                 v = normalize!(H * (H * (H * DVec(addr => 1.0))))
 
-                g2 = dot(v, G2RealSpace(Geometry(6)), v)
+                g2 = dot(v, G2RealSpace(CubicGrid(6)), v)
                 for d in 0:5
                     @test g2[d + 1] ≈ dot(v, G2RealCorrelator(d), v)
                 end
@@ -899,12 +899,12 @@ using Rimu.Hamiltonians: circshift_dot
                 H = HubbardRealSpace(addr)
                 v = normalize!(H * (H * (H * DVec(addr => 1.0))))
 
-                g2 = dot(v, G2RealSpace(Geometry(4); sum_components=true), v)
+                g2 = dot(v, G2RealSpace(CubicGrid(4); sum_components=true), v)
                 for d in 0:3
                     @test g2[d + 1] ≈ dot(v, G2RealCorrelator(d), v)
                 end
 
-                g2_nosum = dot(v, G2RealSpace(Geometry(4)), v)
+                g2_nosum = dot(v, G2RealSpace(CubicGrid(4)), v)
                 @test iszero(g2_nosum)
             end
         end
@@ -913,7 +913,7 @@ using Rimu.Hamiltonians: circshift_dot
             c1 = BoseFS(1, 0, 0, 0, 0, 0)
             c2 = BoseFS(1, 2, 3, 4, 5, 6)
             addr = CompositeFS(c1, c2)
-            geom = Geometry((3, 2))
+            geom = CubicGrid((3, 2))
 
             g2_11 = diagonal_element(G2RealSpace(geom, 1, 1), addr)
             g2_12 = diagonal_element(G2RealSpace(geom, 1, 2), addr)
@@ -936,7 +936,7 @@ using Rimu.Hamiltonians: circshift_dot
 
         @testset "G2 is symmetric for translationally invariant ground states" begin
             addr = near_uniform(BoseFS{3,18})
-            geom = Geometry((2,3,3), (false, true, true))
+            geom = CubicGrid((2,3,3), (false, true, true))
             H = HubbardRealSpace(addr; geometry=geom)
             bsr = BasisSetRep(H)
             v0 = PDVec(zip(bsr.basis, eigen(Matrix(bsr)).vectors[:,1]))

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -183,13 +183,13 @@ using Rimu.Hamiltonians: Directions, Offsets
         @test g[SVector(2,3,0)] == 0
     end
 
-    @testset "UnitVectors" begin
-        @test UnitVectors(1) == [[1], [-1]]
-        @test UnitVectors(CubicGrid(2,3)) == [[1,0], [0,1], [-1,0], [0,-1]]
-        @test UnitVectors(3) == [[1,0,0], [0,1,0], [0,0,1], [-1,0,0], [0,-1,0], [0,0,-1]]
-        @test_throws BoundsError UnitVectors(3)[0]
-        @test_throws BoundsError UnitVectors(2)[5]
-        @test_throws BoundsError UnitVectors(1)[15]
+    @testset "Directions" begin
+        @test Directions(1) == [[1], [-1]]
+        @test Directions(Geometry(2,3)) == [[1,0], [0,1], [-1,0], [0,-1]]
+        @test Directions(3) == [[1,0,0], [0,1,0], [0,0,1], [-1,0,0], [0,-1,0], [0,0,-1]]
+        @test_throws BoundsError Directions(3)[0]
+        @test_throws BoundsError Directions(2)[5]
+        @test_throws BoundsError Directions(1)[15]
     end
 
     @testset "Offsets" begin

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -185,7 +185,7 @@ using Rimu.Hamiltonians: Directions, Offsets
 
     @testset "Directions" begin
         @test Directions(1) == [[1], [-1]]
-        @test Directions(Geometry(2,3)) == [[1,0], [0,1], [-1,0], [0,-1]]
+        @test Directions(CubicGrid(2,3)) == [[1,0], [0,1], [-1,0], [0,-1]]
         @test Directions(3) == [[1,0,0], [0,1,0], [0,0,1], [-1,0,0], [0,-1,0], [0,0,-1]]
         @test_throws BoundsError Directions(3)[0]
         @test_throws BoundsError Directions(2)[5]

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -867,9 +867,9 @@ using Rimu.Hamiltonians: circshift_dot
     @testset "G2RealSpace" begin
         @testset "1D G2RealCorrelator comparison" begin
             @testset "constructors" begin
-                g2_1 = G2RealSpace(Geometry(2, 2, 3), 1, 3) isa G2RealSpace{1,3}
-                g2_2 = G2RealSpace(Geometry(2, 2), 2) isa G2RealSpace{2,2}
-                g2_3 = G2RealSpace(Geometry(2, 2); sum_components=true) isa G2RealSpace{0,0}
+                g2_1 = G2RealSpace(Geometry(2, 2, 3), 1, 3)
+                g2_2 = G2RealSpace(Geometry(2, 2), 2)
+                g2_3 = G2RealSpace(Geometry(2, 2); sum_components=true)
                 @test g2_1 isa G2RealSpace{1,3}
                 @test g2_2 isa G2RealSpace{2,2}
                 @test g2_3 isa G2RealSpace{0,0}

--- a/test/mpi_runtests.jl
+++ b/test/mpi_runtests.jl
@@ -266,6 +266,7 @@ end
             add = BoseFS((0,0,10,0,0))
             H = HubbardMom1D(add)
             D = DensityMatrixDiagonal(1)
+            G2 = G2RealSpace(PeriodicBoundaries(5))
 
             # Need to seed here to get the same random vectors on all ranks.
             Random.seed!(1)
@@ -300,6 +301,12 @@ end
                 @test norm(u, 2) ≈ norm(pu, 2)
                 @test norm(u, Inf) ≈ norm(pu, Inf)
             end
+            # dot only for G2
+            @test dot(v, G2, w) ≈ dot(pv, G2, pw)
+            @test dot(w, G2, v) ≈ dot(pw, G2, pv)
+
+            @test dot(v, G2, w) ≈ dot(pv, G2, pw, wm)
+            @test dot(w, G2, v) ≈ dot(pw, G2, pv, wm)
 
             @test dot(pv, (H, D), pw, wm) == (dot(pv, H, pw), dot(pv, D, pw))
             @test dot(pv, (H, D), pw) == (dot(pv, H, pw), dot(pv, D, pw))


### PR DESCRIPTION
# Rework Geometry, add new G2 correlator

## changes to the code

* `LatticeGeometry`, `PeriodicBoundaries`, `HardwallBoundaries` and `LadderBoundaries` replaced with `CubicGrid`.
* Observables with `eltype(op) <: AbstractArray` are now supported in both `dot` and for use in `AllOverlaps`.
* New `G2RealSpace` operator, which is aware of the geometry and computes G_2 for all displacement vectors at the same time.

## breaking changes

* `LatticeGeometry` no longer exists, `PeriodicBoundaries`, `HardwallBoundaries` and `LadderBoundaries` are no longer separate types. All user code should still run without modifications.