### PR TITLE
Breaking changes before v1.0 release

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -58,7 +58,7 @@ const SUITE = @benchmarkset "Rimu" begin
             ham = HubbardMom1D(addr, u=1.0)
             dv = PDVec(addr => 1.0; style=IsDynamicSemistochastic(), initiator=true)
             post_step = ProjectedEnergy(ham, dv)
-            s_strat = DoubleLogUpdate(targetwalkers=40_000)
+            s_strat = DoubleLogUpdate(target_walkers=40_000)
 
             lomc!(ham, dv; s_strat, post_step, dτ=1e-4, laststep=8000)
         end seconds=150
@@ -67,7 +67,7 @@ const SUITE = @benchmarkset "Rimu" begin
             addr = BoseFS2C(ntuple(i -> ifelse(i == 5, 4, 0), 11), ntuple(==(5), 11))
             ham = BoseHubbardMom1D2C(addr, v=0.1)
             dv = PDVec(addr => 1.0f0; style=IsDynamicSemistochastic{Float32}())
-            s_strat = DoubleLogUpdate(targetwalkers=10_000)
+            s_strat = DoubleLogUpdate(target_walkers=10_000)
             replica_strategy = AllOverlaps(2; operator = ntuple(i -> G2Correlator(i - 1), 7))
 
             lomc!(ham, dv; s_strat, replica_strategy, laststep=2000)
@@ -77,7 +77,7 @@ const SUITE = @benchmarkset "Rimu" begin
             addr = near_uniform(BoseFS{50,50})
             ham = HubbardReal1D(addr, u=6.0)
             dv = PDVec(addr => 1.0; style=IsDynamicSemistochastic())
-            s_strat = DoubleLogUpdate(targetwalkers=50_000)
+            s_strat = DoubleLogUpdate(target_walkers=50_000)
 
             lomc!(ham, dv; s_strat, dτ=1e-4, laststep=1000)
         end seconds=150

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -54,6 +54,7 @@ makedocs(;
         "Examples" => EXAMPLES_PAIRS[sortperm(EXAMPLES_NUMS)],
         "User documentation" => [
             "Exact Diagonalization" => "exactdiagonalization.md",
+            "Projector Monte Carlo" => "projectormontecarlo.md",
             "StatsTools" => "statstools.md",
             "Using MPI" => "mpi.md",
         ],

--- a/docs/src/projectormontecarlo.md
+++ b/docs/src/projectormontecarlo.md
@@ -28,7 +28,7 @@ the projector Monte Carlo calculation.
 Rimu.PMCSimulation
 ```
 
-The `DataFrame` returned from `DataFrame(::PNCSimulation)` contains the time series data from 
+The `DataFrame` returned from `DataFrame(::PMCSimulation)` contains the time series data from 
 the projector Monte Carlo simulation that is of primary interest for analysis. Depending on the 
 `reporting_strategy` and other options passed as keyword arguments to 
 `ProjectorMonteCarloProblem` it can have different numbers of rows and columns. The rows 

--- a/docs/src/projectormontecarlo.md
+++ b/docs/src/projectormontecarlo.md
@@ -1,0 +1,45 @@
+# Projector Monte Carlo / FCIQMC
+
+The purpose of Projector Monte Carlo is to stochastically sample the ground state, i.e. the 
+eigenvector corresponding to the lowest eigenvalue of a quantum Hamiltonian, or more generally, 
+a very large matrix. Rimu implements a flavor of Projector Monte Carlo called 
+Full Configuration Interaction Quantum Monte Carlo (FCIQMC).
+
+## `ProjectorMonteCarloProblem`
+
+To run a projector Monte Carlo simulation you set up a problem with `ProjectorMonteCarloProblem`
+and solve it with `solve`. Alternatively you can initialize a `PMCSimulation` struct, `step!` 
+through time steps, and `solve!` it to completion. 
+
+```@docs; canonical=false
+ProjectorMonteCarloProblem
+init
+solve
+solve!
+step!
+```
+
+After `solve` or `solve!` have been called the returned `PMCSimulation` contains the results of 
+the projector Monte Carlo calculation.
+
+### `PNCSimulation` and report as a `DataFrame`
+
+```@docs; canonical=false
+Rimu.PMCSimulation
+```
+
+The `DataFrame` returned from `DataFrame(::PNCSimulation)` contains the time series data from 
+the projector Monte Carlo simulation that is of primary interest for analysis. Depending on the 
+`reporting_strategy` and other options passed as keyword arguments to 
+`ProjectorMonteCarloProblem` it can have different numbers of rows and columns. The rows 
+correspond to the reported time steps (Monte Carlo steps). The is at least one column with the name `:step`. Further columns are usually present with additional data reported from the simulation.
+
+For the default option `algorithm = FCIQMC(; shift_strategy, time_step_strategy)` with a single
+replica (`n_replicas = 1`) and single spectral state, the fields `:shift`, `:norm`, `:len` will 
+be present as well as others depending on the `style` argument and the `post_step_strategy`.
+
+If multiple replicas or spectral states are requested, then the relevant field names in the 
+`DataFrame` will have a suffix identifying the respective replica simulation. 
+
+Many tools for analysing the time series data obtained from a 
+[`ProjectorMonteCarloProblem`](@ref) are contained in the [Module `StatsTools`](@ref).

--- a/docs/src/projectormontecarlo.md
+++ b/docs/src/projectormontecarlo.md
@@ -22,7 +22,7 @@ step!
 After `solve` or `solve!` have been called the returned `PMCSimulation` contains the results of 
 the projector Monte Carlo calculation.
 
-### `PNCSimulation` and report as a `DataFrame`
+### `PMCSimulation` and report as a `DataFrame`
 
 ```@docs; canonical=false
 Rimu.PMCSimulation
@@ -32,14 +32,14 @@ The `DataFrame` returned from `DataFrame(::PNCSimulation)` contains the time ser
 the projector Monte Carlo simulation that is of primary interest for analysis. Depending on the 
 `reporting_strategy` and other options passed as keyword arguments to 
 `ProjectorMonteCarloProblem` it can have different numbers of rows and columns. The rows 
-correspond to the reported time steps (Monte Carlo steps). The is at least one column with the name `:step`. Further columns are usually present with additional data reported from the simulation.
+correspond to the reported time steps (Monte Carlo steps). There is at least one column with the name `:step`. Further columns are usually present with additional data reported from the simulation.
 
 For the default option `algorithm = FCIQMC(; shift_strategy, time_step_strategy)` with a single
 replica (`n_replicas = 1`) and single spectral state, the fields `:shift`, `:norm`, `:len` will 
 be present as well as others depending on the `style` argument and the `post_step_strategy`.
 
 If multiple replicas or spectral states are requested, then the relevant field names in the 
-`DataFrame` will have a suffix identifying the respective replica simulation. 
+`DataFrame` will have a suffix identifying the respective replica simulation, e.g. the `shift`s will be reported as `shift_1`, `shift_2`, ... 
 
 Many tools for analysing the time series data obtained from a 
 [`ProjectorMonteCarloProblem`](@ref) are contained in the [Module `StatsTools`](@ref).

--- a/scripts/BHM-example-mpi.jl
+++ b/scripts/BHM-example-mpi.jl
@@ -57,7 +57,7 @@ problem = ProjectorMonteCarloProblem(H;
     start_at=initial_vector,
     reporting_strategy,
     post_step_strategy=ProjectedEnergy(H, initial_vector),
-    targetwalkers=10_000,
+    target_walkers=10_000,
     time_step=1e-4,
     last_step=10_000
 );

--- a/scripts/BHM-example.jl
+++ b/scripts/BHM-example.jl
@@ -29,7 +29,7 @@ H = HubbardReal1D(initial_address; u = 6.0, t = 1.0)
 # use in this Monte Carlo run, which is equivalent to the average one-norm of the
 # coefficient vector. Higher values will result in better statistics, but require more
 # memory and computing power.
-targetwalkers = 1_000;
+target_walkers = 1_000;
 
 # FCIQMC takes a certain number of steps to equllibrate, after which the observables will
 # fluctuate around a mean value. In this example, we will devote 1000 steps to equilibration
@@ -76,7 +76,7 @@ problem = ProjectorMonteCarloProblem(
     start_at = initial_vector,
     last_step,
     time_step,
-    targetwalkers,
+    target_walkers,
     post_step_strategy
 );
 
@@ -91,8 +91,8 @@ df = DataFrame(simulation);
 
 # We can plot the norm of the coefficient vector as a function of the number of steps.
 hline(
-    [targetwalkers];
-    label="targetwalkers", xlabel="step", ylabel="norm",
+    [target_walkers];
+    label="target_walkers", xlabel="step", ylabel="norm",
     color=2, linestyle=:dash, margin = 1Plots.cm
 )
 plot!(df.step, df.norm, label="norm", color=1)
@@ -146,7 +146,7 @@ exact_energy = solve(edp).values[1]
 
 println(
     """
-    Energy from $steps_measure steps with $targetwalkers walkers:
+    Energy from $steps_measure steps with $target_walkers walkers:
     Shift: $(se.mean) ± $(se.err)
     Projected Energy: $(v.val) ± ($(v.val_l), $(v.val_u))
     Exact Energy: $exact_energy

--- a/scripts/BHM-example.jl
+++ b/scripts/BHM-example.jl
@@ -92,10 +92,10 @@ df = DataFrame(simulation);
 # We can plot the norm of the coefficient vector as a function of the number of steps.
 hline(
     [targetwalkers];
-    label="targetwalkers", xlabel="steps", ylabel="norm",
+    label="targetwalkers", xlabel="step", ylabel="norm",
     color=2, linestyle=:dash, margin = 1Plots.cm
 )
-plot!(df.steps, df.norm, label="norm", color=1)
+plot!(df.step, df.norm, label="norm", color=1)
 
 # After an initial equilibriation period, the norm fluctuates around the target number of
 # walkers.
@@ -120,11 +120,11 @@ pe = projected_energy(df; skip=steps_equilibrate)
 v = val_and_errs(pe; p=0.95)
 
 # Let's visualise these estimators together with the time series of the shift.
-plot(df.steps, df.shift, ylabel="energy", xlabel="steps", label="shift", margin = 1Plots.cm)
+plot(df.step, df.shift, ylabel="energy", xlabel="step", label="shift", margin = 1Plots.cm)
 
-plot!(x->se.mean, df.steps[steps_equilibrate+1:end], ribbon=se.err, label="shift mean")
+plot!(x->se.mean, df.step[steps_equilibrate+1:end], ribbon=se.err, label="shift mean")
 plot!(
-    x -> v.val, df.steps[steps_equilibrate+1:end], ribbon=(v.val_l,v.val_u),
+    x -> v.val, df.step[steps_equilibrate+1:end], ribbon=(v.val_l,v.val_u),
     label="projected energy",
 )
 lens!([steps_equilibrate, last_step], [-5.1, -2.9]; inset=(1, bbox(0.2, 0.25, 0.6, 0.4)))

--- a/scripts/G2-example.jl
+++ b/scripts/G2-example.jl
@@ -53,7 +53,7 @@ replica_strategy = AllOverlaps(num_replicas; operator = G2list)
 # Other FCIQMC parameters and strategies can be set in the same way as before.
 steps_equilibrate = 1_000
 steps_measure = 5_000
-targetwalkers = 100;
+target_walkers = 100;
 time_step = 0.001
 
 Random.seed!(17); #hide
@@ -62,9 +62,9 @@ Random.seed!(17); #hide
 # style, a vector with the appropriate style is created automatically.
 df, state = lomc!(
     H; style=IsDynamicSemistochastic(),
-    time_step,
+    dτ = time_step,
     laststep = steps_equilibrate + steps_measure,
-    targetwalkers,
+    targetwalkers = target_walkers,
     replica_strategy,
 );
 

--- a/scripts/G2-example.jl
+++ b/scripts/G2-example.jl
@@ -54,7 +54,7 @@ replica_strategy = AllOverlaps(num_replicas; operator = G2list)
 steps_equilibrate = 1_000
 steps_measure = 5_000
 targetwalkers = 100;
-dτ = 0.001
+time_step = 0.001
 
 Random.seed!(17); #hide
 
@@ -62,7 +62,7 @@ Random.seed!(17); #hide
 # style, a vector with the appropriate style is created automatically.
 df, state = lomc!(
     H; style=IsDynamicSemistochastic(),
-    dτ,
+    time_step,
     laststep = steps_equilibrate + steps_measure,
     targetwalkers,
     replica_strategy,

--- a/scripts/G2-example.jl
+++ b/scripts/G2-example.jl
@@ -60,13 +60,15 @@ Random.seed!(17); #hide
 
 # Now, we run FCIQMC. Note that passing an initial vector is optional - if we only pass the
 # style, a vector with the appropriate style is created automatically.
-df, state = lomc!(
-    H; style=IsDynamicSemistochastic(),
-    dτ = time_step,
-    laststep = steps_equilibrate + steps_measure,
-    targetwalkers = target_walkers,
+problem = ProjectorMonteCarloProblem(H;
+    style=IsDynamicSemistochastic(),
+    time_step,
+    last_step = steps_equilibrate + steps_measure,
+    target_walkers,
     replica_strategy,
-);
+)
+result = solve(problem)
+df = DataFrame(result);
 
 # The output `DataFrame` has FCIQMC statistics for each replica (e.g. shift, norm),
 println(filter(startswith("shift_"), names(df)))

--- a/src/DictVectors/initiatordvec.jl
+++ b/src/DictVectors/initiatordvec.jl
@@ -1,7 +1,8 @@
 """
     InitiatorDVec{K,V} <: AbstractDVec{K,V}
 
-Dictionary-based vector-like data structure for use with [`lomc!`](@ref Main.lomc!) and
+Dictionary-based vector-like data structure for use with
+[`ProjectorMonteCarloProblem`](@ref Main.ProjectorMonteCarloProblem) and
 [`KrylovKit.jl`](https://github.com/Jutho/KrylovKit.jl). See [`AbstractDVec`](@ref).
 Functionally identical to [`DVec`](@ref), but contains [`InitiatorValue`](@ref)s internally
 in order to facilitate initiator methods. Initiator methods for controlling the Monte Carlo

--- a/src/DictVectors/projectors.jl
+++ b/src/DictVectors/projectors.jl
@@ -10,7 +10,7 @@ products. Implemented subtypes:
 - [`Norm2Projector`](@ref)
 - [`Norm1ProjectorPPop`](@ref)
 
-See also [`PostStepStrategy`](@ref Main.PostStepStrategy) for use of projectors in [`lomc!`](@ref Main.lomc!).
+See also [`PostStepStrategy`](@ref Main.PostStepStrategy) for use of projectors in [`ProjectorMonteCarloProblem`](@ref Main.ProjectorMonteCarloProblem).
 
 ## Interface
 
@@ -33,7 +33,7 @@ dot(UniformProjector(), LO, v) == sum(LO*v)
 ```
 
 See also [`PostStepStrategy`](@ref Main.PostStepStrategy), and [`AbstractProjector`](@ref) for use
-of projectors in [`lomc!`](@ref Main.lomc!).
+of projectors in [`ProjectorMonteCarloProblem`](@ref Main.ProjectorMonteCarloProblem).
 """
 struct UniformProjector <: AbstractProjector end
 
@@ -60,7 +60,7 @@ dot(NormProjector(),x)
 `NormProjector()` thus represents the vector `sign.(x)`.
 
 See also [`PostStepStrategy`](@ref Main.PostStepStrategy), and [`AbstractProjector`](@ref) for use
-of projectors in [`lomc!`](@ref Main.lomc!).
+of projectors in [`ProjectorMonteCarloProblem`](@ref Main.ProjectorMonteCarloProblem).
 """
 struct NormProjector <: AbstractProjector end
 
@@ -75,7 +75,7 @@ dot(NormProjector(),x)
 ```
 
 See also [`PostStepStrategy`](@ref Main.PostStepStrategy), and [`AbstractProjector`](@ref) for use
-of projectors in [`lomc!`](@ref Main.lomc!).
+of projectors in [`ProjectorMonteCarloProblem`](@ref Main.ProjectorMonteCarloProblem).
 """
 struct Norm2Projector <: AbstractProjector end
 
@@ -92,7 +92,7 @@ dot(Norm1ProjectorPPop(),x)
 ```
 
 See also [`PostStepStrategy`](@ref Main.PostStepStrategy), and [`AbstractProjector`](@ref) for use
-of projectors in [`lomc!`](@ref Main.lomc!).
+of projectors in [`ProjectorMonteCarloProblem`](@ref Main.ProjectorMonteCarloProblem).
 """
 struct Norm1ProjectorPPop <: AbstractProjector end
 
@@ -121,7 +121,7 @@ dot(PopsProjector(),x)
 ```
 
 See also [`PostStepStrategy`](@ref Main.PostStepStrategy), and [`AbstractProjector`](@ref) for use
-of projectors in [`lomc!`](@ref Main.lomc!).
+of projectors in [`ProjectorMonteCarloProblem`](@ref Main.ProjectorMonteCarloProblem).
 """
 struct PopsProjector <: AbstractProjector end
 

--- a/src/Hamiltonians/MatrixHamiltonian.jl
+++ b/src/Hamiltonians/MatrixHamiltonian.jl
@@ -4,7 +4,7 @@
         starting_address::Int = starting_address(mat)
     ) <: AbstractHamiltonian{T}
 Wrap an abstract matrix `mat` as an [`AbstractHamiltonian`](@ref) object.
-Works with stochastic methods of [`lomc!()`](@ref) and [`DVec`](@ref).
+Works with stochastic methods of [`ProjectorMonteCarloProblem()`](@ref) and [`DVec`](@ref).
 Optionally, a valid index can be provided as the [`starting_address`](@ref).
 
 Specialised methods are implemented for sparse matrices of type `AbstractSparseMatrixCSC`.

--- a/src/Hamiltonians/correlation_functions.jl
+++ b/src/Hamiltonians/correlation_functions.jl
@@ -392,7 +392,7 @@ Assumes a one-dimensional lattice with ``M`` sites and periodic boundary conditi
 
 # Usage
 Superfluid correlations can be extracted from a Monte Carlo calculation by wrapping `SuperfluidCorrelator` with
-[`AllOverlaps`](@ref) and passing into [`lomc!`](@ref) with the `replica` keyword argument. For an example with a
+[`AllOverlaps`](@ref) and passing into [`ProjectorMonteCarloProblem`](@ref) with the `replica` keyword argument. For an example with a
 similar use of [`G2RealCorrelator`](@ref) see
 [G2 Correlator Example](https://joachimbrand.github.io/Rimu.jl/previews/PR227/generated/G2-example.html).
 

--- a/src/Interfaces/Interfaces.jl
+++ b/src/Interfaces/Interfaces.jl
@@ -7,7 +7,9 @@ This module contains interfaces that can be used to extend and modify the algori
 Follow the links for the definitions of the interfaces!
 * [`AbstractHamiltonian`](@ref) for defining [`Hamiltonians`](@ref Main.Hamiltonians)
 * [`AbstractDVec`](@ref) for defining data structures for `Rimu` as in [`DictVectors`](@ref Main.DictVectors)
-* [`StochasticStyle`](@ref) for controlling the stochastic algorithms used by [`lomc!`](@ref Main.lomc!) as implemented in [`StochasticStyles`](@ref Main.StochasticStyles)
+* [`StochasticStyle`](@ref) for controlling the stochastic algorithms used by
+  [`ProjectorMonteCarloProblem`](@ref Main.ProjectorMonteCarloProblem) as implemented in
+  [`StochasticStyles`](@ref Main.StochasticStyles)
 
 # Additional exports
 

--- a/src/Interfaces/dictvectors.jl
+++ b/src/Interfaces/dictvectors.jl
@@ -5,7 +5,8 @@ Abstract data type for vector-like data structures with sparse storage. While co
 `AbstractDVec`s represent elements of a vector space over a scalar type `V`, they are
 indexed by an arbitrary type `K` (could be non-integers) similar to dictionaries. They
 support the interface from [VectorInterface.jl](https://github.com/Jutho/VectorInterface.jl)
-and are designed to work well for quantum Monte Carlo with [`lomc!`](@ref Main.lomc!) and
+and are designed to work well for quantum Monte Carlo with
+[`ProjectorMonteCarloProblem`](@ref Main.ProjectorMonteCarloProblem) and
 for matrix-free linear algebra with [KrylovKit](https://github.com/Jutho/KrylovKit.jl).
 
 Concrete implementations are available as [`PDVec`](@ref Main.DictVectors.PDVec),

--- a/src/Interfaces/hamiltonians.jl
+++ b/src/Interfaces/hamiltonians.jl
@@ -5,7 +5,8 @@
     AbstractHamiltonian{T}
 
 Supertype that provides an interface for linear operators over a linear space with scalar
-type `T` that are suitable for FCIQMC (with [`lomc!`](@ref Main.lomc!)). Indexing is done
+type `T` that are suitable for FCIQMC (with
+[`ProjectorMonteCarloProblem`](@ref Main.ProjectorMonteCarloProblem)). Indexing is done
 with addresses (typically not integers) from an address space that may be large (and will
 not need to be completely generated).
 

--- a/src/Interfaces/stochasticstyles.jl
+++ b/src/Interfaces/stochasticstyles.jl
@@ -7,7 +7,8 @@ generalised vector `v` that determines how simulations are to proceed.
 # Usage
 
 Concrete `StochasticStyle`s can be used for the `style` keyword argument of
-[`lomc!`](@ref Main.lomc!), [`DVec`](@ref Main.DictVectors.DVec) and
+[`ProjectorMonteCarloProblem`](@ref Main.ProjectorMonteCarloProblem),
+[`DVec`](@ref Main.DictVectors.DVec) and
 [`PDVec`](@ref Main.DictVectors.PDVec). The following styles are available:
 
 * [`IsStochasticInteger`](@ref Main.StochasticStyles.IsStochasticInteger)
@@ -22,7 +23,7 @@ Concrete `StochasticStyle`s can be used for the `style` keyword argument of
 When defining a new `StochasticStyle`, subtype it as `MyStyle<:StochasticStyle{T}` where `T`
 is the concrete value type the style is designed to work with.
 
-For it to work with [`lomc!`](@ref Main.lomc!), a `StochasticStyle` must define the
+For it to work with [`ProjectorMonteCarloProblem`](@ref Main.ProjectorMonteCarloProblem), a `StochasticStyle` must define the
 following:
 
 * [`apply_column!(::StochasticStyle, w, H, address, value)`](@ref)
@@ -123,7 +124,8 @@ end
     step_stats(::CompressionStrategy)
 
 Return a tuple of stat names (`Symbol` or `String`) and a tuple of zeros of the same
-length. These will be reported as columns in the `DataFrame` returned by [`lomc!`](@ref Main.lomc!).
+length. These will be reported as columns in the `DataFrame` returned by
+[`ProjectorMonteCarloProblem`](@ref Main.ProjectorMonteCarloProblem).
 """
 step_stats(v) = step_stats(StochasticStyle(v))
 

--- a/src/StatsTools/growth_witness.jl
+++ b/src/StatsTools/growth_witness.jl
@@ -32,7 +32,12 @@ function growth_witness(shift::AbstractArray, norm::AbstractArray, dt, b; kwargs
     return smoothen(g_raw, b)
 end
 """
-    growth_witness(df::DataFrame, [b]; shift=:shift, norm=:norm, dτ=df.dτ[end], skip=0)
+    growth_witness(df::DataFrame, [b];
+        shift=:shift,
+        norm=:norm,
+        time_step=determine_constant_time_step(df),
+        skip=0
+    )
     growth_witness(sim::PMCSimulation, [b]; kwargs...)
 
 Calculate the growth witness directly from the result (`DataFrame` or
@@ -43,14 +48,14 @@ Calculate the growth witness directly from the result (`DataFrame` or
 """
 function growth_witness(
     sim, b=Val(0);
-    shift=:shift, norm=:norm, dτ=nothing, kwargs...
+    shift=:shift, norm=:norm, time_step=nothing, kwargs...
 )
     df = DataFrame(sim)
-    dτ = determine_constant_time_step(df)
+    time_step = determine_constant_time_step(df)
 
     shift_vec = getproperty(df, Symbol(shift))
     norm_vec = getproperty(df, Symbol(norm))
-    return growth_witness(shift_vec, norm_vec, dτ, b; kwargs...)
+    return growth_witness(shift_vec, norm_vec, time_step, b; kwargs...)
 end
 
 """

--- a/src/StochasticStyles/StochasticStyles.jl
+++ b/src/StochasticStyles/StochasticStyles.jl
@@ -1,6 +1,7 @@
 """
 This module provides concrete implementations of [`StochasticStyle`](@ref)s, which
-specify the algorithm used by [`lomc!`](@ref Main.lomc!) when
+specify the algorithm used by
+[`ProjectorMonteCarloProblem`](@ref Main.ProjectorMonteCarloProblem) when
 performing stochastic matrix-vector multiplication.
 
 # Implemented stochastic styles:

--- a/src/fciqmc.jl
+++ b/src/fciqmc.jl
@@ -61,14 +61,14 @@ function _determine_initial_shift(hamiltonian, starting_vectors)
 end
 
 """
-    FirstOrderTransitionOperator(hamiltonian, shift, dτ) <: AbstractHamiltonian
+    FirstOrderTransitionOperator(hamiltonian, shift, time_step) <: AbstractHamiltonian
     FirstOrderTransitionOperator(sp::DefaultShiftParameters, hamiltonian)
 
 First order transition operator
 ```math
 𝐓 = 1 + dτ(S - 𝐇)
 ```
-where ``𝐇`` is the `hamiltonian` and ``S`` is the `shift`.
+where ``𝐇`` is the `hamiltonian`, ``dτ`` the `time_step` and ``S`` is the `shift`.
 
 ``𝐓`` represents the first order expansion of the exponential evolution operator
 of the imaginary-time Schrödinger equation (Euler step) and repeated application
@@ -78,11 +78,11 @@ transition operator used in [`FCIQMC`](@ref).
 struct FirstOrderTransitionOperator{T,S,H} <: AbstractHamiltonian{T}
     hamiltonian::H
     shift::S
-    dτ::Float64
+    time_step::Float64
 
-    function FirstOrderTransitionOperator(hamiltonian::H, shift::S, dτ) where {H,S}
+    function FirstOrderTransitionOperator(hamiltonian::H, shift::S, time_step) where {H,S}
         T = eltype(hamiltonian)
-        return new{T,S,H}(hamiltonian, shift, Float64(dτ))
+        return new{T,S,H}(hamiltonian, shift, Float64(time_step))
     end
 end
 
@@ -92,23 +92,23 @@ end
 
 function Hamiltonians.diagonal_element(t::FirstOrderTransitionOperator, add)
     diag = diagonal_element(t.hamiltonian, add)
-    return 1 - t.dτ * (diag - t.shift)
+    return 1 - t.time_step * (diag - t.shift)
 end
 
 struct FirstOrderOffdiagonals{
     A,V,O<:AbstractVector{Tuple{A,V}}
 } <: AbstractVector{Tuple{A,V}}
-    dτ::Float64
+    time_step::Float64
     offdiagonals::O
 end
 function Hamiltonians.offdiagonals(t::FirstOrderTransitionOperator, add)
-    return FirstOrderOffdiagonals(t.dτ, offdiagonals(t.hamiltonian, add))
+    return FirstOrderOffdiagonals(t.time_step, offdiagonals(t.hamiltonian, add))
 end
 Base.size(o::FirstOrderOffdiagonals) = size(o.offdiagonals)
 
 function Base.getindex(o::FirstOrderOffdiagonals, i)
     add, val = o.offdiagonals[i]
-    return add, -val * o.dτ
+    return add, -val * o.time_step
 end
 
 """
@@ -159,7 +159,7 @@ function advance!(algorithm::FCIQMC, report, state::ReplicaState, s_state::Singl
         post_step_stats = post_step_action(state.post_step_strategy, s_state, step)
 
         # Reporting
-        report!(reporting_strategy, step, report, (; dτ=time_step, len), id)
+        report!(reporting_strategy, step, report, (; time_step, len), id)
         report!(reporting_strategy, step, report, shift_stats, id) # shift, norm, shift_mode
 
         report!(reporting_strategy, step, report, step_stat_names, step_stat_values, id)

--- a/src/fciqmc.jl
+++ b/src/fciqmc.jl
@@ -145,7 +145,7 @@ function advance!(algorithm::FCIQMC, report, state::ReplicaState, s_state::Singl
     len = length(v)
 
     # Updates
-    time_step = update_dτ(time_step_strategy, time_step, tnorm)
+    time_step = update_time_step(time_step_strategy, time_step, tnorm)
 
     shift_stats, proceed = update_shift_parameters!(
         shift_strategy, shift_parameters, tnorm, v, pv, step, report

--- a/src/fciqmc.jl
+++ b/src/fciqmc.jl
@@ -159,7 +159,7 @@ function advance!(algorithm::FCIQMC, report, state::ReplicaState, s_state::Singl
         post_step_stats = post_step_action(state.post_step_strategy, s_state, step)
 
         # Reporting
-        if !(reporting_strategy isa ConstantTimeStep) # report time_step unless it is constant
+        if !(time_step_strategy isa ConstantTimeStep) # report time_step unless it is constant
             report!(reporting_strategy, step, report, (; time_step), id)
         end
 

--- a/src/fciqmc.jl
+++ b/src/fciqmc.jl
@@ -159,7 +159,11 @@ function advance!(algorithm::FCIQMC, report, state::ReplicaState, s_state::Singl
         post_step_stats = post_step_action(state.post_step_strategy, s_state, step)
 
         # Reporting
-        report!(reporting_strategy, step, report, (; time_step, len), id)
+        if !(reporting_strategy isa ConstantTimeStep) # report time_step unless it is constant
+            report!(reporting_strategy, step, report, (; time_step), id)
+        end
+
+        report!(reporting_strategy, step, report, (; len), id)
         report!(reporting_strategy, step, report, shift_stats, id) # shift, norm, shift_mode
 
         report!(reporting_strategy, step, report, step_stat_names, step_stat_values, id)

--- a/src/lomc.jl
+++ b/src/lomc.jl
@@ -76,9 +76,9 @@ julia> metadata(df2, "hamiltonian") # some metadata is automatically added
 
 * `τ_strat::TimeStepStrategy = ConstantTimeStep()` - adjust time step or not, see
   [`TimeStepStrategy`](@ref)
-* `s_strat::ShiftStrategy = DoubleLogUpdate(; targetwalkers, ζ = 0.08, ξ = ζ^2/4)` -
+* `s_strat::ShiftStrategy = DoubleLogUpdate(; target_walkers=targetwalkers, ζ = 0.08, ξ = ζ^2/4)` -
   how to update the `shift`, see [`ShiftStrategy`](@ref).
-* `maxlength = 2 * s_strat.targetwalkers + 100` - upper limit on the length of `v`; when
+* `maxlength = 2 * s_strat.target_walkers + 100` - upper limit on the length of `v`; when
   reached, `lomc!` will abort
 * `wm` - working memory for re-use in subsequent calculations; is mutated.
 * `df = DataFrame()` - when called with `AbstractHamiltonian` argument, a `DataFrame` can
@@ -100,7 +100,7 @@ function lomc!(
     reporting_strategy = ReportDFAndInfo(),
     r_strat = reporting_strategy,
     targetwalkers = 1000,
-    s_strat = DoubleLogUpdate(; targetwalkers),
+    s_strat = DoubleLogUpdate(; target_walkers=targetwalkers),
     τ_strat = ConstantTimeStep(),
     replica_strategy = NoStats(),
     replica = replica_strategy,
@@ -121,8 +121,8 @@ function lomc!(
     if !isnothing(wm)
         @warn "The `wm` argument has been removed and will be ignored."
     end
-    if hasfield(typeof(s_strat), :targetwalkers)
-        targetwalkers = s_strat.targetwalkers
+    if hasfield(typeof(s_strat), :target_walkers)
+        targetwalkers = s_strat.target_walkers
     end
     if isnothing(maxlength)
         maxlength = round(Int, 2 * abs(targetwalkers) + 100)

--- a/src/lomc.jl
+++ b/src/lomc.jl
@@ -60,10 +60,10 @@ julia> df1, state = lomc!(hamiltonian; targetwalkers=500, laststep=100);
 julia> df2, _ = lomc!(state, df1; laststep=200, metadata=(;info="cont")); # Continuation run
 
 julia> size(df1)
-(100, 10)
+(100, 9)
 
 julia> size(df2)
-(200, 10)
+(200, 9)
 
 julia> using DataFrames; metadata(df2, "info") # retrieve custom metadata
 "cont"

--- a/src/pmc_simulation.jl
+++ b/src/pmc_simulation.jl
@@ -253,7 +253,7 @@ function CommonSolve.step!(sm::PMCSimulation)
 
     # report step number
     if step[] % reporting_interval(reporting_strategy) == 0
-        report!(reporting_strategy, step[], report, :steps, step[])
+        report!(reporting_strategy, step[], report, :step, step[])
     end
 
     proceed = true

--- a/src/projector_monte_carlo_problem.jl
+++ b/src/projector_monte_carlo_problem.jl
@@ -78,7 +78,7 @@ julia> size(DataFrame(simulation))
 - `ξ = ζ^2/4`: Forcing parameter for the shift update.
 - `shift_strategy = DoubleLogUpdate(; target_walkers, ζ, ξ)`: How to update the `shift`,
     see [`ShiftStrategy`](@ref).
-- `time_step_strategy = ConstantTimeStep()``: Adjust time step or not, see
+- `time_step_strategy = ConstantTimeStep()`: Adjust time step or not, see
     `TimeStepStrategy`.
 - `algorithm = FCIQMC(; shift_strategy, time_step_strategy)`: The algorithm to use.
     Currenlty only [`FCIQMC`](@ref) is implemented.

--- a/src/projector_monte_carlo_problem.jl
+++ b/src/projector_monte_carlo_problem.jl
@@ -66,7 +66,7 @@ julia> simulation.success[]
 true
 
 julia> size(DataFrame(simulation))
-(100, 10)
+(100, 9)
 ```
 
 # Further keyword arguments:

--- a/src/projector_monte_carlo_problem.jl
+++ b/src/projector_monte_carlo_problem.jl
@@ -151,6 +151,7 @@ function ProjectorMonteCarloProblem(
     walltime = Inf,
     simulation_plan = SimulationPlan(starting_step, last_step, walltime),
     replica_strategy = NoStats(n_replicas),
+    targetwalkers = nothing, # deprecated
     target_walkers = 1_000,
     ζ = 0.08,
     ξ = ζ^2/4,
@@ -166,6 +167,11 @@ function ProjectorMonteCarloProblem(
     display_name = "PMCSimulation",
     random_seed = true
 )
+    if !isnothing(targetwalkers)
+        @warn "The keyword argument `targetwalkers` is deprecated. Use `target_walkers` instead."
+        target_walkers = targetwalkers
+    end
+
     n_replicas = num_replicas(replica_strategy) # replica_strategy may override n_replicas
 
     if random_seed == true

--- a/src/projector_monte_carlo_problem.jl
+++ b/src/projector_monte_carlo_problem.jl
@@ -33,7 +33,7 @@ the [`FCIQMC`](@ref) algorithm.
 # Common keyword arguments and defaults:
 - `time_step = 0.01`: Initial time step size.
 - `last_step = 100`: Controls the number of steps.
-- `targetwalkers = 1_000`: Target for the 1-norm of the coefficient vector.
+- `target_walkers = 1_000`: Target for the 1-norm of the coefficient vector.
 - `start_at = starting_address(hamiltonian)`: Define the initial state vector(s).
     An ``r × s`` matrix of state vectors can be passed where ``r`` is the
     number of replicas and ``s`` the number of spectral states. See also
@@ -58,7 +58,7 @@ the [`FCIQMC`](@ref) algorithm.
 ```jldoctest
 julia> hamiltonian = HubbardReal1D(BoseFS(1,2,3));
 
-julia> problem = ProjectorMonteCarloProblem(hamiltonian; targetwalkers = 500, last_step = 100);
+julia> problem = ProjectorMonteCarloProblem(hamiltonian; target_walkers = 500, last_step = 100);
 
 julia> simulation = solve(problem);
 
@@ -76,7 +76,7 @@ julia> size(DataFrame(simulation))
     duration of the simulation. Takes precedence over `last_step` and `walltime`.
 - `ζ = 0.08`: Damping parameter for the shift update.
 - `ξ = ζ^2/4`: Forcing parameter for the shift update.
-- `shift_strategy = DoubleLogUpdate(; targetwalkers, ζ, ξ)`: How to update the `shift`,
+- `shift_strategy = DoubleLogUpdate(; target_walkers, ζ, ξ)`: How to update the `shift`,
     see [`ShiftStrategy`](@ref).
 - `time_step_strategy = ConstantTimeStep()``: Adjust time step or not, see
     `TimeStepStrategy`.
@@ -86,7 +86,7 @@ julia> size(DataFrame(simulation))
     Hamiltonian and the starting vectors.
 - `initial_shift_parameters`: Initial shift parameters or collection of initial shift
     parameters. Overrides `shift` if provided.
-- `maxlength = 2 * targetwalkers + 100`: Maximum length of the vectors.
+- `maxlength = 2 * target_walkers + 100`: Maximum length of the vectors.
 - `display_name = "PMCSimulation"`: Name displayed in progress bar (via `ProgressLogging`).
 - `metadata`: User-supplied metadata to be added to the report. Must be an iterable of
   pairs or a `NamedTuple`, e.g. `metadata = ("key1" => "value1", "key2" => "value2")`.
@@ -151,10 +151,10 @@ function ProjectorMonteCarloProblem(
     walltime = Inf,
     simulation_plan = SimulationPlan(starting_step, last_step, walltime),
     replica_strategy = NoStats(n_replicas),
-    targetwalkers = 1_000,
+    target_walkers = 1_000,
     ζ = 0.08,
     ξ = ζ^2/4,
-    shift_strategy = DoubleLogUpdate(; targetwalkers, ζ, ξ),
+    shift_strategy = DoubleLogUpdate(; target_walkers, ζ, ξ),
     time_step_strategy=ConstantTimeStep(),
     algorithm=FCIQMC(; shift_strategy, time_step_strategy),
     initial_shift_parameters=nothing,
@@ -182,7 +182,7 @@ function ProjectorMonteCarloProblem(
 
     if isnothing(threading)
         s_strat = algorithm.shift_strategy
-        if !hasfield(typeof(s_strat), :targetwalkers) || abs(s_strat.targetwalkers) > 1_000
+        if !hasfield(typeof(s_strat), :target_walkers) || abs(s_strat.target_walkers) > 1_000
             threading = Threads.nthreads() > 1
         else
             threading = false
@@ -198,7 +198,7 @@ function ProjectorMonteCarloProblem(
 
     shift_strategy = algorithm.shift_strategy
     if isnothing(maxlength)
-        maxlength = round(Int, 2 * abs(shift_strategy.targetwalkers) + 100)
+        maxlength = round(Int, 2 * abs(shift_strategy.target_walkers) + 100)
         # padding for small walkernumbers
     end
 

--- a/src/qmc_states.jl
+++ b/src/qmc_states.jl
@@ -72,8 +72,8 @@ end
 Returns an estimate of the expected number of walkers as an integer.
 """
 function _n_walkers(v, shift_strategy)
-    n = if hasfield(typeof(shift_strategy), :targetwalkers)
-        shift_strategy.targetwalkers
+    n = if hasfield(typeof(shift_strategy), :target_walkers)
+        shift_strategy.target_walkers
     else # e.g. for LogUpdate()
         walkernumber(v)
     end

--- a/src/strategies_and_params/poststepstrategy.jl
+++ b/src/strategies_and_params/poststepstrategy.jl
@@ -12,8 +12,8 @@ state after an FCIQMC step is finished and report the results.
 * [`WalkerLoneliness`](@ref)
 * [`Timer`](@ref)
 
-Note: A tuple of multiple strategies can be passed to [`lomc!`](@ref). In that case, all
-reported column names must be distinct.
+Note: A tuple of multiple strategies can be passed to [`ProjectorMonteCarloProblem`](@ref).
+In that case, all reported column names must be distinct.
 
 # Interface:
 

--- a/src/strategies_and_params/replicastrategy.jl
+++ b/src/strategies_and_params/replicastrategy.jl
@@ -1,9 +1,9 @@
 """
     ReplicaStrategy{N}
 
-Supertype for strategies that can be passed to [`lomc!`](@ref) and control how many
-replicas are used, and what information is computed and returned. The number of replicas
-is `N`.
+Supertype for strategies that can be passed to [`ProjectorMonteCarloProblem`](@ref) and
+control how many replicas are used, and what information is computed and returned. The
+number of replicas is `N`.
 
 ## Concrete implementations
 
@@ -17,7 +17,7 @@ function:
 
 * [`Rimu.replica_stats`](@ref) - return a
   tuple of `String`s or `Symbols` of names for replica statistics and a tuple of the values.
-  These will be reported to the `DataFrame` returned by [`lomc!`](@ref).
+  These will be reported to the `DataFrame` returned by [`ProjectorMonteCarloProblem`](@ref).
 """
 abstract type ReplicaStrategy{N} end
 
@@ -34,8 +34,9 @@ num_replicas(::ReplicaStrategy{N}) where {N} = N
 Return the names and values of statistics related to `N` replica states consistent with the
 [`ReplicaStrategy`](@ref) `RS`. `names`
 should be a tuple of `Symbol`s or `String`s and `values` should be a tuple of the same
-length. This function will be called every [`reporting_interval`](@ref) steps from [`lomc!`](@ref),
-or once per time step if `reporting_interval` is not defined.
+length. This function will be called every [`reporting_interval`](@ref) steps from
+[`ProjectorMonteCarloProblem`](@ref), or once per time step if `reporting_interval` is not
+defined.
 
 Part of the [`ReplicaStrategy`](@ref) interface. See also [`SingleState`](@ref).
 """
@@ -47,7 +48,7 @@ replica_stats
 The default [`ReplicaStrategy`](@ref). `N` replicas are run, but no statistics are
 collected.
 
-See also [`lomc!`](@ref).
+See also [`ProjectorMonteCarloProblem`](@ref).
 """
 struct NoStats{N} <: ReplicaStrategy{N} end
 NoStats(N=1) = NoStats{N}()
@@ -66,12 +67,12 @@ of operators, the overlaps are computed for all operators.
 Column names in the report are of the form `c{i}_dot_c{j}` for vector-vector overlaps, and
 `c{i}_Op{k}_c{j}` for operator overlaps.
 
-See [`lomc!`](@ref), [`ReplicaStrategy`](@ref) and [`AbstractHamiltonian`](@ref) (for an
-interface for implementing operators).
+See [`ProjectorMonteCarloProblem`](@ref), [`ReplicaStrategy`](@ref) and
+[`AbstractHamiltonian`](@ref) (for an interface for implementing operators).
 
 # Transformed Hamiltonians
 
-If a transformed Hamiltonian `G` has been passed to [`lomc!`](@ref) then overlaps can be calculated by
+If a transformed Hamiltonian `G` has been passed to [`ProjectorMonteCarloProblem`](@ref) then overlaps can be calculated by
 passing the same transformed Hamiltonian to `AllOverlaps` by setting `transform=G`. A warning is given
 if these two Hamiltonians do not match.
 
@@ -175,7 +176,7 @@ end
     check_transform(r::AllOverlaps, ham)
 
 Check that the transformation provided to `r::AllOverlaps` matches the given Hamiltonian `ham`.
-Used as a sanity check before starting main [`lomc!`](@ref) loop.
+Used as a sanity check before starting main [`ProjectorMonteCarloProblem`](@ref) loop.
 """
 function check_transform(r::AllOverlaps, ham::AbstractHamiltonian)
     ops = r.operators

--- a/src/strategies_and_params/reportingstrategy.jl
+++ b/src/strategies_and_params/reportingstrategy.jl
@@ -208,7 +208,7 @@ refine_reporting_strategy(reporting_strategy::ReportingStrategy) = reporting_str
      report!(::ReportingStrategy, step, report::Report, nt, id="")
 
 Report `keys` and `values` to `report`, which will be converted to a `DataFrame` before
-[`lomc!`](@ref) exits. Alternatively, a `nt::NamedTuple` can be passed in place of `keys`
+[`ProjectorMonteCarloProblem`](@ref) exits. Alternatively, a `nt::NamedTuple` can be passed in place of `keys`
 and `values`. If `id` is specified, it is appended to all `keys`. This is used to
 differentiate between values reported by different replicas.
 
@@ -242,8 +242,8 @@ reporting_interval(::ReportingStrategy) = 1
 """
     finalize_report!(::ReportingStrategy, report)
 
-Finalize the report. This function is called after all steps in [`lomc!`](@ref) have
-finished.
+Finalize the report. This function is called after all steps in
+[`solve!`](@ref) have finished.
 """
 function finalize_report!(::ReportingStrategy, report)
     report.is_finalized[] = true

--- a/src/strategies_and_params/shiftstrategy.jl
+++ b/src/strategies_and_params/shiftstrategy.jl
@@ -1,12 +1,12 @@
 """
     ShiftStrategy
 Abstract type for defining the strategy for controlling the norm, potentially by updating
-the `shift`. Passed as a parameter to [`lomc!`](@ref).
+the `shift`. Passed as a parameter to [`ProjectorMonteCarloProblem`](@ref) or to [`FCIQMC`](@ref).
 
 ## Implemented strategies:
 
 * [`DontUpdate`](@ref)
-* [`DoubleLogUpdate`](@ref) - default in [`lomc!()`](@ref)
+* [`DoubleLogUpdate`](@ref) - default in [`ProjectorMonteCarloProblem()`](@ref)
 * [`LogUpdate`](@ref)
 * [`LogUpdateAfterTargetWalkers`](@ref) - FCIQMC standard
 * [`DoubleLogUpdateAfterTargetWalkers`](@ref)
@@ -72,7 +72,7 @@ update_shift_parameters!
     DontUpdate(; target_walkers = 1_000_000) <: ShiftStrategy
 Don't update the `shift`.  Return when `target_walkers` is reached.
 
-See [`ShiftStrategy`](@ref), [`lomc!`](@ref).
+See [`ShiftStrategy`](@ref), [`ProjectorMonteCarloProblem`](@ref).
 """
 Base.@kwdef struct DontUpdate <: ShiftStrategy
     target_walkers::Int = 1_000_000
@@ -87,7 +87,7 @@ end
 Strategy for updating the shift: After `target_walkers` is reached, update the
 shift according to the log formula with damping parameter `ζ`.
 
-See [`LogUpdate`](@ref), [`ShiftStrategy`](@ref), [`lomc!`](@ref).
+See [`LogUpdate`](@ref), [`ShiftStrategy`](@ref), [`ProjectorMonteCarloProblem`](@ref).
 """
 Base.@kwdef struct LogUpdateAfterTargetWalkers <: ShiftStrategy
     target_walkers::Int
@@ -115,7 +115,7 @@ parameter `ζ`.
 S^{n+1} = S^n -\\frac{ζ}{dτ}\\ln\\left(\\frac{\\|Ψ\\|_1^{n+1}}{\\|Ψ\\|_1^n}\\right)
 ```
 
-See [`ShiftStrategy`](@ref), [`lomc!`](@ref).
+See [`ShiftStrategy`](@ref), [`ProjectorMonteCarloProblem`](@ref).
 """
 Base.@kwdef struct LogUpdate <: ShiftStrategy
     ζ::Float64 = 0.08 # damping parameter, best left at value of 0.3
@@ -141,7 +141,7 @@ S^{n+1} = S^n -\\frac{ζ}{dτ}\\ln\\left(\\frac{\\|Ψ\\|_1^{n+1}}{\\|Ψ\\|_1^n}\
 When ξ = ζ^2/4 this corresponds to critical damping with a damping time scale
 T = 2/ζ.
 
-See [`ShiftStrategy`](@ref), [`lomc!`](@ref).
+See [`ShiftStrategy`](@ref), [`ProjectorMonteCarloProblem`](@ref).
 """
 struct DoubleLogUpdate{T} <: ShiftStrategy
     target_walkers::T
@@ -166,7 +166,7 @@ end
 Strategy for updating the shift: After `target_walkers` is reached, update the
 shift according to the log formula with damping parameter `ζ` and `ξ`.
 
-See [`DoubleLogUpdate`](@ref), [`ShiftStrategy`](@ref), [`lomc!`](@ref).
+See [`DoubleLogUpdate`](@ref), [`ShiftStrategy`](@ref), [`ProjectorMonteCarloProblem`](@ref).
 """
 Base.@kwdef struct DoubleLogUpdateAfterTargetWalkers <: ShiftStrategy
     target_walkers::Int
@@ -203,7 +203,7 @@ When ξ = ζ^2/4 this corresponds to critical damping with a damping time scale
 T = 2/ζ.
 
 
-See [`ShiftStrategy`](@ref), [`lomc!`](@ref).
+See [`ShiftStrategy`](@ref), [`ProjectorMonteCarloProblem`](@ref).
 """
 struct DoubleLogSumUpdate{T} <: ShiftStrategy
     target_walkers::T
@@ -239,10 +239,10 @@ parameter `ζ` and `ξ` after projecting onto `projector`.
 S^{n+1} = S^n -\\frac{ζ}{dτ}\\ln\\left(\\frac{P⋅Ψ^{(n+1)}}{P⋅Ψ^{(n)}}\\right)-\\frac{ξ}{dτ}\\ln\\left(\\frac{P⋅Ψ^{(n+1)}}{\\text{target}}\\right)
 ```
 
-Note that adjusting the keyword `maxlength` in [`lomc!`](@ref) is advised as the
-default may not be appropriate.
+Note that adjusting the keyword `maxlength` in [`ProjectorMonteCarloProblem`](@ref) is
+advised as the default may not be appropriate.
 
-See [`ShiftStrategy`](@ref), [`lomc!`](@ref).
+See [`ShiftStrategy`](@ref), [`ProjectorMonteCarloProblem`](@ref).
 """
 struct DoubleLogProjected{T,P} <: ShiftStrategy
     target::T

--- a/src/strategies_and_params/shiftstrategy.jl
+++ b/src/strategies_and_params/shiftstrategy.jl
@@ -69,29 +69,44 @@ See [`initialise_shift_parameters`](@ref), [`ShiftStrategy`](@ref).
 update_shift_parameters!
 
 """
-    DontUpdate(; target_walkers = 1_000_000) <: ShiftStrategy
+    DontUpdate(; target_walkers = 1_000) <: ShiftStrategy
 Don't update the `shift`.  Return when `target_walkers` is reached.
 
 See [`ShiftStrategy`](@ref), [`ProjectorMonteCarloProblem`](@ref).
 """
-Base.@kwdef struct DontUpdate <: ShiftStrategy
-    target_walkers::Int = 1_000_000
+struct DontUpdate <: ShiftStrategy
+    target_walkers::Int
 end
+function DontUpdate(; targetwalkers = nothing, target_walkers = 1_000)
+    if !isnothing(targetwalkers)
+        @warn "The keyword targetwalkers is deprecated. Use target_walkers instead."
+        target_walkers = targetwalkers
+    end
+    return DontUpdate(target_walkers)
+end
+
 
 function update_shift_parameters!(s::DontUpdate, sp, tnorm, _...)
     return (; shift=sp.shift, norm=tnorm), tnorm < s.target_walkers
 end
 
 """
-    LogUpdateAfterTargetWalkers(target_walkers, ζ = 0.08) <: ShiftStrategy
+    LogUpdateAfterTargetWalkers(target_walkers = 1_000, ζ = 0.08) <: ShiftStrategy
 Strategy for updating the shift: After `target_walkers` is reached, update the
 shift according to the log formula with damping parameter `ζ`.
 
 See [`LogUpdate`](@ref), [`ShiftStrategy`](@ref), [`ProjectorMonteCarloProblem`](@ref).
 """
-Base.@kwdef struct LogUpdateAfterTargetWalkers <: ShiftStrategy
+struct LogUpdateAfterTargetWalkers <: ShiftStrategy
     target_walkers::Int
-    ζ::Float64 = 0.08 # damping parameter, best left at value of 0.3
+    ζ::Float64
+end
+function LogUpdateAfterTargetWalkers(; targetwalkers=nothing, target_walkers = 1_000, ζ = 0.08)
+    if !isnothing(targetwalkers)
+        @warn "The keyword targetwalkers is deprecated. Use target_walkers instead."
+        target_walkers = targetwalkers
+    end
+    return LogUpdateAfterTargetWalkers(target_walkers, ζ)
 end
 
 function update_shift_parameters!(s::LogUpdateAfterTargetWalkers, sp, tnorm, _...)
@@ -131,7 +146,7 @@ function update_shift_parameters!(s::LogUpdate, sp, tnorm, _...)
 end
 
 """
-    DoubleLogUpdate(; target_walkers = 1000, ζ = 0.08, ξ = ζ^2/4) <: ShiftStrategy
+    DoubleLogUpdate(; target_walkers = 1_000, ζ = 0.08, ξ = ζ^2/4) <: ShiftStrategy
 Strategy for updating the shift according to the log formula with damping
 parameter `ζ` and `ξ`.
 
@@ -148,7 +163,11 @@ struct DoubleLogUpdate{T} <: ShiftStrategy
     ζ::Float64 # damping parameter, best left at value of 0.08
     ξ::Float64  # restoring force to bring walker number to the target
 end
-function DoubleLogUpdate(;target_walkers = 1000,  ζ = 0.08, ξ = ζ^2/4)
+function DoubleLogUpdate(;targetwalkers = nothing, target_walkers = 1_000,  ζ = 0.08, ξ = ζ^2/4)
+    if !isnothing(targetwalkers)
+        @warn "The keyword targetwalkers is deprecated. Use target_walkers instead."
+        target_walkers = targetwalkers
+    end
     return DoubleLogUpdate(target_walkers, ζ, ξ)
 end
 
@@ -162,16 +181,25 @@ function update_shift_parameters!(s::DoubleLogUpdate, sp, tnorm, _...)
 end
 
 """
-    DoubleLogUpdateAfterTargetWalkers(target_walkers, ζ = 0.08, ξ = 0.0016) <: ShiftStrategy
+    DoubleLogUpdateAfterTargetWalkers(target_walkers = 1_000, ζ = 0.08, ξ = ζ^2/4) <: ShiftStrategy
 Strategy for updating the shift: After `target_walkers` is reached, update the
 shift according to the log formula with damping parameter `ζ` and `ξ`.
 
 See [`DoubleLogUpdate`](@ref), [`ShiftStrategy`](@ref), [`ProjectorMonteCarloProblem`](@ref).
 """
-Base.@kwdef struct DoubleLogUpdateAfterTargetWalkers <: ShiftStrategy
+struct DoubleLogUpdateAfterTargetWalkers <: ShiftStrategy
     target_walkers::Int
-    ζ::Float64 = 0.08 # damping parameter, best left at value of 0.3
-    ξ::Float64 = 0.0016 # restoring force to bring walker number to the target
+    ζ::Float64 # damping parameter
+    ξ::Float64 # restoring force to bring walker number to the target
+end
+function DoubleLogUpdateAfterTargetWalkers(;
+    targetwalkers=nothing, target_walkers = 1_000, ζ = 0.08, ξ = ζ^2/4
+)
+    if !isnothing(targetwalkers)
+        @warn "The keyword targetwalkers is deprecated. Use target_walkers instead."
+        target_walkers = targetwalkers
+    end
+    return DoubleLogUpdateAfterTargetWalkers(target_walkers, ζ, ξ)
 end
 
 function update_shift_parameters!(s::DoubleLogUpdateAfterTargetWalkers, sp, tnorm, _...)
@@ -211,7 +239,12 @@ struct DoubleLogSumUpdate{T} <: ShiftStrategy
     ξ::Float64  # restoring force to bring walker number to the target
     α::Float64  # mixing angle for (1-α)*walkernumber + α*UniformProjector()⋅ψ
 end
-function DoubleLogSumUpdate(;target_walkers = 1000,  ζ = 0.08, ξ = ζ^2/4, α = 1/2)
+function DoubleLogSumUpdate(;
+    targetwalkers = nothing, target_walkers = 1000,  ζ = 0.08, ξ = ζ^2/4, α = 1/2)
+    if !isnothing(targetwalkers)
+        @warn "The keyword targetwalkers is deprecated. Use target_walkers instead."
+        target_walkers = targetwalkers
+    end
     DoubleLogSumUpdate(target_walkers,  ζ, ξ, α)
 end
 

--- a/src/strategies_and_params/timestepstrategy.jl
+++ b/src/strategies_and_params/timestepstrategy.jl
@@ -2,7 +2,7 @@
     TimeStepStrategy
 
 Abstract type for strategies for updating the time step with
-[`update_dτ()`](@ref). Implemented strategies:
+[`update_time_step()`](@ref). Implemented strategies:
 
    * [`ConstantTimeStep`](@ref)
 """
@@ -16,7 +16,7 @@ Keep `time_step` constant.
 struct ConstantTimeStep <: TimeStepStrategy end
 
 """
-    update_dτ(s<:TimeStepStrategy, time_step, tnorm) -> new_time_step
+    update_time_step(s<:TimeStepStrategy, time_step, tnorm) -> new_time_step
 Update the time step according to the strategy `s`.
 """
-update_dτ(::ConstantTimeStep, time_step, args...) = time_step
+update_time_step(::ConstantTimeStep, time_step, args...) = time_step

--- a/src/strategies_and_params/timestepstrategy.jl
+++ b/src/strategies_and_params/timestepstrategy.jl
@@ -11,12 +11,12 @@ abstract type TimeStepStrategy end
 """
     ConstantTimeStep <: TimeStepStrategy
 
-Keep `dτ` constant.
+Keep `time_step` constant.
 """
 struct ConstantTimeStep <: TimeStepStrategy end
 
 """
-    update_dτ(s<:TimeStepStrategy, dτ, tnorm) -> new dτ
+    update_dτ(s<:TimeStepStrategy, time_step, tnorm) -> new_time_step
 Update the time step according to the strategy `s`.
 """
-update_dτ(::ConstantTimeStep, dτ, args...) = dτ
+update_dτ(::ConstantTimeStep, time_step, args...) = time_step

--- a/test/RMPI.jl
+++ b/test/RMPI.jl
@@ -11,13 +11,13 @@ using Test
         dv = DVec(starting_address(ham) => 10; style=IsDynamicSemistochastic())
         v = MPIData(dv; setup)
         df, state = lomc!(ham,v)
-        @test size(df) == (100, 10)
+        @test size(df) == (100, 9)
     end
     # need to do mpi_one_sided separately
     dv = DVec(starting_address(ham)=>10; style=IsDynamicSemistochastic())
     v = RMPI.mpi_one_sided(dv; capacity = 1000)
     df, state = lomc!(ham,v)
-    @test size(df) == (100, 10)
+    @test size(df) == (100, 9)
 end
 
 @testset "sort_and_count!" begin

--- a/test/StatsTools.jl
+++ b/test/StatsTools.jl
@@ -22,9 +22,9 @@ end
     @test_throws AssertionError growth_witness(rand(5), rand(5), 0.01; skip=10)
     nor = rand(200)
     shift = rand(200)
-    dτ = 0.01 * ones(200)
-    df = DataFrame(; norm=nor, shift, dτ)
-    m = mean(growth_witness(shift, nor, dτ[1]; skip=10))
+    time_step = 0.01 * ones(200)
+    df = DataFrame(; norm=nor, shift, time_step)
+    m = mean(growth_witness(shift, nor, time_step[1]; skip=10))
     @test mean(growth_witness(df, 10; skip=10)) ≈ m
     @test mean(growth_witness(df; skip=10)) ≈ m
 end
@@ -236,7 +236,7 @@ end
     # projected energy
     bp = @suppress projected_energy(df; skip=steps_equi)
     me = @suppress @inferred mixed_estimator(
-        df.hproj, df.vproj, df.shift, h, df.dτ[end];
+        df.hproj, df.vproj, df.shift, h, df.time_step[end];
         skip=steps_equi, E_r
     )
     @test me.ratio ≈ bp.ratio # reweighting has not significantly improved the projected energy

--- a/test/StatsTools.jl
+++ b/test/StatsTools.jl
@@ -206,7 +206,7 @@ end
     steps_meas = 2^10
     p = RunTillLastStep(laststep=steps_equi + steps_meas)
     post_step = ProjectedEnergy(ham, v)
-    s_strat = DoubleLogUpdate(targetwalkers=10)
+    s_strat = DoubleLogUpdate(target_walkers=10)
     df = lomc!(ham, v; params=p, s_strat, post_step).df
     @test_throws ArgumentError variational_energy_estimator(df) # see next testset
     bs = shift_estimator(df; skip=steps_equi)
@@ -264,7 +264,7 @@ end
     tw = 10
 
     params = RunTillLastStep(laststep = skipsteps + runsteps)
-    s_strat = DoubleLogUpdate(targetwalkers = tw)
+    s_strat = DoubleLogUpdate(target_walkers = tw)
     G2list = ([G2RealCorrelator(i) for i in dvals]...,)
 
     Random.seed!(174)
@@ -307,7 +307,7 @@ using Rimu.StatsTools: replica_fidelity
     steps_meas = 2^10
     p = RunTillLastStep(laststep=steps_equi + steps_meas)
     post_step = (Projector(vproj=gs), Projector(hproj=os))
-    s_strat = DoubleLogUpdate(targetwalkers=10)
+    s_strat = DoubleLogUpdate(target_walkers=10)
 
     # run replica fciqmc
     Random.seed!(170)

--- a/test/StatsTools.jl
+++ b/test/StatsTools.jl
@@ -235,8 +235,9 @@ end
     @test all(abs.(df_nt.val .- df_ge.val) .< df_nt.val_l)
     # projected energy
     bp = @suppress projected_energy(df; skip=steps_equi)
+    time_step = Rimu.StatsTools.determine_constant_time_step(df)
     me = @suppress @inferred mixed_estimator(
-        df.hproj, df.vproj, df.shift, h, df.time_step[end];
+        df.hproj, df.vproj, df.shift, h, time_step;
         skip=steps_equi, E_r
     )
     @test me.ratio ≈ bp.ratio # reweighting has not significantly improved the projected energy

--- a/test/lomc.jl
+++ b/test/lomc.jl
@@ -76,7 +76,7 @@ Random.seed!(1234)
         H = HubbardMom1D(address; u=0.5)
         dv = DVec(address => 1; style=IsStochasticWithThreshold(1.0))
 
-        s_strat = DoubleLogUpdate(ζ=0.05, ξ=0.05^2/4, targetwalkers=100)
+        s_strat = DoubleLogUpdate(ζ=0.05, ξ=0.05^2/4, target_walkers=100)
         v = copy(dv)
         walkers = lomc!(H, v; s_strat, laststep=1000).df.norm
         @test median(walkers) ≈ 100 rtol=0.1
@@ -84,16 +84,16 @@ Random.seed!(1234)
         walkers = lomc!(H, v; s_strat, laststep=1000).df.norm # continuation run
         @test median(walkers) > 10 # essentially just test that it does not error
 
-        s_strat = DoubleLogUpdate(ζ=0.05, ξ=0.05^2/4, targetwalkers=200)
+        s_strat = DoubleLogUpdate(ζ=0.05, ξ=0.05^2/4, target_walkers=200)
         walkers = lomc!(H, copy(dv); s_strat, laststep=1000).df.norm
         @test median(walkers) ≈ 200 rtol=0.1
 
-        s_strat = DoubleLogUpdate(ζ=0.05, ξ=0.05^2/4, targetwalkers=1000)
+        s_strat = DoubleLogUpdate(ζ=0.05, ξ=0.05^2/4, target_walkers=1000)
         walkers = lomc!(H, copy(dv); s_strat, laststep=1000).df.norm
         @test median(walkers) ≈ 1000 rtol=0.1
 
         _, state = @test_logs (:warn, Regex("(Simulation)")) lomc!(H, copy(dv); targetwalkers=500, laststep=0)
-        @test only(state).algorithm.shift_strategy.targetwalkers == 500
+        @test only(state).algorithm.shift_strategy.target_walkers == 500
     end
 
     @testset "Replicas" begin
@@ -232,19 +232,19 @@ Random.seed!(1234)
         H = HubbardReal1D(address; u=20)
 
         # DontUpdate
-        s_strat = DontUpdate(targetwalkers = 100)
+        s_strat = DontUpdate(target_walkers = 100)
         df = lomc!(H; s_strat, laststep=100).df
         @test size(df, 1) < 100 # finish early without error
 
         # LogUpdateAfterTargetWalkers
-        s_strat = LogUpdateAfterTargetWalkers(targetwalkers = 100)
+        s_strat = LogUpdateAfterTargetWalkers(target_walkers = 100)
         df, state  = lomc!(H; s_strat, laststep=100)
         @test size(df, 1) == 100
         @test df.shift_mode[end] # finish in variable shift mode
         @test df.norm[end] > 100
 
         # LogUpdate
-        s_strat = DoubleLogUpdate(targetwalkers=100)
+        s_strat = DoubleLogUpdate(target_walkers=100)
         df, state = lomc!(H; s_strat, laststep=100)
         @test size(df, 1) == 100
 
@@ -256,7 +256,7 @@ Random.seed!(1234)
         @test 500 > df.norm[end] > 100
 
         # DoubleLogUpdateAfterTargetWalkers
-        s_strat = DoubleLogUpdateAfterTargetWalkers(targetwalkers = 100)
+        s_strat = DoubleLogUpdateAfterTargetWalkers(target_walkers = 100)
         df, state  = lomc!(H; s_strat, laststep=100)
         @test size(df, 1) == 100
         @test df.shift_mode[end] # finish in variable shift mode
@@ -264,7 +264,7 @@ Random.seed!(1234)
 
         # test unexported strategies
         # DoubleLogSumUpdate
-        s_strat = Rimu.DoubleLogSumUpdate(targetwalkers = 100)
+        s_strat = Rimu.DoubleLogSumUpdate(target_walkers = 100)
         df, state  = lomc!(H; s_strat, laststep=100)
         @test size(df, 1) == 100
 
@@ -562,8 +562,8 @@ end
         dv_nr = DVec(address => 1; style=IsDynamicSemistochastic(spawning=WithoutReplacement()))
         dv_br = DVec(address => 1; style=IsDynamicSemistochastic(spawning=Bernoulli()))
 
-        s_strat = DoubleLogUpdate(ζ=0.05, ξ=0.05^2/4, targetwalkers=100)
-        s_strat_cx = DoubleLogUpdate(ζ=0.05, ξ=0.05^2/4, targetwalkers=100 + 100im)
+        s_strat = DoubleLogUpdate(ζ=0.05, ξ=0.05^2/4, target_walkers=100)
+        s_strat_cx = DoubleLogUpdate(ζ=0.05, ξ=0.05^2/4, target_walkers=100 + 100im)
         df_st = lomc!(H, dv_st; s_strat, laststep=2500).df
         df_th = lomc!(H, dv_th; s_strat, laststep=2500).df
         df_cx = lomc!(H, dv_cx; s_strat=s_strat_cx, laststep=2500).df
@@ -648,7 +648,7 @@ end
             H = HubbardMom1D(address; u=4.0)
             E0 = -9.251592973178997
 
-            s_strat = DoubleLogUpdate(ζ=0.05, ξ=0.05^2/4, targetwalkers=300)
+            s_strat = DoubleLogUpdate(ζ=0.05, ξ=0.05^2/4, target_walkers=300)
             laststep = 6_000
             dτ = 5e-4
             df_no = lomc!(H, copy(dv_no); s_strat, laststep, dτ).df
@@ -684,7 +684,7 @@ end
             H = HubbardMom1D(address)
             E0 = -16.36048582876015
 
-            s_strat = DoubleLogUpdate(ζ=0.05, ξ=0.05^2/4, targetwalkers=3000)
+            s_strat = DoubleLogUpdate(ζ=0.05, ξ=0.05^2/4, target_walkers=3000)
             laststep = 2500
             dτ = 1e-2
             df_no = lomc!(H, copy(dv_no); s_strat, laststep, dτ).df

--- a/test/lomc.jl
+++ b/test/lomc.jl
@@ -47,7 +47,7 @@ Random.seed!(1234)
         state.step[] = 0
         df, state = lomc!(state, df)
         @test size(df, 1) == 200
-        @test df.steps == [1:100; 1:100]
+        @test df.step == [1:100; 1:100]
     end
 
     @testset "Setting dτ and shift" begin

--- a/test/mpi_runtests.jl
+++ b/test/mpi_runtests.jl
@@ -367,7 +367,7 @@ end
                 else
                     dv = MPIData(InitiatorDVec(add => 3); setup, kwargs...)
                 end
-                s_strat = DoubleLogUpdate(targetwalkers=100)
+                s_strat = DoubleLogUpdate(target_walkers=100)
                 df = lomc!(H, dv; laststep=5000, s_strat).df
 
                 # Shift estimate.

--- a/test/projector_monte_carlo_problem.jl
+++ b/test/projector_monte_carlo_problem.jl
@@ -22,7 +22,7 @@ using OrderedCollections: freeze
     @test sp.shift == diagonal_element(h, starting_address(h))
     @test sp.pnorm == walkernumber(only(state_vectors(simulation)))
     @test sp.pnorm isa Float64
-    @test p.maxlength == 2 * p.algorithm.shift_strategy.targetwalkers + 100
+    @test p.maxlength == 2 * p.algorithm.shift_strategy.target_walkers + 100
 
     ps = ProjectorMonteCarloProblem(h; initial_shift_parameters=sp, threading=false)
     @test ps.initial_shift_parameters === sp


### PR DESCRIPTION
A PR to clean up the user interface and user interaction.

## Breaking changes
- Report / `DataFrame` column `:steps` renamed to `:step` and from `:dτ` to `:time_step`
- `:time_step` is only reported in report if `time_step_strategy ≠ ConstantTimeStep()`
- Renamed function `update_dτ` to `update_time_step`
- defaults changed for some `ShiftStrategy`s

## Deprecations
- Renamed keyword argument `targetwalkers` to `target_walkers` in `ProjectorMonteCarloProblem`; 
  `targetwakers` is deprecated and will trigger a warning message
 

## Other changes
- documentation page for Projector Monte Carlo added; structure of data frames explained
- references to `lomc!` removed from docstrings
