### PR TITLE
Make it easier to run continuation runs

### DIFF
--- a/src/pmc_simulation.jl
+++ b/src/pmc_simulation.jl
@@ -93,7 +93,7 @@ function PMCSimulation(problem::ProjectorMonteCarloProblem; copy_vectors=true)
         @unpack shift, time_step = initial_shift_parameters
         set_up_initial_shift_parameters(algorithm, hamiltonian, vectors, shift, time_step)
     else
-        initial_shift_parameters
+        SMatrix{n_spectral,n_replicas}(initial_shift_parameters...)
     end
     @assert shift_parameters isa SMatrix{n_spectral,n_replicas}
 

--- a/src/projector_monte_carlo_problem.jl
+++ b/src/projector_monte_carlo_problem.jl
@@ -78,7 +78,7 @@ julia> size(DataFrame(simulation))
 - `ξ = ζ^2/4`: Forcing parameter for the shift update.
 - `shift_strategy = DoubleLogUpdate(; targetwalkers, ζ, ξ)`: How to update the `shift`,
     see [`ShiftStrategy`](@ref).
-- `time_step_strategy = ConstantTimeStep()``: Adjust time step or not, see
+- `time_step_strategy = ConstantTimeStep()`: Adjust time step or not, see
     `TimeStepStrategy`.
 - `algorithm = FCIQMC(; shift_strategy, time_step_strategy)`: The algorithm to use.
     Currenlty only [`FCIQMC`](@ref) is implemented.


### PR DESCRIPTION
# Changes
- Any collection can now be passed to `initial_shift_parameters`, which makes it less cumbersome to use.