### PR TITLE
Allow computing estimators directly on a PMCSimulation

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -78,7 +78,7 @@ julia> using Revise
 Rimu offers a number of tools for representing Hamiltonians (see
 [`Hamiltonians`](@ref)) and state vectors / wave functions
 (see [`DictVectors`](@ref))
-as well as algorithms to find the ground state, e.g. [`lomc!`](@ref).
+as well as algorithms to find the ground state, e.g. [`ProjectorMonteCarloProblem`](@ref), [`ExactDiagonalizationProblem`](@ref).
 
 ## Scripts
 
@@ -99,7 +99,7 @@ distribute work by making use of MPI, or "message passing interface". For exampl
 ```
 > julia scripts/BHM-example.jl
 ```
-will run on one processor with the main `lomc!()` computation (i.e. after
+will run on one processor with the main computation (i.e. after
 package loading and compilation) completing in 2.69 seconds.
 
 Running
@@ -110,10 +110,10 @@ on the same hardware makes use of 4 cores and the main part completes in 1.04
 seconds, a speedup factor of 2.6. This seems reasonable, given that extra work
 needs to be done for communicating between different processes.
 
-Using MPI parallelism with `Rimu` is easy. Enabling MPI for use in [`lomc!()`](@ref) is
-enabled automatically if [`PDVec`](@ref) is used to store a vector. In that case, data will
-be stored in a distributed fashion among the MPI ranks and only communicated between ranks
-when necessary. Additional MPI-related functionality is provided by the module [`RMPI`](@ref
+Using MPI parallelism with `Rimu` is easy. Enabling MPI enabled automatically if
+[`PDVec`](@ref) is used to store a vector. In that case, data will be stored in a
+distributed fashion among the MPI ranks and only communicated between ranks when
+necessary. Additional MPI-related functionality is provided by the module [`RMPI`](@ref
 Rimu.RMPI).
 
 ## Compatibility

--- a/docs/src/statstools.md
+++ b/docs/src/statstools.md
@@ -18,11 +18,11 @@ sample means is done with [`ratio_of_means`](@ref), where error propagation
 of correlated uncertainties is done with the help of the package
 [`MonteCarloMeasurements`](https://github.com/baggepinnen/MonteCarloMeasurements.jl).
 
-Many convenience functions are implemented for directly analysing data
-obtained from [`lomc!`](@ref) as a `DataFrame`. See, e.g.,
-[`shift_estimator`](@ref) and [`projected_energy`](@ref). Asymptotically
-unbiased estimators are implemented as [`mixed_estimator`](@ref),
-[`growth_estimator`](@ref) and [`rayleigh_replica_estimator`](@ref).
+Many convenience functions are implemented for directly analysing data obtained from
+[`solve`](@ref solve(::ProjectorMonteCarloProblem)) as a `DataFrame`. See, e.g.,
+[`shift_estimator`](@ref) and [`projected_energy`](@ref). Asymptotically unbiased estimators
+are implemented as [`mixed_estimator`](@ref), [`growth_estimator`](@ref) and
+[`rayleigh_replica_estimator`](@ref).
 
 ## Exported
 ```@autodocs

--- a/docs/src/statstools.md
+++ b/docs/src/statstools.md
@@ -19,7 +19,7 @@ of correlated uncertainties is done with the help of the package
 [`MonteCarloMeasurements`](https://github.com/baggepinnen/MonteCarloMeasurements.jl).
 
 Many convenience functions are implemented for directly analysing data obtained from
-[`solve`](@ref solve(::ProjectorMonteCarloProblem)) as a `DataFrame`. See, e.g.,
+[`solve`](@ref CommonSolve.solve(::ProjectorMonteCarloProblem)) as a `DataFrame`. See, e.g.,
 [`shift_estimator`](@ref) and [`projected_energy`](@ref). Asymptotically unbiased estimators
 are implemented as [`mixed_estimator`](@ref), [`growth_estimator`](@ref) and
 [`rayleigh_replica_estimator`](@ref).

--- a/src/StatsTools/StatsTools.jl
+++ b/src/StatsTools/StatsTools.jl
@@ -22,7 +22,7 @@ Tools for the statistical analysis of Monte Carlo data.
 """
 module StatsTools
 
-using DataFrames: DataFrames, DataFrame
+using DataFrames: DataFrames, DataFrame, metadata
 using Distributions: Distributions, Chisq, Distribution, MvNormal, Normal,
     cquantile, var
 using LinearAlgebra: LinearAlgebra, diag, norm

--- a/src/StatsTools/fidelity.jl
+++ b/src/StatsTools/fidelity.jl
@@ -3,12 +3,10 @@
     replica_fidelity(sim::PMCSimulation; kwargs...)
 
 Compute the fidelity of the average coefficient vector and the projector defined in
-`p_field` from the result of replica [`lomc!`](@ref Main.lomc!) passed as  argument `df`,
-using replicas `_1` and `_2`.
-Calls [`ratio_of_means()`](@ref) to perform a blocking analysis
-on a ratio of the means of separate time series and returns a
-[`RatioBlockingResult`](@ref).
-The first `skip` steps in the time series are skipped.
+`p_field` from the [`PQMCSimulation`](@ref) or `DataFrame` returned by solve, using replicas
+`_1` and `_2`. Calls [`ratio_of_means()`](@ref) to perform a blocking analysis on a ratio
+of the means of separate time series and returns a [`RatioBlockingResult`](@ref). The first
+`skip` steps in the time series are skipped.
 
 The fidelity of states `|ψ⟩` and `|ϕ⟩` is defined as
 ```math

--- a/src/StatsTools/fidelity.jl
+++ b/src/StatsTools/fidelity.jl
@@ -22,7 +22,8 @@ where `v` is the projector specified by `p_field`, which is assumed to be normal
 unity with the two-norm (i.e. `v⋅v == 1`), and ``\\mathbf{c}_1`` and ``\\mathbf{c}_2``
 are two replica coefficient vectors.
 """
-function replica_fidelity(df::DataFrame; p_field = :hproj, skip = 0,  args...)
+function replica_fidelity(sim; p_field = :hproj, skip = 0,  args...)
+    df = DataFrame(sim)
     p_field_1 = Symbol(p_field, :_1)
     p_field_2 = Symbol(p_field, :_2)
     fid_num = conj(getproperty(df, p_field_1)) .* getproperty(df, p_field_2)

--- a/src/StatsTools/fidelity.jl
+++ b/src/StatsTools/fidelity.jl
@@ -3,7 +3,7 @@
     replica_fidelity(sim::PMCSimulation; kwargs...)
 
 Compute the fidelity of the average coefficient vector and the projector defined in
-`p_field` from the [`PQMCSimulation`](@ref Main.Rimu.PQMCSimulation) or `DataFrame` returned
+`p_field` from the [`PMCSimulation`](@ref Main.Rimu.PMCSimulation) or `DataFrame` returned
 by solve, using replicas `_1` and `_2`. Calls [`ratio_of_means`](@ref) to perform a
 blocking analysis on a ratio of the means of separate time series and returns a
 [`RatioBlockingResult`](@ref). The first `skip` steps in the time series are skipped.

--- a/src/StatsTools/fidelity.jl
+++ b/src/StatsTools/fidelity.jl
@@ -1,5 +1,7 @@
 """
     replica_fidelity(df::DataFrame; p_field = :hproj, skip = 0)
+    replica_fidelity(sim::PMCSimulation; kwargs...)
+
 Compute the fidelity of the average coefficient vector and the projector defined in
 `p_field` from the result of replica [`lomc!`](@ref Main.lomc!) passed as  argument `df`,
 using replicas `_1` and `_2`.

--- a/src/StatsTools/fidelity.jl
+++ b/src/StatsTools/fidelity.jl
@@ -3,10 +3,10 @@
     replica_fidelity(sim::PMCSimulation; kwargs...)
 
 Compute the fidelity of the average coefficient vector and the projector defined in
-`p_field` from the [`PQMCSimulation`](@ref) or `DataFrame` returned by solve, using replicas
-`_1` and `_2`. Calls [`ratio_of_means()`](@ref) to perform a blocking analysis on a ratio
-of the means of separate time series and returns a [`RatioBlockingResult`](@ref). The first
-`skip` steps in the time series are skipped.
+`p_field` from the [`PQMCSimulation`](@ref Main.Rimu.PQMCSimulation) or `DataFrame` returned
+by solve, using replicas `_1` and `_2`. Calls [`ratio_of_means`](@ref) to perform a
+blocking analysis on a ratio of the means of separate time series and returns a
+[`RatioBlockingResult`](@ref). The first `skip` steps in the time series are skipped.
 
 The fidelity of states `|ψ⟩` and `|ϕ⟩` is defined as
 ```math

--- a/src/StatsTools/growth_witness.jl
+++ b/src/StatsTools/growth_witness.jl
@@ -37,8 +37,8 @@ end
     growth_witness(df::DataFrame, [b]; shift=:shift, norm=:norm, dτ=df.dτ[end], skip=0)
 
 Calculate the growth witness directly from the result (`DataFrame` or
-[`PMCSimulation`](@ref)) of
-[`solve`](@ref Main.CommonSolve.solve(::ProjectorMonteCarloProblem))ing a
+[`PMCSimulation`](@ref Main.Rimu.PMCSimulation)) of
+[`solve`](@ref CommonSolve.solve(::ProjectorMonteCarloProblem))ing a
 [`ProjectorMonteCarloProblem`](@ref Main.ProjectorMonteCarloProblem). The keyword arguments
 `shift` and `norm` can be used to change the names of the relevant columns.
 """

--- a/src/StatsTools/growth_witness.jl
+++ b/src/StatsTools/growth_witness.jl
@@ -37,7 +37,8 @@ end
     growth_witness(df::DataFrame, [b]; shift=:shift, norm=:norm, dτ=df.dτ[end], skip=0)
 
 Calculate the growth witness directly from the result (`DataFrame` or
-[`PMCSimulation`](@ref)) of [`solve`](@ref Main.solve(::ProjectorMonteCarloProblem))ing a
+[`PMCSimulation`](@ref)) of
+[`solve`](@ref Main.CommonSolve.solve(::ProjectorMonteCarloProblem))ing a
 [`ProjectorMonteCarloProblem`](@ref Main.ProjectorMonteCarloProblem). The keyword arguments
 `shift` and `norm` can be used to change the names of the relevant columns.
 """

--- a/src/StatsTools/growth_witness.jl
+++ b/src/StatsTools/growth_witness.jl
@@ -1,7 +1,5 @@
 """
     growth_witness(shift::AbstractArray, norm::AbstractArray, dt, [b]; skip=0)
-    growth_witness(df::DataFrame, [b]; skip=0)
-    growth_witness(sim::PMCSimulation, [b]; skip=0)
 
 Compute the growth witness
 ```math
@@ -35,6 +33,7 @@ function growth_witness(shift::AbstractArray, norm::AbstractArray, dt, b; kwargs
 end
 """
     growth_witness(df::DataFrame, [b]; shift=:shift, norm=:norm, dτ=df.dτ[end], skip=0)
+    growth_witness(sim::PMCSimulation, [b]; kwargs...)
 
 Calculate the growth witness directly from the result (`DataFrame` or
 [`PMCSimulation`](@ref Main.Rimu.PMCSimulation)) of

--- a/src/StatsTools/growth_witness.jl
+++ b/src/StatsTools/growth_witness.jl
@@ -41,9 +41,10 @@ Calculate the growth witness directly from a `DataFrame` returned by
 can be used to change the names of the relevant columns.
 """
 function growth_witness(
-    df::DataFrame, b=Val(0);
+    sim, b=Val(0);
     shift=:shift, norm=:norm, dτ=df.dτ[end], kwargs...
 )
+    df = DataFrame(sim)
     shift_vec = getproperty(df, Symbol(shift))
     norm_vec = getproperty(df, Symbol(norm))
     return growth_witness(shift_vec, norm_vec, dτ, b; kwargs...)

--- a/src/StatsTools/growth_witness.jl
+++ b/src/StatsTools/growth_witness.jl
@@ -36,9 +36,10 @@ end
 """
     growth_witness(df::DataFrame, [b]; shift=:shift, norm=:norm, dτ=df.dτ[end], skip=0)
 
-Calculate the growth witness directly from a `DataFrame` returned by
-[`lomc!`](@ref Main.lomc!). The keyword arguments `shift` and `norm`
-can be used to change the names of the relevant columns.
+Calculate the growth witness directly from the result (`DataFrame` or
+[`PMCSimulation`](@ref)) of [`solve`](@ref Main.solve(::ProjectorMonteCarloProblem))ing a
+[`ProjectorMonteCarloProblem`](@ref Main.ProjectorMonteCarloProblem). The keyword arguments
+`shift` and `norm` can be used to change the names of the relevant columns.
 """
 function growth_witness(
     sim, b=Val(0);

--- a/src/StatsTools/growth_witness.jl
+++ b/src/StatsTools/growth_witness.jl
@@ -1,9 +1,8 @@
-# growth_witness()
-# smoothen()
-
 """
     growth_witness(shift::AbstractArray, norm::AbstractArray, dt, [b]; skip=0) -> g
     growth_witness(df::DataFrame, [b]; skip=0) -> g
+    growth_witness(sim::SimulationState, [b]; skip=0) -> g
+
 Compute the growth witness
 ```math
 G^{(n)} = S^{(n)} - \\frac{\\vert\\mathbf{c}^{(n+1)}\\vert -
@@ -45,9 +44,8 @@ function growth_witness(
     shift=:shift, norm=:norm, dτ=nothing, kwargs...
 )
     df = DataFrame(sim)
-    if isnothing(dτ)
-        dτ = df.dτ[end]
-    end
+    dτ = determine_constant_time_step(df)
+
     shift_vec = getproperty(df, Symbol(shift))
     norm_vec = getproperty(df, Symbol(norm))
     return growth_witness(shift_vec, norm_vec, dτ, b; kwargs...)

--- a/src/StatsTools/growth_witness.jl
+++ b/src/StatsTools/growth_witness.jl
@@ -42,9 +42,12 @@ can be used to change the names of the relevant columns.
 """
 function growth_witness(
     sim, b=Val(0);
-    shift=:shift, norm=:norm, dτ=df.dτ[end], kwargs...
+    shift=:shift, norm=:norm, dτ=nothing, kwargs...
 )
     df = DataFrame(sim)
+    if isnothing(dτ)
+        dτ = df.dτ[end]
+    end
     shift_vec = getproperty(df, Symbol(shift))
     norm_vec = getproperty(df, Symbol(norm))
     return growth_witness(shift_vec, norm_vec, dτ, b; kwargs...)

--- a/src/StatsTools/growth_witness.jl
+++ b/src/StatsTools/growth_witness.jl
@@ -1,7 +1,7 @@
 """
-    growth_witness(shift::AbstractArray, norm::AbstractArray, dt, [b]; skip=0) -> g
-    growth_witness(df::DataFrame, [b]; skip=0) -> g
-    growth_witness(sim::SimulationState, [b]; skip=0) -> g
+    growth_witness(shift::AbstractArray, norm::AbstractArray, dt, [b]; skip=0)
+    growth_witness(df::DataFrame, [b]; skip=0)
+    growth_witness(sim::PMCSimulation, [b]; skip=0)
 
 Compute the growth witness
 ```math
@@ -35,6 +35,7 @@ function growth_witness(shift::AbstractArray, norm::AbstractArray, dt, b; kwargs
 end
 """
     growth_witness(df::DataFrame, [b]; shift=:shift, norm=:norm, dτ=df.dτ[end], skip=0)
+
 Calculate the growth witness directly from a `DataFrame` returned by
 [`lomc!`](@ref Main.lomc!). The keyword arguments `shift` and `norm`
 can be used to change the names of the relevant columns.

--- a/src/StatsTools/reweighting.jl
+++ b/src/StatsTools/reweighting.jl
@@ -195,7 +195,7 @@ end
     -> (; df_ge, correlation_estimate, se, se_l, se_u)
 
 Compute the [`growth_estimator`](@ref) on a `DataFrame` `df` or
-[`PMCSimulation`](@ref Main.PMCSimulation) `sim`. repeatedly over a range of reweighting
+[`PMCSimulation`](@ref Main.Rimu.PMCSimulation) `sim`. repeatedly over a range of reweighting
 depths.
 
 Returns a `NamedTuple` with the fields

--- a/src/StatsTools/reweighting.jl
+++ b/src/StatsTools/reweighting.jl
@@ -139,9 +139,10 @@ function growth_estimator(
     # return (; E_gr, k=rbr.k, blocks = rbr.blocks, success = rbr.success)
 end
 function growth_estimator(
-    df::DataFrame, h;
+    sim, h;
     shift_name=:shift, norm_name=:norm, dτ=df.dτ[end], kwargs...
 )
+    df = DataFrame(sim)
     shift_vec = Vector(getproperty(df, Symbol(shift_name)))
     norm_vec = Vector(getproperty(df, Symbol(norm_name)))
     # converting to Vector here because this works fastest with `growth_estimator`
@@ -193,7 +194,7 @@ xlabel!("h")
 See also: [`growth_estimator`](@ref), [`mixed_estimator_analysis`](@ref).
 """
 function growth_estimator_analysis(
-    df::DataFrame;
+    sim;
     h_range=nothing,
     h_values=100,
     skip=0,
@@ -203,6 +204,7 @@ function growth_estimator_analysis(
     warn=true,
     kwargs...
 )
+    df = DataFrame(sim)
     shift_v = Vector(getproperty(df, Symbol(shift_name))) # casting to `Vector` to make SIMD loops efficient
     norm_v = Vector(getproperty(df, Symbol(norm_name)))
     num_reps = length(filter(startswith("dτ"), names(df)))
@@ -298,7 +300,7 @@ returned by [`lomc!`](@ref Main.lomc!). The keyword arguments `hproj_name`, `vpr
 See also [`growth_estimator()`](@ref).
 """
 function mixed_estimator(
-    hproj, vproj, shift, h, dτ;
+    hproj::AbstractVector, vproj::AbstractVector, shift::AbstractVector, h, dτ;
     skip=0,
     E_r=mean(view(shift, skip+1:length(shift))),
     weights=w_exp,
@@ -310,9 +312,10 @@ function mixed_estimator(
     return ratio_of_means(num, denom; kwargs...)
 end
 function mixed_estimator(
-    df::DataFrame, h;
+    sim, h;
     hproj_name=:hproj, vproj_name=:vproj, shift_name=:shift, dτ=df.dτ[end], kwargs...
 )
+    df = DataFrame(sim)
     hproj_vec = Vector(getproperty(df, Symbol(hproj_name)))
     vproj_vec = Vector(getproperty(df, Symbol(vproj_name)))
     shift_vec = Vector(getproperty(df, Symbol(shift_name)))
@@ -561,7 +564,7 @@ xlabel!("h")
 See also: [`rayleigh_replica_estimator`](@ref), [`mixed_estimator_analysis`](@ref), [`AllOverlaps`](@ref Main.AllOverlaps).
 """
 function rayleigh_replica_estimator_analysis(
-    df::DataFrame;
+    sim,
     h_range=nothing,
     h_values=100,
     skip=0,
@@ -573,6 +576,7 @@ function rayleigh_replica_estimator_analysis(
     warn=true,
     kwargs...
 )
+    df = DataFrame(sim)
     num_reps = length(filter(startswith("dτ"), names(df)))
     dτ = if num_reps == 1
         df.dτ[end]
@@ -662,7 +666,8 @@ Returns a [`RatioBlockingResult`](@ref).
 See [`NamedTuple`](@ref), [`val_and_errs`](@ref), [`val`](@ref), [`errs`](@ref) for
 processing results.
 """
-function projected_energy(df::DataFrame; skip=0, hproj=:hproj, vproj=:vproj, kwargs...)
+function projected_energy(sim; skip=0, hproj=:hproj, vproj=:vproj, kwargs...)
+    df = DataFrame(sim)
     hproj_vec = Vector(getproperty(df, Symbol(hproj)))
     vproj_vec = Vector(getproperty(df, Symbol(vproj)))
     return @views ratio_of_means(hproj_vec[skip+1:end], vproj_vec[skip+1:end]; kwargs...)
@@ -676,7 +681,8 @@ on to [`blocking_analysis`](@ref). Returns a [`BlockingResult`](@ref).
 
 See also [`growth_estimator`](@ref), [`projected_energy`](@ref).
 """
-function shift_estimator(df::DataFrame; shift=:shift, kwargs...)
+function shift_estimator(sim; shift=:shift, kwargs...)
+    df = DataFrame(sim)
     shift_vec = Vector(getproperty(df, Symbol(shift)))
     return blocking_analysis(shift_vec; kwargs...)
 end

--- a/src/StatsTools/reweighting.jl
+++ b/src/StatsTools/reweighting.jl
@@ -110,9 +110,9 @@ technique described in [Umrigar *et al.* (1993)](http://dx.doi.org/10.1063/1.465
 see Eq. (20).
 `shift` and `wn` are equal length vectors containing the shift and walker number time
 series, respectively.  Reweighting is done over `h` time steps and `length(shift) - skip`
-time steps are used for the blocking analysis done with [`ratio_of_means()`](@ref). `dτ` is
-the time step and `weights` a function that calulates the weights. See [`w_exp()`](@ref) and
-[`w_lin()`](@ref).
+time steps are used for the blocking analysis done with [`ratio_of_means`](@ref). `dτ` is
+the time step and `weights` a function that calulates the weights. See [`w_exp`](@ref) and
+[`w_lin`](@ref).
 ```math
 E_{gr} = E_r - \\frac{1}{dτ}\\ln
     \\frac{\\sum_n w_{h+1}^{(n+1)} N_\\mathrm{w}^{(n+1)}}
@@ -130,10 +130,10 @@ Propagation through the logarithm can be modified by setting `change_type` to
 If `success==true` the blocking analysis was successful in `k-1` steps, using `blocks`
 uncorrelated data points.
 
-The second method calculates the growth estimator directly from a [`PQMCSimulation`](@ref)
-or `DataFrame` returned by [`solve`](@ref Main.solve(::ProjectorMonteCarloProblem)). The
-keyword arguments `shift_name` and `norm_name` can be used to change the names of the
-relevant columns.
+The second method calculates the growth estimator directly from a
+[`PQMCSimulation`](@ref Main.Rimu.PQMCSimulation) or `DataFrame` returned by
+[`solve`](@ref Main.CommonSolve.solve(::ProjectorMonteCarloProblem)). The keyword arguments
+`shift_name` and `norm_name` can be used to change the names of the relevant columns.
 
 See also [`mixed_estimator`](@ref) and [`RatioBlockingResult`](@ref).
 """
@@ -317,9 +317,9 @@ where the time series `hproj ==` ``(Ĥ'\\mathbf{v})⋅\\mathbf{c}^{(n)}`` and `
 ``\\mathbf{v}⋅\\mathbf{c}^{(m)}`` have the same length as `shift` (See
 [`ProjectedEnergy`](@ref Main.ProjectedEnergy) on how to set these up).  Reweighting is done
 over `h` time steps and `length(shift) - skip` time steps are used for the blocking analysis
-done with [`ratio_of_means()`](@ref). `dτ` is the time step and `weights` a function that
-calulates the weights. See [`w_exp()`](@ref) and [`w_lin()`](@ref).  Additional keyword
-arguments are passed on to [`ratio_of_means()`](@ref).
+done with [`ratio_of_means`](@ref). `dτ` is the time step and `weights` a function that
+calulates the weights. See [`w_exp`](@ref) and [`w_lin`](@ref).  Additional keyword
+arguments are passed on to [`ratio_of_means`](@ref).
 
 When `h` is greater than the autocorrelation time scale of the `shift`, then `r.ratio` is an
 unbiased but approximate estimator for the ground state energy ``E_0`` with an error
@@ -329,9 +329,10 @@ unweighted ratio.  Error propagation is done with
 Results are returned as [`RatioBlockingResult`](@ref).
 
 The second method calculates the mixed energy estimator directly from a `DataFrame` or
-`PQMCSimulation` returned by [`solve`](@ref Main.solve(::ProjectorMonteCarloProblem)). The
-keyword arguments `hproj_name`, `vproj_name`, and `shift_name` can be used to change the
-names of the relevant columns.
+[`PQMCSimulation`](@ref Main.Rimu.PQMCSimulation) returned by
+[`solve`](@ref Main.CommonSolve.solve(::ProjectorMonteCarloProblem)). The keyword arguments
+`hproj_name`, `vproj_name`, and `shift_name` can be used to change the names of the relevant
+columns.
 
 See also [`growth_estimator`](@ref).
 """
@@ -364,9 +365,10 @@ end
     mixed_estimator_analysis(sim::PMCSimulation; kwargs...)
     -> (; df_me, correlation_estimate, se, se_l, se_u)
 
-Compute the [`mixed_estimator`](@ref) on a `DataFrame` `df` or [`PQMCSimulation`](@ref)
-`sim` returned from [`solve`](@ref Main.solve(::ProjectorMonteCarloProblem)) repeatedly over
-a range of reweighting depths.
+Compute the [`mixed_estimator`](@ref) on a `DataFrame` `df` or
+[`PQMCSimulation`](@ref Main.Rimu.PQMCSimulation) `sim` returned from
+[`solve`](@ref Main.CommonSolve.solve(::ProjectorMonteCarloProblem)) repeatedly over a
+range of reweighting depths.
 
 Returns a `NamedTuple` with the fields
 * `df_me`: `DataFrame` with reweighting depth and `mixed_estiamator` data. See example below.
@@ -490,25 +492,26 @@ Argument `shift` is of type `Vector{Vector}`, with each element `Vector`
 holding the shift data for each individual replica.
 
 The second method computes the Rayleigh quotient directly from a `DataFrame` or
-[`PQMCSimulation`](@ref) returned by [`solve`](@ref
-Main.solve(::ProjectorMonteCarloProblem)). The keyword arguments `shift_name`, `op_name` and
-`vec_name` can be used to change the names of the relevant columns, see [`AllOverlaps`](@ref
-Main.AllOverlaps) for default formatting. The operator overlap data can be scaled by a
-prefactor `Anorm`. A specific reweighting depth can be set with keyword argument `h`. The
-default is `h = 0` which calculates the Rayleigh quotient without reweighting.
+[`PQMCSimulation`](@ref Main.Rimu.PQMCSimulation) returned by
+[`solve`](@ref Main.CommonSolve.solve(::ProjectorMonteCarloProblem)). The keyword arguments
+`shift_name`, `op_name` and `vec_name` can be used to change the names of the relevant
+columns, see [`AllOverlaps`](@ref Main.AllOverlaps) for default formatting. The operator
+overlap data can be scaled by a prefactor `Anorm`. A specific reweighting depth can be set
+with keyword argument `h`. The default is `h = 0` which calculates the Rayleigh quotient
+without reweighting.
 
 The reweighting is an extension of the mixed estimator using the reweighting technique
 described in [Umrigar *et al.* (1993)](http://dx.doi.org/10.1063/1.465195).
 Reweighting is done over `h` time steps and `length(shift) - skip` time steps are used
-for the blocking analysis done with [`ratio_of_means()`](@ref).
+for the blocking analysis done with [`ratio_of_means`](@ref).
 `dτ` is the time step and `weights` a function that
-calulates the weights. See [`w_exp()`](@ref) and [`w_lin()`](@ref).
-Additional keyword arguments are passed on to [`ratio_of_means()`](@ref).
+calulates the weights. See [`w_exp`](@ref) and [`w_lin`](@ref).
+Additional keyword arguments are passed on to [`ratio_of_means`](@ref).
 
 Error propagation is done with [`MonteCarloMeasurements`](https://github.com/baggepinnen/MonteCarloMeasurements.jl).
 Results are returned as [`RatioBlockingResult`](@ref).
 
-See also [`mixed_estimator`](@ref), [`growth_estimator()`](@ref).
+See also [`mixed_estimator`](@ref), [`growth_estimator`](@ref).
 """
 function rayleigh_replica_estimator(
     op_ol::Vector,
@@ -578,8 +581,9 @@ end
     -> (; df_rre, df_se)
 
 Compute the [`rayleigh_replica_estimator`](@ref) on a `DataFrame` `df` or
-[`PQMCSimulation`](@ref) `sim` returned from [`solve`](@ref
-Main.solve(::ProjectorMonteCarloProblem)) repeatedly over a range of reweighting depths.
+[`PQMCSimulation`](@ref Main.Rimu.PQMCSimulation) `sim` returned from
+[`solve`](@ref Main.CommonSolve.solve(::ProjectorMonteCarloProblem)) repeatedly over a
+range of reweighting depths.
 
 Returns a `NamedTuple` with the fields
 * `df_rre`: `DataFrame` with reweighting depth and `rayleigh_replica_estimator` data. See example below.

--- a/src/StatsTools/reweighting.jl
+++ b/src/StatsTools/reweighting.jl
@@ -498,7 +498,7 @@ function rayleigh_replica_estimator(
     return ratio_of_means(num, denom; kwargs...)
 end
 function rayleigh_replica_estimator(
-    df::DataFrame;
+    sim;
     shift_name="shift",
     op_name="Op1",
     vec_name="dot",
@@ -507,6 +507,7 @@ function rayleigh_replica_estimator(
     Anorm=1,
     kwargs...
 )
+    df = DataFrame(sim)
     num_reps = length(filter(startswith("dτ"), names(df)))
     dτ = if num_reps == 1
         df.dτ[end]

--- a/src/StatsTools/reweighting.jl
+++ b/src/StatsTools/reweighting.jl
@@ -131,8 +131,8 @@ If `success==true` the blocking analysis was successful in `k-1` steps, using `b
 uncorrelated data points.
 
 The second method calculates the growth estimator directly from a
-[`PQMCSimulation`](@ref Main.Rimu.PQMCSimulation) or `DataFrame` returned by
-[`solve`](@ref Main.CommonSolve.solve(::ProjectorMonteCarloProblem)). The keyword arguments
+[`PMCSimulation`](@ref Main.Rimu.PMCSimulation) or `DataFrame` returned by
+[`solve`](@ref CommonSolve.solve(::ProjectorMonteCarloProblem)). The keyword arguments
 `shift_name` and `norm_name` can be used to change the names of the relevant columns.
 
 See also [`mixed_estimator`](@ref) and [`RatioBlockingResult`](@ref).
@@ -329,8 +329,8 @@ unweighted ratio.  Error propagation is done with
 Results are returned as [`RatioBlockingResult`](@ref).
 
 The second method calculates the mixed energy estimator directly from a `DataFrame` or
-[`PQMCSimulation`](@ref Main.Rimu.PQMCSimulation) returned by
-[`solve`](@ref Main.CommonSolve.solve(::ProjectorMonteCarloProblem)). The keyword arguments
+[`PMCSimulation`](@ref Main.Rimu.PMCSimulation) returned by
+[`solve`](@ref CommonSolve.solve(::ProjectorMonteCarloProblem)). The keyword arguments
 `hproj_name`, `vproj_name`, and `shift_name` can be used to change the names of the relevant
 columns.
 
@@ -366,8 +366,8 @@ end
     -> (; df_me, correlation_estimate, se, se_l, se_u)
 
 Compute the [`mixed_estimator`](@ref) on a `DataFrame` `df` or
-[`PQMCSimulation`](@ref Main.Rimu.PQMCSimulation) `sim` returned from
-[`solve`](@ref Main.CommonSolve.solve(::ProjectorMonteCarloProblem)) repeatedly over a
+[`PMCSimulation`](@ref Main.Rimu.PMCSimulation) `sim` returned from
+[`solve`](@ref CommonSolve.solve(::ProjectorMonteCarloProblem)) repeatedly over a
 range of reweighting depths.
 
 Returns a `NamedTuple` with the fields
@@ -492,8 +492,8 @@ Argument `shift` is of type `Vector{Vector}`, with each element `Vector`
 holding the shift data for each individual replica.
 
 The second method computes the Rayleigh quotient directly from a `DataFrame` or
-[`PQMCSimulation`](@ref Main.Rimu.PQMCSimulation) returned by
-[`solve`](@ref Main.CommonSolve.solve(::ProjectorMonteCarloProblem)). The keyword arguments
+[`PMCSimulation`](@ref Main.Rimu.PMCSimulation) returned by
+[`solve`](@ref CommonSolve.solve(::ProjectorMonteCarloProblem)). The keyword arguments
 `shift_name`, `op_name` and `vec_name` can be used to change the names of the relevant
 columns, see [`AllOverlaps`](@ref Main.AllOverlaps) for default formatting. The operator
 overlap data can be scaled by a prefactor `Anorm`. A specific reweighting depth can be set
@@ -581,8 +581,8 @@ end
     -> (; df_rre, df_se)
 
 Compute the [`rayleigh_replica_estimator`](@ref) on a `DataFrame` `df` or
-[`PQMCSimulation`](@ref Main.Rimu.PQMCSimulation) `sim` returned from
-[`solve`](@ref Main.CommonSolve.solve(::ProjectorMonteCarloProblem)) repeatedly over a
+[`PMCSimulation`](@ref Main.Rimu.PMCSimulation) `sim` returned from
+[`solve`](@ref CommonSolve.solve(::ProjectorMonteCarloProblem)) repeatedly over a
 range of reweighting depths.
 
 Returns a `NamedTuple` with the fields

--- a/src/StatsTools/reweighting.jl
+++ b/src/StatsTools/reweighting.jl
@@ -140,9 +140,12 @@ function growth_estimator(
 end
 function growth_estimator(
     sim, h;
-    shift_name=:shift, norm_name=:norm, dτ=df.dτ[end], kwargs...
+    shift_name=:shift, norm_name=:norm, dτ=nothing, kwargs...
 )
     df = DataFrame(sim)
+    if isnothing(dτ)
+        dτ = df.dτ[end]
+    end
     shift_vec = Vector(getproperty(df, Symbol(shift_name)))
     norm_vec = Vector(getproperty(df, Symbol(norm_name)))
     # converting to Vector here because this works fastest with `growth_estimator`
@@ -313,9 +316,12 @@ function mixed_estimator(
 end
 function mixed_estimator(
     sim, h;
-    hproj_name=:hproj, vproj_name=:vproj, shift_name=:shift, dτ=df.dτ[end], kwargs...
+    hproj_name=:hproj, vproj_name=:vproj, shift_name=:shift, dτ=nothing, kwargs...
 )
     df = DataFrame(sim)
+    if isnothing(dτ)
+        dτ = df.dτ[end]
+    end
     hproj_vec = Vector(getproperty(df, Symbol(hproj_name)))
     vproj_vec = Vector(getproperty(df, Symbol(vproj_name)))
     shift_vec = Vector(getproperty(df, Symbol(shift_name)))
@@ -565,7 +571,7 @@ xlabel!("h")
 See also: [`rayleigh_replica_estimator`](@ref), [`mixed_estimator_analysis`](@ref), [`AllOverlaps`](@ref Main.AllOverlaps).
 """
 function rayleigh_replica_estimator_analysis(
-    sim,
+    sim;
     h_range=nothing,
     h_values=100,
     skip=0,

--- a/src/StatsTools/variational_energy_estimator.jl
+++ b/src/StatsTools/variational_energy_estimator.jl
@@ -1,7 +1,7 @@
 """
     variational_energy_estimator(shifts, overlaps; kwargs...)
     variational_energy_estimator(df::DataFrame; max_replicas=:all, kwargs...)
-    variational_energy_estimator(sim::PQMCSimulation; kwargs...)
+    variational_energy_estimator(sim::PMCSimulation; kwargs...)
     -> r::RatioBlockingResult
 
 Compute the variational energy estimator from the replica time series of the `shifts` and
@@ -23,9 +23,9 @@ Ē_{v}  =  \\frac{\\sum_{a<b}^R \\overline{(S_a+S_b) \\mathbf{c}_a^† \\mathbf
 where the sum goes over distinct pairs out of the ``R`` replicas. See
 [arXiv:2103.07800](http://arxiv.org/abs/2103.07800).
 
-The `DataFrame` and [`PQMCSimulation`](@ref Main.Rimu.PQMCSimulation) versions can extract
+The `DataFrame` and [`PMCSimulation`](@ref Main.Rimu.PMCSimulation) versions can extract
 the relevant information from the result of
-[`solve`](@ref Main.CommonSolve.solve(::ProjectorMonteCarloProblem)).
+[`solve`](@ref CommonSolve.solve(::ProjectorMonteCarloProblem)).
 Set up the [`ProjectorMonteCarloProblem`](@ref Main.ProjectorMonteCarloProblem) with the
 keyword argument `replica_strategy = AllOverlaps(R)` and `R ≥ 2`. If passing `shifts` and
 `overlaps`, the data has to be arranged in the correct order (as provided in the `DataFrame`

--- a/src/StatsTools/variational_energy_estimator.jl
+++ b/src/StatsTools/variational_energy_estimator.jl
@@ -46,7 +46,8 @@ function variational_energy_estimator(shifts, overlaps; kwargs...)
     return ratio_of_means(numerator, denominator; kwargs...)
 end
 
-function variational_energy_estimator(df::DataFrame; max_replicas=:all, kwargs...)
+function variational_energy_estimator(sim; max_replicas=:all, kwargs...)
+    df = DataFrame(sim)
     num_replicas = length(filter(startswith("norm_"), names(df))) # number of replicas
     if iszero(num_replicas)
         throw(ArgumentError(

--- a/src/StatsTools/variational_energy_estimator.jl
+++ b/src/StatsTools/variational_energy_estimator.jl
@@ -23,10 +23,11 @@ Ē_{v}  =  \\frac{\\sum_{a<b}^R \\overline{(S_a+S_b) \\mathbf{c}_a^† \\mathbf
 where the sum goes over distinct pairs out of the ``R`` replicas. See
 [arXiv:2103.07800](http://arxiv.org/abs/2103.07800).
 
-The `DataFrame` and [`PQMCSimulation`](@ref) versions can extract the relevant information
-from the result of [`solve`](@ref Main.solve(::ProjectorMonteCarloProblem)). Set up the
-[`ProjectorMonteCarloProblem`](@ref Main.ProjectorMonteCarloProblem) with the keyword
-argument `replica_strategy = AllOverlaps(R)` and `R ≥ 2`. If passing `shifts` and
+The `DataFrame` and [`PQMCSimulation`](@ref Main.Rimu.PQMCSimulation) versions can extract
+the relevant information from the result of
+[`solve`](@ref Main.CommonSolve.solve(::ProjectorMonteCarloProblem)).
+Set up the [`ProjectorMonteCarloProblem`](@ref Main.ProjectorMonteCarloProblem) with the
+keyword argument `replica_strategy = AllOverlaps(R)` and `R ≥ 2`. If passing `shifts` and
 `overlaps`, the data has to be arranged in the correct order (as provided in the `DataFrame`
 version).
 

--- a/src/StatsTools/variational_energy_estimator.jl
+++ b/src/StatsTools/variational_energy_estimator.jl
@@ -1,7 +1,9 @@
 """
     variational_energy_estimator(shifts, overlaps; kwargs...)
     variational_energy_estimator(df::DataFrame; max_replicas=:all, kwargs...)
+    variational_energy_estimator(sim::PQMCSimulation; kwargs...)
     -> r::RatioBlockingResult
+
 Compute the variational energy estimator from the replica time series of the `shifts` and
 coefficient vector `overlaps` by blocking analysis.
 The keyword argument `max_replicas` can be used to constrain the number of replicas
@@ -21,11 +23,12 @@ Ē_{v}  =  \\frac{\\sum_{a<b}^R \\overline{(S_a+S_b) \\mathbf{c}_a^† \\mathbf
 where the sum goes over distinct pairs out of the ``R`` replicas. See
 [arXiv:2103.07800](http://arxiv.org/abs/2103.07800).
 
-The `DataFrame` version can extract the relevant information from the result of
-[`lomc!`](@ref Main.lomc!). Set up [`lomc!`](@ref Main.lomc!) with the keyword argument
-`replica = AllOverlaps(R)` and `R ≥ 2`.
-If passing `shifts` and `overlaps`, the data has to be arranged in the correct order (as
-provided in the `DataFrame` version).
+The `DataFrame` and [`PQMCSimulation`](@ref) versions can extract the relevant information
+from the result of [`solve`](@ref Main.solve(::ProjectorMonteCarloProblem)). Set up the
+[`ProjectorMonteCarloProblem`](@ref Main.ProjectorMonteCarloProblem) with the keyword
+argument `replica_strategy = AllOverlaps(R)` and `R ≥ 2`. If passing `shifts` and
+`overlaps`, the data has to be arranged in the correct order (as provided in the `DataFrame`
+version).
 
 See [`AllOverlaps`](@ref Main.AllOverlaps).
 """
@@ -52,7 +55,7 @@ function variational_energy_estimator(sim; max_replicas=:all, kwargs...)
     if iszero(num_replicas)
         throw(ArgumentError(
             "No replicas found. Use keyword \
-            `replica=AllOverlaps(n)` with n≥2 in `lomc!()` to set up replicas!"
+            `replica_strategy=AllOverlaps(n)` with n≥2 in `ProjectorMonteCarloProblem` to set up replicas!"
         ))
     end
     @assert num_replicas ≥ 2 "At least two replicas are needed, found $num_replicas"

--- a/test/ExactDiagonalization.jl
+++ b/test/ExactDiagonalization.jl
@@ -2,7 +2,6 @@ using Rimu
 using Test
 using Random
 using Suppressor
-using SparseArrays
 
 @testset "BasisSetRepresentation" begin
     @testset "basics" begin

--- a/test/ExactDiagonalization.jl
+++ b/test/ExactDiagonalization.jl
@@ -2,6 +2,7 @@ using Rimu
 using Test
 using Random
 using Suppressor
+using SparseArrays
 
 @testset "BasisSetRepresentation" begin
     @testset "basics" begin

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -936,7 +936,7 @@ using Rimu.Hamiltonians: circshift_dot
             addr = near_uniform(BoseFS{3,18})
             geom = CubicGrid((2,3,3), (false, true, true))
             H = HubbardRealSpace(addr; geometry=geom)
-            bsr = BasisSetRep(H)
+            bsr = BasisSetRepresentation(H)
             v0 = PDVec(zip(bsr.basis, eigen(Matrix(bsr)).vectors[:,1]))
 
             g2 = dot(v0, G2RealSpace(geom), v0)


### PR DESCRIPTION
# changes
* All functions in StatsTools that used to accept a `DataFrame` now accept `Any` and try to convert it. This allows computing estimators directly on the `PMCSimulation` struct that is returned by `solve`.
* New helper function `determine_constant_time_step` takes a `DataFrame` and returns a time step from its metadata.