### PR TITLE
Observables

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Rimu"
 uuid = "c53c40cc-bd84-11e9-2cf4-a9fde2b9386e"
 authors = ["Joachim Brand <j.brand@massey.ac.nz>"]
-version = "0.12.1"
+version = "0.13.0"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/docs/src/hamiltonians.md
+++ b/docs/src/hamiltonians.md
@@ -69,10 +69,15 @@ Stoquastic
 ```
 
 ## Observables
-Observables are [`AbstractHamiltonian`](@ref)s that represent a physical
-observable. Their ground state expectation values can be sampled by passing
-them into [`AllOverlaps`](@ref).
+Observables are [`AbstractOperator`](@ref)s that represent a physical
+observable. Their expectation values can be sampled during a
+[`ProjectorMonteCarloProblem`](@ref) simulation by passing
+them into a suitable [`ReplicaStrategy`](@ref), e.g. 
+[`AllOverlaps`](@ref).  [`AbstractOperator`](@ref)s are a supertype of 
+[`AbstractHamiltonian`](@ref)s and fulfil less stringent 
+requirements.
 ```@docs
+AbstractOperator
 ParticleNumberOperator
 G2RealCorrelator
 G2RealSpace
@@ -115,6 +120,8 @@ Hamiltonians.LOStructure
 dimension
 has_adjoint
 allows_address_type
+Base.eltype
+VectorInterface.scalartype
 ```
 
 This interface relies on unexported functionality, including

--- a/docs/src/hamiltonians.md
+++ b/docs/src/hamiltonians.md
@@ -114,7 +114,7 @@ random_offdiagonal
 Hamiltonians.LOStructure
 dimension
 has_adjoint
-allowed_address_type
+allows_address_type
 ```
 
 This interface relies on unexported functionality, including

--- a/docs/src/hamiltonians.md
+++ b/docs/src/hamiltonians.md
@@ -73,9 +73,10 @@ Observables are [`AbstractOperator`](@ref)s that represent a physical
 observable. Their expectation values can be sampled during a
 [`ProjectorMonteCarloProblem`](@ref) simulation by passing
 them into a suitable [`ReplicaStrategy`](@ref), e.g. 
-[`AllOverlaps`](@ref).  [`AbstractOperator`](@ref)s are a supertype of 
-[`AbstractHamiltonian`](@ref)s and fulfil less stringent 
-requirements.
+[`AllOverlaps`](@ref).  [`AbstractOperator`](@ref) is a supertype of 
+[`AbstractHamiltonian`](@ref) and has less stringent 
+requirements. Some observables are also [`AbstractHamiltonian`](@ref)s.
+
 ```@docs
 AbstractOperator
 ParticleNumberOperator
@@ -122,6 +123,7 @@ has_adjoint
 allows_address_type
 Base.eltype
 VectorInterface.scalartype
+mul!
 ```
 
 This interface relies on unexported functionality, including

--- a/scripts/G2-example.jl
+++ b/scripts/G2-example.jl
@@ -47,8 +47,8 @@ G2list = ((G2RealCorrelator(d) for d in dvals)...,)
 # To obtain an unbiased result, at least two replicas should be used. One can also use more
 # than two to improve the statistics. This is particularly helpful when the walker number is
 # low.
-num_replicas = 3
-replica_strategy = AllOverlaps(num_replicas; operator = G2list)
+number_of_replicas = 3
+replica_strategy = AllOverlaps(number_of_replicas; operator=G2list)
 
 # Other FCIQMC parameters and strategies can be set in the same way as before.
 steps_equilibrate = 1_000

--- a/scripts/G2-example.jl
+++ b/scripts/G2-example.jl
@@ -47,8 +47,8 @@ G2list = ((G2RealCorrelator(d) for d in dvals)...,)
 # To obtain an unbiased result, at least two replicas should be used. One can also use more
 # than two to improve the statistics. This is particularly helpful when the walker number is
 # low.
-number_of_replicas = 3
-replica_strategy = AllOverlaps(number_of_replicas; operator=G2list)
+n_replicas = 3
+replica_strategy = AllOverlaps(n_replicas; operator=G2list)
 
 # Other FCIQMC parameters and strategies can be set in the same way as before.
 steps_equilibrate = 1_000
@@ -93,7 +93,7 @@ println(filter(contains("Op"), names(df)))
 # equilibration steps.
 
 # Now, we can calculate the correlation function for each value of ``d``.
-println("Two-body correlator from $num_replicas replicas:")
+println("Two-body correlator from $n_replicas replicas:")
 for d in dvals
     r = rayleigh_replica_estimator(df; op_name = "Op$(d+1)", skip=steps_equilibrate)
     println("   G2($d) = $(r.f) ± $(r.σ_f)")
@@ -105,8 +105,8 @@ end
 
 # Since we ran multiple independent replicas, we also have multiple estimates of the shift
 # energy.
-println("Shift energy from $num_replicas replicas:")
-for i in 1:num_replicas
+println("Shift energy from $n_replicas replicas:")
+for i in 1:n_replicas
     se = shift_estimator(df; shift="shift_$i", skip=steps_equilibrate)
     println("   Replica $i: $(se.mean) ± $(se.err)")
 end

--- a/src/BitStringAddresses/multicomponent.jl
+++ b/src/BitStringAddresses/multicomponent.jl
@@ -72,7 +72,7 @@ function CompositeFS(adds::Vararg{SingleComponentFockAddress})
     return CompositeFS{length(adds),N,M1,typeof(adds)}(adds)
 end
 
-num_components(::CompositeFS{C}) where {C} = C
+num_components(::Type{<:CompositeFS{C}}) where {C} = C
 Base.hash(c::CompositeFS, u::UInt) = hash(c.components, u)
 
 function print_address(io::IO, c::CompositeFS{C}; compact=false) where {C}

--- a/src/DictVectors/DictVectors.jl
+++ b/src/DictVectors/DictVectors.jl
@@ -21,7 +21,7 @@ import MPI
 using ..Interfaces: Interfaces, AbstractDVec, AdjointUnknown,
     CompressionStrategy, IsDiagonal, LOStructure,
     apply_column!, apply_operator!, compress!,
-    diagonal_element, offdiagonals, step_stats, AbstractHamiltonian
+    diagonal_element, offdiagonals, step_stats, AbstractHamiltonian, AbstractOperator
 using ..StochasticStyles: StochasticStyles, IsDeterministic
 
 import ..Interfaces: deposit!, storage, StochasticStyle, default_style, freeze, localpart,

--- a/src/DictVectors/DictVectors.jl
+++ b/src/DictVectors/DictVectors.jl
@@ -21,7 +21,8 @@ import MPI
 using ..Interfaces: Interfaces, AbstractDVec, AdjointUnknown,
     CompressionStrategy, IsDiagonal, LOStructure,
     apply_column!, apply_operator!, compress!,
-    diagonal_element, offdiagonals, step_stats, AbstractHamiltonian, AbstractOperator
+    diagonal_element, offdiagonals, step_stats, AbstractHamiltonian, AbstractOperator,
+    dot_from_right
 using ..StochasticStyles: StochasticStyles, IsDeterministic
 
 import ..Interfaces: deposit!, storage, StochasticStyle, default_style, freeze, localpart,

--- a/src/DictVectors/abstractdvec.jl
+++ b/src/DictVectors/abstractdvec.jl
@@ -278,11 +278,7 @@ function Base.:*(h::AbstractOperator, v::AbstractDVec)
     return mul!(zerovector(v, promote_type(eltype(h), valtype(v))), h, v)
 end
 
-"""
-    dot(w, op::AbstractOperator, v)
-
-Evaluate `w⋅op(v)` minimizing memory allocations.
-"""
+# docstring in Interfaces
 function LinearAlgebra.dot(w::AbstractDVec, op::AbstractOperator, v::AbstractDVec)
     return dot(LOStructure(op), w, op, v)
 end
@@ -297,13 +293,8 @@ function LinearAlgebra.dot(::LOStructure, w, op::AbstractOperator, v)
     end
 end
 
-"""
-    dot_from_right(w, op::AbstractOperator, v)
-
-Internal function evaluates the 3-argument `dot()` function in order from right
-to left.
-"""
-function dot_from_right(w, op, v::AbstractDVec)
+# docstring in Interfaces
+function Interfaces.dot_from_right(w, op, v::AbstractDVec)
     T = typeof(zero(valtype(w)) * zero(eltype(op)) * zero(valtype(v)))
     result = zero(T)
     for (key, val) in pairs(v)

--- a/src/DictVectors/abstractdvec.jl
+++ b/src/DictVectors/abstractdvec.jl
@@ -263,7 +263,7 @@ walkernumber_and_length(v) = walkernumber(v), length(v)
 ###
 ### Vector-operator functions
 ###
-function LinearAlgebra.mul!(w::AbstractDVec, h::AbstractHamiltonian, v::AbstractDVec)
+function LinearAlgebra.mul!(w::AbstractDVec, h::AbstractOperator, v::AbstractDVec)
     empty!(w)
     for (key, val) in pairs(v)
         w[key] += diagonal_element(h, key) * val
@@ -274,22 +274,22 @@ function LinearAlgebra.mul!(w::AbstractDVec, h::AbstractHamiltonian, v::Abstract
     return w
 end
 
-function Base.:*(h::AbstractHamiltonian, v::AbstractDVec)
+function Base.:*(h::AbstractOperator, v::AbstractDVec)
     return mul!(zerovector(v, promote_type(eltype(h), valtype(v))), h, v)
 end
 
 """
-    dot(w, op::AbstractHamiltonian, v)
+    dot(w, op::AbstractOperator, v)
 
 Evaluate `w⋅op(v)` minimizing memory allocations.
 """
-function LinearAlgebra.dot(w::AbstractDVec, op::AbstractHamiltonian, v::AbstractDVec)
+function LinearAlgebra.dot(w::AbstractDVec, op::AbstractOperator, v::AbstractDVec)
     return dot(LOStructure(op), w, op, v)
 end
-function LinearAlgebra.dot(::AdjointUnknown, w, op::AbstractHamiltonian, v)
+function LinearAlgebra.dot(::AdjointUnknown, w, op::AbstractOperator, v)
     return dot_from_right(w, op, v)
 end
-function LinearAlgebra.dot(::LOStructure, w, op::AbstractHamiltonian, v)
+function LinearAlgebra.dot(::LOStructure, w, op::AbstractOperator, v)
     if length(w) < length(v)
         return conj(dot_from_right(v, op', w)) # turn args around to execute faster
     else
@@ -298,7 +298,7 @@ function LinearAlgebra.dot(::LOStructure, w, op::AbstractHamiltonian, v)
 end
 
 """
-    dot_from_right(w, op::AbstractHamiltonian, v)
+    dot_from_right(w, op::AbstractOperator, v)
 
 Internal function evaluates the 3-argument `dot()` function in order from right
 to left.

--- a/src/DictVectors/abstractdvec.jl
+++ b/src/DictVectors/abstractdvec.jl
@@ -275,7 +275,14 @@ function LinearAlgebra.mul!(w::AbstractDVec, h::AbstractOperator, v::AbstractDVe
 end
 
 function Base.:*(h::AbstractOperator, v::AbstractDVec)
-    return mul!(zerovector(v, promote_type(eltype(h), valtype(v))), h, v)
+    T = promote_type(scalartype(h), scalartype(v))
+    if eltype(h) ≠ scalartype(h)
+        throw(ArgumentError("Operators with non-scalar eltype don't support "*
+                            "multiplication with `*`. Use `mul!` or `dot` instead."))
+    end
+    # first argument in mul! requires IsDeterministic style
+    w = empty(v, T; style=IsDeterministic{T}())
+    return mul!(w, h, v)
 end
 
 # docstring in Interfaces

--- a/src/DictVectors/initiatordvec.jl
+++ b/src/DictVectors/initiatordvec.jl
@@ -120,17 +120,17 @@ function InitiatorDVec(
     return InitiatorDVec(copy(storage(dv)); style, initiator, capacity)
 end
 
-function Base.empty(dvec::InitiatorDVec{K,V}) where {K,V}
-    return InitiatorDVec{K,V}(; style=dvec.style, initiator=dvec.initiator)
+function Base.empty(dvec::InitiatorDVec{K,V}; style=dvec.style) where {K,V}
+    return InitiatorDVec{K,V}(; style, initiator=dvec.initiator)
 end
-function Base.empty(dvec::InitiatorDVec{K,V}, ::Type{V}) where {K,V}
-    return empty(dvec)
+function Base.empty(dvec::InitiatorDVec{K,V}, ::Type{V}; style=dvec.style) where {K,V}
+    return empty(dvec; style)
 end
-function Base.empty(dvec::InitiatorDVec{K}, ::Type{V}) where {K,V}
-    return InitiatorDVec{K,V}(; initiator=dvec.initiator)
+function Base.empty(dvec::InitiatorDVec{K}, ::Type{V}; style=default_style(V)) where {K,V}
+    return InitiatorDVec{K,V}(; style, initiator=dvec.initiator)
 end
-function Base.empty(dvec::InitiatorDVec, ::Type{K}, ::Type{V}) where {K,V}
-    return InitiatorDVec{K,V}(; initiator=dvec.initiator)
+function Base.empty(dvec::InitiatorDVec, ::Type{K}, ::Type{V}; style=default_style(V)) where {K,V}
+    return InitiatorDVec{K,V}(; style, initiator=dvec.initiator)
 end
 
 ###

--- a/src/DictVectors/pdvec.jl
+++ b/src/DictVectors/pdvec.jl
@@ -754,15 +754,15 @@ See [`PDVec`](@ref), [`PDWorkingMemory`](@ref), [`AbstractOperator`](@ref).
 """
 function LinearAlgebra.mul!(
     y::PDVec, op::AbstractOperator, x::PDVec,
-    w=PDWorkingMemory(y; style=IsDeterministic()),
+    w=PDWorkingMemory(y; style=StochasticStyle(y)),
 )
-    if w.style ≢ IsDeterministic()
+    if !(w.style isa IsDeterministic)
         throw(ArgumentError(
             "Attempted to use `mul!` with non-deterministic working memory. " *
             "Use `apply_operator!` instead."
         ))
     end
-    _, _, wm, y = apply_operator!(w, y, x, op)
+    _, _, _, y = apply_operator!(w, y, x, op)
     return y
 end
 

--- a/src/DictVectors/pdvec.jl
+++ b/src/DictVectors/pdvec.jl
@@ -823,7 +823,7 @@ function LinearAlgebra.dot(
     return dot_from_right(target, op, source)
 end
 
-function dot_from_right(target, op, source::PDVec)
+function Interfaces.dot_from_right(target, op, source::PDVec)
     T = typeof(zero(valtype(target)) * zero(valtype(source)) * zero(eltype(op)))
 
     result = sum(pairs(source); init=zero(T)) do (k, v)

--- a/src/DictVectors/pdvec.jl
+++ b/src/DictVectors/pdvec.jl
@@ -377,11 +377,15 @@ end
 function Base.empty(t::PDVec{K,V}, ::Type{V}; kwargs...) where {K,V}
     return empty(t; kwargs...)
 end
-function Base.empty(t::PDVec{K,<:Any,N}, ::Type{V}; kwargs...) where {K,V,N}
-    return PDVec{K,V,N}(; kwargs...)
+function Base.empty(
+    t::PDVec{K,<:Any,N}, ::Type{V}; style=default_style(V), kwargs...
+) where {K,V,N}
+    return PDVec{K,V,N}(; style, kwargs...)
 end
-function Base.empty(t::PDVec{<:Any,<:Any,N}, ::Type{K}, ::Type{V}; kwargs...) where {K,V,N}
-    return PDVec{K,V,N}(; kwargs...)
+function Base.empty(
+    t::PDVec{<:Any,<:Any,N}, ::Type{K}, ::Type{V}; style=default_style(V), kwargs...
+) where {K,V,N}
+    return PDVec{K,V,N}(; style, kwargs...)
 end
 function Base.empty!(t::PDVec)
     Folds.foreach(empty!, t.segments, )

--- a/src/DictVectors/projectors.jl
+++ b/src/DictVectors/projectors.jl
@@ -40,7 +40,7 @@ struct UniformProjector <: AbstractProjector end
 VectorInterface.inner(::UniformProjector, y::DVecOrVec) = sum(values(y))
 Base.getindex(::UniformProjector, add) = 1
 
-function VectorInterface.inner(::UniformProjector, op::AbstractHamiltonian, v::AbstractDVec)
+function LinearAlgebra.dot(::UniformProjector, op::AbstractOperator, v::AbstractDVec)
     return sum(pairs(v)) do (key, val)
         diag = diagonal_element(op, key) * val
         offdiag = sum(offdiagonals(op, key)) do (add, elem)

--- a/src/Hamiltonians/DensityMatrixDiagonal.jl
+++ b/src/Hamiltonians/DensityMatrixDiagonal.jl
@@ -21,6 +21,10 @@ struct DensityMatrixDiagonal{C} <: AbstractHamiltonian{Float64}
 end
 DensityMatrixDiagonal(mode; component=0) = DensityMatrixDiagonal{component}(mode)
 
+function allows_address_type(dmd::DensityMatrixDiagonal{C}, ::Type{A}) where {C, A}
+    return C ≤ num_components(A) && dmd.mode ≤ num_modes(A)
+end
+
 function diagonal_element(dmd::DensityMatrixDiagonal{1}, add::SingleComponentFockAddress)
     return float(find_mode(add, dmd.mode).occnum)
 end

--- a/src/Hamiltonians/GuidingVectorSampling.jl
+++ b/src/Hamiltonians/GuidingVectorSampling.jl
@@ -128,7 +128,7 @@ end
 Base.size(h::GuidingVectorOffdiagonals) = size(h.offdiagonals)
 
 """
-    TransformUndoer(k::GuidingVectorSampling, op::AbstractHamiltonian)
+    TransformUndoer(k::GuidingVectorSampling, op::AbstractOperator)
     TransformUndoer(k::GuidingVectorSampling)
 
 For a guiding vector similarity transformation ``\\hat{G} = f \\hat{H} f^{-1}``
@@ -138,7 +138,7 @@ the components of the guiding vector, i.e.``f_{ii} = v_i``.
 
 See [`AllOverlaps`](@ref), [`GuidingVectorSampling`](@ref).
 """
-function TransformUndoer(k::GuidingVectorSampling, op::Union{Nothing,AbstractHamiltonian})
+function TransformUndoer(k::GuidingVectorSampling, op::Union{Nothing,AbstractOperator})
     if isnothing(op)
         T = eltype(k)
     else
@@ -150,12 +150,12 @@ end
 # methods for general operator `f^{-1} A f^{-1}`
 LOStructure(::Type{<:TransformUndoer{<:Any,<:GuidingVectorSampling,A}}) where {A} = LOStructure(A)
 
-function LinearAlgebra.adjoint(s::TransformUndoer{T,<:GuidingVectorSampling,<:AbstractHamiltonian}) where {T}
+function LinearAlgebra.adjoint(s::TransformUndoer{T,<:GuidingVectorSampling,<:AbstractOperator}) where {T}
     a_adj = adjoint(s.op)
     return TransformUndoer{T,typeof(s.transform),typeof(a_adj)}(s.transform, a_adj)
 end
 
-function diagonal_element(s::TransformUndoer{<:Any,<:GuidingVectorSampling,<:AbstractHamiltonian}, add)
+function diagonal_element(s::TransformUndoer{<:Any,<:GuidingVectorSampling,<:AbstractOperator}, add)
     guide = s.transform.vector[add]
     diagA = diagonal_element(s.op, add)
     return guided_vector_modify(diagA, true, s.transform.eps, 1., 2 * guide)

--- a/src/Hamiltonians/GutzwillerSampling.jl
+++ b/src/Hamiltonians/GutzwillerSampling.jl
@@ -121,7 +121,7 @@ end
 Base.size(h::GutzwillerOffdiagonals) = size(h.offdiagonals)
 
 """
-    TransformUndoer(k::GutzwillerSampling, op::AbstractHamiltonian)
+    TransformUndoer(k::GutzwillerSampling, op::AbstractOperator)
     TransformUndoer(k::GutzwillerSampling)
 
 For a Gutzwiller similarity transformation ``\\hat{G} = f \\hat{H} f^{-1}``
@@ -131,7 +131,7 @@ to calculate observables. Here ``f`` is a diagonal operator whose entries are
 
 See [`AllOverlaps`](@ref), [`GutzwillerSampling`](@ref).
 """
-function TransformUndoer(k::GutzwillerSampling, op::Union{Nothing,AbstractHamiltonian})
+function TransformUndoer(k::GutzwillerSampling, op::Union{Nothing,AbstractOperator})
     if isnothing(op)
         T = eltype(k)
     else
@@ -143,12 +143,12 @@ end
 # methods for general operator `f^{-1} A f^{-1}`
 LOStructure(::Type{<:TransformUndoer{<:Any,<:GutzwillerSampling,A}}) where {A} = LOStructure(A)
 
-function LinearAlgebra.adjoint(s::TransformUndoer{T,<:GutzwillerSampling,<:AbstractHamiltonian}) where {T}
+function LinearAlgebra.adjoint(s::TransformUndoer{T,<:GutzwillerSampling,<:AbstractOperator}) where {T}
     a_adj = adjoint(s.op)
     return TransformUndoer{T,typeof(s.transform),typeof(a_adj)}(s.transform, a_adj)
 end
 
-function diagonal_element(s::TransformUndoer{<:Any,<:GutzwillerSampling,<:AbstractHamiltonian}, add)
+function diagonal_element(s::TransformUndoer{<:Any,<:GutzwillerSampling,<:AbstractOperator}, add)
     diagH = diagonal_element(s.transform.hamiltonian, add)
     diagA = diagonal_element(s.op, add)
     return gutzwiller_modify(diagA, true, s.transform.g, 0., 2 * diagH)

--- a/src/Hamiltonians/HOCartesianContactInteractions.jl
+++ b/src/Hamiltonians/HOCartesianContactInteractions.jl
@@ -291,8 +291,13 @@ num_offdiagonals(h::HOCartesianContactInteractions, addr::BoseFS) = dimension(h)
 """
     HOCartOffdiagonals
 
-Specialized [`AbstractOffdiagonals`](@ref) that iterates over valid offdiagonal moves that
-are connected by the interaction matrix.
+Specialized iterator for [`HOCartesianContactInteractions`](@ref) that iterates over valid
+offdiagonal moves that are connected by the interaction matrix.
+
+!!! note
+    This iterator is not an [`AbstractOffdiagonals`](@ref) and only supports basic
+    iteration. The number of offdiagonals is not known in advance and the iterator will
+    throw an error if `size` or `length` is called.
 """
 struct HOCartOffdiagonals{
     A<:BoseFS,T,B,H<:AbstractHamiltonian{T},P<:OccupiedPairsMap

--- a/src/Hamiltonians/Hamiltonians.jl
+++ b/src/Hamiltonians/Hamiltonians.jl
@@ -66,7 +66,7 @@ using TupleTools: TupleTools
 using ..BitStringAddresses
 using ..Interfaces
 import ..Interfaces: diagonal_element, num_offdiagonals, get_offdiagonal, starting_address,
-    offdiagonals, random_offdiagonal, LOStructure, allowed_address_type
+    offdiagonals, random_offdiagonal, LOStructure, allows_address_type
 
 export dimension, rayleigh_quotient, momentum
 

--- a/src/Hamiltonians/Momentum.jl
+++ b/src/Hamiltonians/Momentum.jl
@@ -1,36 +1,39 @@
 """
     Momentum(component=0; fold=true) <: AbstractHamiltonian
 
-The momentum operator ``\\hat{p}``.
+The momentum operator ``P̂``.
 
 The component argument controls which component of the address is taken into
 consideration. A value of 0 sums the contributions of all components. If `fold` is true, the
 momentum is folded into the Brillouin zone.
 
 ```jldoctest
-julia> add = BoseFS((1, 0, 2, 1, 2, 1, 1, 3))
+julia> address = BoseFS((1, 0, 2, 1, 2, 1, 1, 3))
 BoseFS{11,8}(1, 0, 2, 1, 2, 1, 1, 3)
 
-julia> v = DVec(add => 10);
+julia> v = DVec(address => 10);
 
-julia> rayleigh_quotient(Momentum(), DVec(add => 1))
+julia> rayleigh_quotient(Momentum(), DVec(address => 1))
 -2.0
 
-julia> rayleigh_quotient(Momentum(fold=false), DVec(add => 1))
+julia> rayleigh_quotient(Momentum(fold=false), DVec(address => 1))
 14.0
 ```
 """
-struct Momentum{C} <: AbstractHamiltonian{Float64}
+struct Momentum{C} <: AbstractOperator{Float64}
     fold::Bool
 end
 Momentum(component=0; fold=true) = Momentum{component}(fold)
 Base.show(io::IO, mom::Momentum{C}) where {C} = print(io, "Momentum($C; fold=$(mom.fold))")
 
 LOStructure(::Type{<:Momentum}) = IsDiagonal()
+function allows_address_type(::Momentum{C}, ::Type{A}) where {C, A}
+    return C ≤ num_components(A)
+end
 
-@inline function _momentum(add::SingleComponentFockAddress, fold)
-    M = num_modes(add)
-    momentum = float(dot(-cld(M,2)+1:fld(M,2), OccupiedModeMap(add)))
+@inline function _momentum(address::SingleComponentFockAddress, fold)
+    M = num_modes(address)
+    momentum = float(dot(-cld(M,2)+1:fld(M,2), OccupiedModeMap(address)))
     if fold
         return mod1(momentum + cld(M,2), M) - cld(M,2)
     else

--- a/src/Hamiltonians/abstract.jl
+++ b/src/Hamiltonians/abstract.jl
@@ -1,13 +1,16 @@
 """
     check_address_type(h::AbstractHamiltonian, addr_or_type)
-Throw an `ArgumentError` if `addr_or_type` is not compatible with `h`. Acceptable arguments
-are either an address or an address type, or a tuple or array thereof.
+Throw an `ArgumentError` if `addr_or_type` is not compatible with `h`, otherwise return
+`true`. Acceptable arguments are either an address or an address type, or a tuple or
+array thereof.
 
-See also [`allowed_address_type`](@ref).
+See also [`allows_address_type`](@ref).
 """
 @inline function check_address_type(h, ::Type{A}) where {A}
-    B = allowed_address_type(h)
-    A <: B || throw(ArgumentError("address type mismatch: found $A, expected <: $B"))
+    if !allows_address_type(h, A)
+        throw(ArgumentError("address type $A not allowed for operator $h"))
+    end
+    return true
 end
 @inline check_address_type(h, addr) = check_address_type(h, typeof(addr))
 @inline function check_address_type(h::AbstractHamiltonian, v::Union{AbstractArray,Tuple})

--- a/src/Hamiltonians/correlation_functions.jl
+++ b/src/Hamiltonians/correlation_functions.jl
@@ -398,17 +398,20 @@ end
 """
     SuperfluidCorrelator(d::Int) <: AbstractOperator{Float64}
 
-Operator for extracting superfluid correlation between sites separated by a distance `d` with `0 ≤ d < M`:
+Operator for extracting superfluid correlation between sites separated by a distance `d`
+with `0 ≤ d < M`:
 
 ```math
     \\hat{C}_{\\text{SF}}(d) = \\frac{1}{M} \\sum_{i}^{M} a_{i}^{\\dagger} a_{i + d}
 ```
-Assumes a one-dimensional lattice with ``M`` sites and periodic boundary conditions. ``M`` is also the number of modes in the Fock state address.
+Assumes a one-dimensional lattice with ``M`` sites and periodic boundary conditions. ``M``
+is also the number of modes in the Fock state address.
 
 # Usage
-Superfluid correlations can be extracted from a Monte Carlo calculation by wrapping `SuperfluidCorrelator` with
-[`AllOverlaps`](@ref) and passing into [`ProjectorMonteCarloProblem`](@ref) with the `replica` keyword argument. For an example with a
-similar use of [`G2RealCorrelator`](@ref) see
+Superfluid correlations can be extracted from a Monte Carlo calculation by wrapping
+`SuperfluidCorrelator` with [`AllOverlaps`](@ref) and passing into
+[`ProjectorMonteCarloProblem`](@ref) with the `replica` keyword argument. For an example
+with a similar use of [`G2RealCorrelator`](@ref) see
 [G2 Correlator Example](https://joachimbrand.github.io/Rimu.jl/previews/PR227/generated/G2-example.html).
 
 
@@ -431,7 +434,9 @@ function num_offdiagonals(::SuperfluidCorrelator, addr::SingleComponentFockAddre
     return num_occupied_modes(addr)
 end
 
-function get_offdiagonal(::SuperfluidCorrelator{D}, addr::SingleComponentFockAddress, chosen) where {D}
+function get_offdiagonal(
+    ::SuperfluidCorrelator{D}, addr::SingleComponentFockAddress, chosen
+) where {D}
     src = find_occupied_mode(addr, chosen)
     dst = find_mode(addr, mod1(src.mode + D, num_modes(addr)))
     address, value = excitation(addr, (dst,), (src,))
@@ -441,7 +446,9 @@ end
 function diagonal_element(::SuperfluidCorrelator{0}, addr::SingleComponentFockAddress)
     return num_particles(addr) / num_modes(addr)
 end
-function diagonal_element(::SuperfluidCorrelator{D}, addr::SingleComponentFockAddress) where {D}
+function diagonal_element(
+    ::SuperfluidCorrelator{D}, addr::SingleComponentFockAddress
+) where {D}
     return 0.0
 end
 
@@ -449,14 +456,15 @@ end
 """
     StringCorrelator(d::Int; address=nothing, type=nothing) <: AbstractOperator{T}
 
-Operator for extracting string correlation between lattice sites on a one-dimensional Hubbard lattice
-separated by a distance `d` with `0 ≤ d < M`
+Operator for extracting string correlation between lattice sites on a one-dimensional
+Hubbard lattice separated by a distance `d` with `0 ≤ d < M`
 
 ```math
-    \\hat{C}_{\\text{string}}(d) = \\frac{1}{M} \\sum_{j}^{M} \\delta n_j (e^{i \\pi \\sum_{j \\leq k < j + d} \\delta n_k}) \\delta n_{j+d}
+    Ĉ_{\\text{string}}(d) = \\frac{1}{M} \\sum_{j}^{M} δ n̂_j
+                                         (e^{i π \\sum_{j ≤ k < j + d} δ n̂_k}) δ n̂_{j+d}
 ```
-Here, ``\\delta \\hat{n}_j = \\hat{n}_j - \\bar{n}`` is the boson number deviation from the mean filling
-number and ``\\bar{n} = N/M`` is the mean filling number of lattice sites with ``N`` particles and
+Here, ``δ n̂_j = n̂_j - n̄`` is the boson number deviation from the mean filling
+number and ``n̄ = N/M`` is the mean filling number of lattice sites with ``N`` particles and
 ``M`` lattice sites (or modes).
 
 Assumes a one-dimensional lattice with periodic boundary conditions. For usage

--- a/src/Hamiltonians/correlation_functions.jl
+++ b/src/Hamiltonians/correlation_functions.jl
@@ -187,7 +187,14 @@ function Base.show(io::IO, g2::G2RealSpace{0,0})
 end
 
 LOStructure(::Type{<:G2RealSpace}) = IsDiagonal()
-Base.valtype(::G2RealSpace) = Float64 # needed because eltype is a vector
+VectorInterface.scalartype(::G2RealSpace) = Float64 # needed because eltype is a vector
+
+function Interfaces.allows_address_type(
+    g2::G2RealSpace{C1,C2}, A::Type{<:AbstractFockAddress}
+) where {C1,C2}
+    result = prod(size(g2.geometry)) == num_modes(A)
+    return result && 0 < C1 ≤ num_components(A) && 0 < C2 ≤ num_components(A)
+end
 
 num_offdiagonals(g2::G2RealSpace, _) = 0
 

--- a/src/Hamiltonians/correlation_functions.jl
+++ b/src/Hamiltonians/correlation_functions.jl
@@ -32,7 +32,7 @@ end
 end
 
 """
-    G2RealCorrelator(d::Int) <: AbstractHamiltonian{Float64}
+    G2RealCorrelator(d::Int) <: AbstractOperator{Float64}
 
 Two-body operator for density-density correlation between sites separated by `d`
 with `0 ≤ d < M`.
@@ -62,10 +62,10 @@ equivalent to stacking all components into a single Fock state.
 * [`HubbardReal1D`](@ref)
 * [`G2RealSpace`](@ref)
 * [`G2MomCorrelator`](@ref)
-* [`AbstractHamiltonian`](@ref)
+* [`AbstractOperator`](@ref)
 * [`AllOverlaps`](@ref)
 """
-struct G2RealCorrelator{D} <: AbstractHamiltonian{Float64}
+struct G2RealCorrelator{D} <: AbstractOperator{Float64}
 end
 
 G2RealCorrelator(d::Int) = G2RealCorrelator{d}()
@@ -104,7 +104,7 @@ num_offdiagonals(::G2RealCorrelator, ::SingleComponentFockAddress) = 0
 num_offdiagonals(::G2RealCorrelator, ::CompositeFS) = 0
 
 """
-    G2RealSpace(geometry::CubicGrid, σ=1, τ=1; sum_components=false) <: AbstractHamiltonian{SArray}
+    G2RealSpace(geometry::CubicGrid, σ=1, τ=1; sum_components=false) <: AbstractOperator{SArray}
 
 Two-body operator for density-density correlation for all [`Displacements`](@ref) ``d⃗`` in the specified `geometry`.
 
@@ -157,10 +157,10 @@ julia> diagonal_element(g2_sum, fs"|⇅⋅↓↑⟩")
 * [`HubbardRealSpace`](@ref)
 * [`G2RealCorrelator`](@ref)
 * [`G2MomCorrelator`](@ref)
-* [`AbstractHamiltonian`](@ref)
+* [`AbstractOperator`](@ref)
 * [`AllOverlaps`](@ref)
 """
-struct G2RealSpace{A,B,G<:CubicGrid,S} <: AbstractHamiltonian{S}
+struct G2RealSpace{A,B,G<:CubicGrid,S} <: AbstractOperator{S}
     geometry::G
     init::S
 end
@@ -226,7 +226,7 @@ function diagonal_element(g2::G2RealSpace{0,0}, addr::CompositeFS)
 end
 
 """
-    G2MomCorrelator(d::Int,c=:cross) <: AbstractHamiltonian{ComplexF64}
+    G2MomCorrelator(d::Int,c=:cross) <: AbstractOperator{ComplexF64}
 
 Two-body correlation operator representing the density-density
 correlation at distance `d` of a two component system
@@ -267,10 +267,10 @@ and let it be the default value.
 * [`BoseFS2C`](@ref)
 * [`G2RealCorrelator`](@ref)
 * [`G2RealSpace`](@ref)
-* [`AbstractHamiltonian`](@ref)
+* [`AbstractOperator`](@ref)
 * [`AllOverlaps`](@ref)
 """
-struct G2MomCorrelator{C} <: AbstractHamiltonian{ComplexF64}
+struct G2MomCorrelator{C} <: AbstractOperator{ComplexF64}
     d::Int
 
     function G2MomCorrelator(d,c=:cross)
@@ -382,7 +382,7 @@ function get_offdiagonal(
 end
 
 """
-    SuperfluidCorrelator(d::Int) <: AbstractHamiltonian{Float64}
+    SuperfluidCorrelator(d::Int) <: AbstractOperator{Float64}
 
 Operator for extracting superfluid correlation between sites separated by a distance `d` with `0 ≤ d < M`:
 
@@ -398,10 +398,10 @@ similar use of [`G2RealCorrelator`](@ref) see
 [G2 Correlator Example](https://joachimbrand.github.io/Rimu.jl/previews/PR227/generated/G2-example.html).
 
 
-See also [`HubbardReal1D`](@ref), [`G2RealCorrelator`](@ref), [`AbstractHamiltonian`](@ref),
+See also [`HubbardReal1D`](@ref), [`G2RealCorrelator`](@ref), [`AbstractOperator`](@ref),
 and [`AllOverlaps`](@ref).
 """
-struct SuperfluidCorrelator{D} <: AbstractHamiltonian{Float64}
+struct SuperfluidCorrelator{D} <: AbstractOperator{Float64}
 end
 
 SuperfluidCorrelator(d::Int) = SuperfluidCorrelator{d}()
@@ -430,7 +430,7 @@ end
 
 
 """
-    StringCorrelator(d::Int) <: AbstractHamiltonian{Float64}
+    StringCorrelator(d::Int) <: AbstractOperator{Float64}
 
 Operator for extracting string correlation between lattice sites on a one-dimensional Hubbard lattice
 separated by a distance `d` with `0 ≤ d < M`
@@ -446,9 +446,9 @@ Assumes a one-dimensional lattice with periodic boundary conditions. For usage
 see [`SuperfluidCorrelator`](@ref) and [`AllOverlaps`](@ref).
 
 See also [`HubbardReal1D`](@ref), [`G2RealCorrelator`](@ref), [`SuperfluidCorrelator`](@ref),
-[`AbstractHamiltonian`](@ref), and [`AllOverlaps`](@ref).
+[`AbstractOperator`](@ref), and [`AllOverlaps`](@ref).
 """
-struct StringCorrelator{D} <: AbstractHamiltonian{Float64}
+struct StringCorrelator{D} <: AbstractOperator{Float64}
 end
 
 StringCorrelator(d::Int) = StringCorrelator{d}()

--- a/src/Hamiltonians/correlation_functions.jl
+++ b/src/Hamiltonians/correlation_functions.jl
@@ -187,6 +187,7 @@ function Base.show(io::IO, g2::G2RealSpace{0,0})
 end
 
 LOStructure(::Type{<:G2RealSpace}) = IsDiagonal()
+Base.valtype(::G2RealSpace) = Float64 # needed because eltype is a vector
 
 num_offdiagonals(g2::G2RealSpace, _) = 0
 

--- a/src/Hamiltonians/correlation_functions.jl
+++ b/src/Hamiltonians/correlation_functions.jl
@@ -75,28 +75,31 @@ function Base.show(io::IO, ::G2RealCorrelator{D}) where {D}
 end
 
 LOStructure(::Type{<:G2RealCorrelator}) = IsDiagonal()
+function Interfaces.allows_address_type(::G2RealCorrelator{D}, ::Type{A}) where {D,A}
+    return num_modes(A) > D
+end
 
-function diagonal_element(::G2RealCorrelator{0}, add::SingleComponentFockAddress)
-    M = num_modes(add)
-    v = onr(add)
+function diagonal_element(::G2RealCorrelator{0}, addr::SingleComponentFockAddress)
+    M = num_modes(addr)
+    v = onr(addr)
     return dot(v, v .- 1) / M
 end
-function diagonal_element(::G2RealCorrelator{D}, add::SingleComponentFockAddress) where {D}
-    M = num_modes(add)
+function diagonal_element(::G2RealCorrelator{D}, addr::SingleComponentFockAddress) where {D}
+    M = num_modes(addr)
     d = mod(D, M)
-    v = onr(add)
+    v = onr(addr)
     return circshift_dot(v, v, (d,)) / M
 end
 
-function diagonal_element(::G2RealCorrelator{0}, add::CompositeFS)
-    M = num_modes(add)
-    v = sum(map(onr, add.components))
+function diagonal_element(::G2RealCorrelator{0}, addr::CompositeFS)
+    M = num_modes(addr)
+    v = sum(map(onr, addr.components))
     return dot(v, v .- 1) / M
 end
-function diagonal_element(::G2RealCorrelator{D}, add::CompositeFS) where {D}
-    M = num_modes(add)
+function diagonal_element(::G2RealCorrelator{D}, addr::CompositeFS) where {D}
+    M = num_modes(addr)
     d = mod(D, M)
-    v = sum(map(onr, add.components))
+    v = sum(map(onr, addr.components))
     return circshift_dot(v, v, (d,)) / M
 end
 
@@ -295,6 +298,10 @@ end
 @deprecate G2Correlator(d,c) G2MomCorrelator(d,c)
 @deprecate G2Correlator(d) G2MomCorrelator(d)
 
+function Interfaces.allows_address_type(g2m::G2MomCorrelator, ::Type{A}) where {A}
+    return num_modes(A) > g2m.d
+end
+
 function Base.show(io::IO, g::G2MomCorrelator{C}) where C
     if C == 1
         print(io, "G2MomCorrelator($(g.d),:first)")
@@ -306,28 +313,28 @@ function Base.show(io::IO, g::G2MomCorrelator{C}) where C
 end
 
 
-num_offdiagonals(g::G2MomCorrelator{1},add::BoseFS2C) = num_offdiagonals(g, add.bsa)
-num_offdiagonals(g::G2MomCorrelator{2},add::BoseFS2C) = num_offdiagonals(g, add.bsb)
+num_offdiagonals(g::G2MomCorrelator{1},addr::BoseFS2C) = num_offdiagonals(g, addr.bsa)
+num_offdiagonals(g::G2MomCorrelator{2},addr::BoseFS2C) = num_offdiagonals(g, addr.bsb)
 
-function num_offdiagonals(g::G2MomCorrelator{3}, add::BoseFS2C)
-    m = num_modes(add)
-    sa = num_occupied_modes(add.bsa)
-    sb = num_occupied_modes(add.bsb)
+function num_offdiagonals(g::G2MomCorrelator{3}, addr::BoseFS2C)
+    m = num_modes(addr)
+    sa = num_occupied_modes(addr.bsa)
+    sb = num_occupied_modes(addr.bsb)
     return sa*(m-1)*sb
 end
 
-function num_offdiagonals(g::G2MomCorrelator, add::SingleComponentFockAddress)
-    m = num_modes(add)
-    singlies, doublies = num_singly_doubly_occupied_sites(add)
+function num_offdiagonals(g::G2MomCorrelator, addr::SingleComponentFockAddress)
+    m = num_modes(addr)
+    singlies, doublies = num_singly_doubly_occupied_sites(addr)
     return singlies*(singlies-1)*(m - 2) + doublies*(m - 1)
 end
 
-diagonal_element(g::G2MomCorrelator{1}, add::BoseFS2C) = diagonal_element(g, add.bsa)
-diagonal_element(g::G2MomCorrelator{2}, add::BoseFS2C) = diagonal_element(g, add.bsb)
+diagonal_element(g::G2MomCorrelator{1}, addr::BoseFS2C) = diagonal_element(g, addr.bsa)
+diagonal_element(g::G2MomCorrelator{2}, addr::BoseFS2C) = diagonal_element(g, addr.bsb)
 
-function diagonal_element(g::G2MomCorrelator{3}, add::BoseFS2C{NA,NB,M,AA,AB}) where {NA,NB,M,AA,AB}
-    onrep_a = onr(add.bsa)
-    onrep_b = onr(add.bsb)
+function diagonal_element(g::G2MomCorrelator{3}, addr::BoseFS2C{NA,NB,M,AA,AB}) where {NA,NB,M,AA,AB}
+    onrep_a = onr(addr.bsa)
+    onrep_b = onr(addr.bsb)
     gd = 0
     for p in 1:M
         iszero(onrep_b[p]) && continue
@@ -338,9 +345,9 @@ function diagonal_element(g::G2MomCorrelator{3}, add::BoseFS2C{NA,NB,M,AA,AB}) w
     return ComplexF64(gd/M)
 end
 
-function diagonal_element(g::G2MomCorrelator, add::SingleComponentFockAddress)
-    M = num_modes(add)
-    onrep = onr(add)
+function diagonal_element(g::G2MomCorrelator, addr::SingleComponentFockAddress)
+    M = num_modes(addr)
+    onrep = onr(addr)
     gd = 0
     for p in 1:M
         iszero(onrep[p]) && continue
@@ -351,27 +358,27 @@ function diagonal_element(g::G2MomCorrelator, add::SingleComponentFockAddress)
     return ComplexF64(gd/M)
 end
 
-function get_offdiagonal(g::G2MomCorrelator{1}, add::A, chosen)::Tuple{A,ComplexF64} where A<:BoseFS2C
-    new_bsa, elem = get_offdiagonal(g, add.bsa, chosen)
-    return A(new_bsa,add.bsb), elem
+function get_offdiagonal(g::G2MomCorrelator{1}, addr::A, chosen)::Tuple{A,ComplexF64} where A<:BoseFS2C
+    new_bsa, elem = get_offdiagonal(g, addr.bsa, chosen)
+    return A(new_bsa,addr.bsb), elem
 end
 
-function get_offdiagonal(g::G2MomCorrelator{2}, add::A, chosen)::Tuple{A,ComplexF64} where A<:BoseFS2C
-    new_bsb, elem = get_offdiagonal(g, add.bsb, chosen)
-    return A(add.bsa, new_bsb), elem
+function get_offdiagonal(g::G2MomCorrelator{2}, addr::A, chosen)::Tuple{A,ComplexF64} where A<:BoseFS2C
+    new_bsb, elem = get_offdiagonal(g, addr.bsb, chosen)
+    return A(addr.bsa, new_bsb), elem
 end
 
 function get_offdiagonal(
     g::G2MomCorrelator{3},
-    add::A,
+    addr::A,
     chosen,
-    ma=OccupiedModeMap(add.bsa),
-    mb=OccupiedModeMap(add.bsb),
+    ma=OccupiedModeMap(addr.bsa),
+    mb=OccupiedModeMap(addr.bsb),
 )::Tuple{A,ComplexF64} where {A<:BoseFS2C}
 
-    m = num_modes(add)
+    m = num_modes(addr)
     new_bsa, new_bsb, gamma, _, _, Δp = momentum_transfer_excitation(
-        add.bsa, add.bsb, chosen, ma, mb
+        addr.bsa, addr.bsb, chosen, ma, mb
     )
     gd = exp(-im*g.d*Δp*2π/m)*gamma
     return A(new_bsa, new_bsb), ComplexF64(gd/m)
@@ -379,11 +386,11 @@ end
 
 function get_offdiagonal(
     g::G2MomCorrelator,
-    add::A,
+    addr::A,
     chosen,
 )::Tuple{A,ComplexF64} where {A<:SingleComponentFockAddress}
-    M = num_modes(add)
-    new_add, gamma, Δp = momentum_transfer_excitation(add, chosen, OccupiedModeMap(add))
+    M = num_modes(addr)
+    new_add, gamma, Δp = momentum_transfer_excitation(addr, chosen, OccupiedModeMap(addr))
     gd = exp(-im*g.d*Δp*2π/M)*gamma
     return new_add, ComplexF64(gd/M)
 end
@@ -416,28 +423,31 @@ SuperfluidCorrelator(d::Int) = SuperfluidCorrelator{d}()
 function Base.show(io::IO, ::SuperfluidCorrelator{D}) where {D}
     print(io, "SuperfluidCorrelator($D)")
 end
-
-function num_offdiagonals(::SuperfluidCorrelator, add::SingleComponentFockAddress)
-    return num_occupied_modes(add)
+function Interfaces.allows_address_type(::SuperfluidCorrelator{D}, ::Type{A}) where {D,A}
+    return num_modes(A) > D
 end
 
-function get_offdiagonal(::SuperfluidCorrelator{D}, add::SingleComponentFockAddress, chosen) where {D}
-    src = find_occupied_mode(add, chosen)
-    dst = find_mode(add, mod1(src.mode + D, num_modes(add)))
-    address, value = excitation(add, (dst,), (src,))
-    return address, value / num_modes(add)
+function num_offdiagonals(::SuperfluidCorrelator, addr::SingleComponentFockAddress)
+    return num_occupied_modes(addr)
 end
 
-function diagonal_element(::SuperfluidCorrelator{0}, add::SingleComponentFockAddress)
-    return num_particles(add) / num_modes(add)
+function get_offdiagonal(::SuperfluidCorrelator{D}, addr::SingleComponentFockAddress, chosen) where {D}
+    src = find_occupied_mode(addr, chosen)
+    dst = find_mode(addr, mod1(src.mode + D, num_modes(addr)))
+    address, value = excitation(addr, (dst,), (src,))
+    return address, value / num_modes(addr)
 end
-function diagonal_element(::SuperfluidCorrelator{D}, add::SingleComponentFockAddress) where {D}
+
+function diagonal_element(::SuperfluidCorrelator{0}, addr::SingleComponentFockAddress)
+    return num_particles(addr) / num_modes(addr)
+end
+function diagonal_element(::SuperfluidCorrelator{D}, addr::SingleComponentFockAddress) where {D}
     return 0.0
 end
 
 
 """
-    StringCorrelator(d::Int) <: AbstractOperator{Float64}
+    StringCorrelator(d::Int; address=nothing, type=nothing) <: AbstractOperator{T}
 
 Operator for extracting string correlation between lattice sites on a one-dimensional Hubbard lattice
 separated by a distance `d` with `0 ≤ d < M`
@@ -452,25 +462,50 @@ number and ``\\bar{n} = N/M`` is the mean filling number of lattice sites with `
 Assumes a one-dimensional lattice with periodic boundary conditions. For usage
 see [`SuperfluidCorrelator`](@ref) and [`AllOverlaps`](@ref).
 
+The default element type `T` is `ComplexF64`. This can be overridden with the `type` keyword
+argument. If an `address` is provided, then `T` is calculated from the address type.
+It is set to `ComplexF64` for non-integer filling numbers, and to `Float64` for integer
+filling numbers or if `d==0`.
+
 See also [`HubbardReal1D`](@ref), [`G2RealCorrelator`](@ref), [`SuperfluidCorrelator`](@ref),
 [`AbstractOperator`](@ref), and [`AllOverlaps`](@ref).
 """
-struct StringCorrelator{D} <: AbstractOperator{Float64}
+struct StringCorrelator{D,T} <: AbstractOperator{T}
 end
 
-StringCorrelator(d::Int) = StringCorrelator{d}()
+function StringCorrelator(d::Int; address=nothing, type=nothing)
+    if type === nothing
+        if iszero(d)
+            type = Float64
+        elseif address === nothing
+            type = ComplexF64
+        else
+            M = num_modes(address)
+            N = num_particles(address)
+            if !ismissing(N) && iszero(N % M)
+                type = Float64
+            else
+                type = ComplexF64
+            end
+        end
+    end
+    return StringCorrelator{d,type}()
+end
 
-function Base.show(io::IO, ::StringCorrelator{D}) where {D}
-    print(io, "StringCorrelator($D)")
+function Base.show(io::IO, ::StringCorrelator{D,T}) where {D,T}
+    print(io, "StringCorrelator($D; type=$T)")
+end
+function Interfaces.allows_address_type(::StringCorrelator{D}, ::Type{A}) where {D,A}
+    return num_modes(A) > D && A <: SingleComponentFockAddress
 end
 
 LOStructure(::Type{<:StringCorrelator}) = IsDiagonal()
 
-function diagonal_element(::StringCorrelator{0}, add::SingleComponentFockAddress)
-    M = num_modes(add)
-    N = num_particles(add)
+function diagonal_element(::StringCorrelator{0}, addr::SingleComponentFockAddress)
+    M = num_modes(addr)
+    N = num_particles(addr)
     n̄ = N/M
-    v = onr(add)
+    v = onr(addr)
 
     result = 0.0
     for i in eachindex(v)
@@ -482,23 +517,25 @@ end
 
 num_offdiagonals(::StringCorrelator, ::SingleComponentFockAddress) = 0
 
-function diagonal_element(::StringCorrelator{D}, add::SingleComponentFockAddress) where {D}
-    M = num_modes(add)
-    N = num_particles(add)
+function diagonal_element(
+    ::StringCorrelator{D,T}, addr::SingleComponentFockAddress
+) where {D,T}
+    M = num_modes(addr)
+    N = num_particles(addr)
     d = mod(D, M)
 
     if !ismissing(N) && iszero(N % M)
-        return _string_diagonal_real(d, add)
+        return T(_string_diagonal_real(d, addr))
     else
-        return _string_diagonal_complex(d, add)
+        return T(_string_diagonal_complex(d, addr))
     end
 end
 
-function _string_diagonal_complex(d, add)
-    M = num_modes(add)
-    N = num_particles(add)
+function _string_diagonal_complex(d, addr)
+    M = num_modes(addr)
+    N = num_particles(addr)
     n̄ = N/M
-    v = onr(add)
+    v = onr(addr)
 
     result = ComplexF64(0)
     for i in eachindex(v)
@@ -509,11 +546,11 @@ function _string_diagonal_complex(d, add)
 
     return result / M
 end
-function _string_diagonal_real(d, add)
-    M = num_modes(add)
-    N = num_particles(add)
+function _string_diagonal_real(d, addr)
+    M = num_modes(addr)
+    N = num_particles(addr)
     n̄ = N ÷ M
-    v = onr(add)
+    v = onr(addr)
 
     result = 0.0
     for i in eachindex(v)

--- a/src/Hamiltonians/correlation_functions.jl
+++ b/src/Hamiltonians/correlation_functions.jl
@@ -193,7 +193,7 @@ function Interfaces.allows_address_type(
     g2::G2RealSpace{C1,C2}, A::Type{<:AbstractFockAddress}
 ) where {C1,C2}
     result = prod(size(g2.geometry)) == num_modes(A)
-    return result && 0 < C1 ≤ num_components(A) && 0 < C2 ≤ num_components(A)
+    return result && 0 ≤ C1 ≤ num_components(A) && 0 ≤ C2 ≤ num_components(A)
 end
 
 num_offdiagonals(g2::G2RealSpace, _) = 0

--- a/src/Hamiltonians/offdiagonals.jl
+++ b/src/Hamiltonians/offdiagonals.jl
@@ -18,7 +18,7 @@ See [`Offdiagonals`](@ref) for a default implementation.
   `get_offdiagonal(h, a, i)`.
 * `Base.size(::AbstractOffdiagonals)`: should be equivalent to `num_offdiagonals(h, a)`.
 
-See also [`offdiagonals`](@ref), [`AbstractHamiltonian`](@ref).
+See also [`offdiagonals`](@ref), [`AbstractHamiltonian`](@ref), [`AbstractOperator`](@ref).
 """
 abstract type AbstractOffdiagonals{A,T} <: AbstractVector{Tuple{A,T}} end
 
@@ -37,9 +37,9 @@ construct this iterator use [`offdiagonals`](@ref).
 This is the default implementation of [`AbstractOffdiagonals`](@ref) defined in terms of
 [`num_offdiagonals`](@ref) and [`get_offdiagonal`](@ref).
 
-See also [`offdiagonals`](@ref), [`AbstractHamiltonian`](@ref).
+See also [`offdiagonals`](@ref), [`AbstractHamiltonian`](@ref), [`AbstractOperator`](@ref).
 """
-struct Offdiagonals{A,T,H<:AbstractHamiltonian{T}} <: AbstractOffdiagonals{A,T}
+struct Offdiagonals{A,T,H<:AbstractOperator{T}} <: AbstractOffdiagonals{A,T}
     hamiltonian::H
     address::A
     length::Int

--- a/src/Hamiltonians/particle_number.jl
+++ b/src/Hamiltonians/particle_number.jl
@@ -30,9 +30,15 @@ end
 LOStructure(::Type{<:ParticleNumberOperator}) = IsDiagonal()
 starting_address(n::ParticleNumberOperator) = n.address
 
-function diagonal_element(::ParticleNumberOperator, addr::AbstractFockAddress)
+function diagonal_element(
+    ::ParticleNumberOperator{<:AbstractFockAddress},
+    addr::AbstractFockAddress
+)
     return float(num_particles(addr))
 end
-function allows_address_type(::ParticleNumberOperator, ::Type{A}) where {A}
-    return A <: AbstractFockAddress
+function allows_address_type(
+    ::ParticleNumberOperator{<:AbstractFockAddress},
+    ::Type{B}
+) where {B}
+    return B <: AbstractFockAddress
 end

--- a/src/Hamiltonians/particle_number.jl
+++ b/src/Hamiltonians/particle_number.jl
@@ -33,4 +33,6 @@ starting_address(n::ParticleNumberOperator) = n.address
 function diagonal_element(::ParticleNumberOperator, addr::AbstractFockAddress)
     return float(num_particles(addr))
 end
-allowed_address_type(::ParticleNumberOperator) = AbstractFockAddress
+function allows_address_type(::ParticleNumberOperator, ::Type{A}) where {A}
+    return A <: AbstractFockAddress
+end

--- a/src/Hamiltonians/particle_number.jl
+++ b/src/Hamiltonians/particle_number.jl
@@ -1,13 +1,14 @@
 """
-    ParticleNumberOperator([address]) <: AbstractHamiltonian
+    ParticleNumberOperator() <: AbstractOperator{Float64}
 
 The number operator in Fock space. This operator is diagonal in the Fock basis and
-returns the number of particles in the Fock state. Passing an address is optional.
+returns the number of particles in the Fock state. It works with any address type that
+is a subtype of [`AbstractFockAddress`](@ref).
 
 ```jldoctest; filter = r"(\\d*)\\.(\\d{4})\\d+" => s"\\1.\\2***"
-julia> h = FroehlichPolaron(fs"|0 0⟩{}"; mode_cutoff=5, v=3); bsr = BasisSetRepresentation(h);
+julia> p = ExactDiagonalizationProblem(FroehlichPolaron(fs"|0 0⟩{}"; mode_cutoff=5, v=3));
 
-julia> gs = DVec(zip(bsr.basis, eigen(Matrix(bsr)).vectors[:,1])); # ground state
+julia> gs = solve(p).vectors[1]; # normalised ground state vector
 
 julia> dot(gs, ParticleNumberOperator(), gs) # particle number expectation value
 2.8823297252925917
@@ -15,30 +16,13 @@ julia> dot(gs, ParticleNumberOperator(), gs) # particle number expectation value
 
 See also [`AbstractHamiltonian`](@ref).
 """
-struct ParticleNumberOperator{A} <: AbstractHamiltonian{Float64}
-    address::A
-end
-ParticleNumberOperator() = ParticleNumberOperator(BoseFS(1,))
-
-function Base.show(io::IO, n::ParticleNumberOperator)
-    io = IOContext(io, :compact => true)
-    print(io, "ParticleNumberOperator(")
-    n.address === BoseFS(1,) || show(io, n.address) # suppress if default
-    print(io, ")")
-end
+struct ParticleNumberOperator <: AbstractOperator{Float64} end
 
 LOStructure(::Type{<:ParticleNumberOperator}) = IsDiagonal()
-starting_address(n::ParticleNumberOperator) = n.address
 
-function diagonal_element(
-    ::ParticleNumberOperator{<:AbstractFockAddress},
-    addr::AbstractFockAddress
-)
+function diagonal_element(::ParticleNumberOperator, addr::AbstractFockAddress)
     return float(num_particles(addr))
 end
-function allows_address_type(
-    ::ParticleNumberOperator{<:AbstractFockAddress},
-    ::Type{B}
-) where {B}
+function allows_address_type(::ParticleNumberOperator, ::Type{B}) where {B}
     return B <: AbstractFockAddress
 end

--- a/src/Hamiltonians/reduced_density_matrix.jl
+++ b/src/Hamiltonians/reduced_density_matrix.jl
@@ -4,7 +4,7 @@
 Represent the ``{i,j}`` element of the single-particle reduced density matrix:
 
 ```math
-\\hat{ρ}^{(1)}_{i,j} = \\hat a^†_{i} \\hat a_{j}
+\\hat{ρ̂}^{(1)}_{i,j} = \\hat a^†_{i} \\hat a_{j}
 ```
 
 where `i <: Int` and `j <: Int` specify the mode numbers.
@@ -15,7 +15,7 @@ where `i <: Int` and `j <: Int` specify the mode numbers.
 * [`SingleParticleDensity`](@ref)
 * [`TwoParticleExcitation`](@ref)
 """
-struct SingleParticleExcitation{I,J} <: AbstractHamiltonian{Float64}
+struct SingleParticleExcitation{I,J} <: AbstractOperator{Float64}
 end
 
 SingleParticleExcitation(I::Int,J::Int) = SingleParticleExcitation{I,J}()
@@ -25,6 +25,9 @@ function Base.show(io::IO, spd::SingleParticleExcitation{I,J}) where {I,J}
 end
 
 LOStructure(::Type{<:SingleParticleExcitation}) = AdjointUnknown()
+function allows_address_type(::SingleParticleExcitation{I,J}, ::Type{A}) where {I,J,A}
+    return A <: SingleComponentFockAddress && I ≤ num_modes(A) && J ≤ num_modes(A)
+end
 
 function diagonal_element(spd::SingleParticleExcitation{I,J}, add::SingleComponentFockAddress) where {I,J}
     if I != J
@@ -55,7 +58,7 @@ end
 Represent the ``{ij, kl}`` element of the two-particle reduced density matrix:
 
 ```math
-\\hat{ρ}^{(2)}_{ij, kl} =  \\hat a^†_{i} \\hat a^†_{j} \\hat a_{l} \\hat a_{k} 
+\\hat{ρ̂}^{(2)}_{ij, kl} =  \\hat a^†_{i} \\hat a^†_{j} \\hat a_{l} \\hat a_{k}
 ```
 
 where `i`, `j`, `k`, and `l` (all `<: Int`) specify the mode numbers.
@@ -66,7 +69,7 @@ where `i`, `j`, `k`, and `l` (all `<: Int`) specify the mode numbers.
 * [`SingleParticleDensity`](@ref)
 * [`SingleParticleExcitation`](@ref)
 """
-struct TwoParticleExcitation{I,J,K,L} <: AbstractHamiltonian{Float64}
+struct TwoParticleExcitation{I,J,K,L} <: AbstractOperator{Float64}
 end
 
 TwoParticleExcitation(I::Int,J::Int,K::Int,L::Int) = TwoParticleExcitation{I,J,K,L}()
@@ -76,6 +79,10 @@ function Base.show(io::IO, spd::TwoParticleExcitation{I,J,K,L}) where {I,J,K,L}
 end
 
 LOStructure(::Type{<:TwoParticleExcitation}) = AdjointUnknown()
+function allows_address_type(::TwoParticleExcitation{I,J,K,L}, ::Type{A}) where {I,J,K,L,A}
+    return A <: SingleComponentFockAddress && I ≤ num_modes(A) && J ≤ num_modes(A) &&
+            K ≤ num_modes(A) && L ≤ num_modes(A)
+end
 
 function diagonal_element(spd::TwoParticleExcitation{I,J,K,L}, add::SingleComponentFockAddress) where {I,J,K,L}
     if (I, J) == (K, L) || (I, J) == (L, K)

--- a/src/Hamiltonians/reduced_density_matrix.jl
+++ b/src/Hamiltonians/reduced_density_matrix.jl
@@ -4,7 +4,7 @@
 Represent the ``{i,j}`` element of the single-particle reduced density matrix:
 
 ```math
-\\hat{ρ̂}^{(1)}_{i,j} = \\hat a^†_{i} \\hat a_{j}
+ρ̂^{(1)}_{i,j} = â^†_{i} â_{j}
 ```
 
 where `i <: Int` and `j <: Int` specify the mode numbers.
@@ -20,7 +20,7 @@ end
 
 SingleParticleExcitation(I::Int,J::Int) = SingleParticleExcitation{I,J}()
 
-function Base.show(io::IO, spd::SingleParticleExcitation{I,J}) where {I,J}
+function Base.show(io::IO, ::SingleParticleExcitation{I,J}) where {I,J}
     print(io, "SingleParticleExcitation($(I), $(J))")
 end
 
@@ -29,15 +29,19 @@ function allows_address_type(::SingleParticleExcitation{I,J}, ::Type{A}) where {
     return A <: SingleComponentFockAddress && I ≤ num_modes(A) && J ≤ num_modes(A)
 end
 
-function diagonal_element(spd::SingleParticleExcitation{I,J}, add::SingleComponentFockAddress) where {I,J}
+function diagonal_element(
+    ::SingleParticleExcitation{I,J}, addr::SingleComponentFockAddress
+) where {I,J}
     if I != J
         return 0.0
     end
-    src = find_mode(add, J)
+    src = find_mode(addr, J)
     return src.occnum
 end
 
-function num_offdiagonals(spd::SingleParticleExcitation{I,J}, address::SingleComponentFockAddress) where {I,J}
+function num_offdiagonals(
+    ::SingleParticleExcitation{I,J}, ::SingleComponentFockAddress
+) where {I,J}
     if I == J
         return 0
     else
@@ -45,10 +49,12 @@ function num_offdiagonals(spd::SingleParticleExcitation{I,J}, address::SingleCom
     end
 end
 
-function get_offdiagonal(spd::SingleParticleExcitation{I,J}, add::SingleComponentFockAddress, chosen) where {I,J}
-    src = find_mode(add, J)
-    dst = find_mode(add,I)
-    address, value = excitation(add, (dst,), (src,))
+function get_offdiagonal(
+    ::SingleParticleExcitation{I,J}, addr::SingleComponentFockAddress, _
+) where {I,J}
+    src = find_mode(addr, J)
+    dst = find_mode(addr,I)
+    address, value = excitation(addr, (dst,), (src,))
     return address, value
 end
 
@@ -58,7 +64,7 @@ end
 Represent the ``{ij, kl}`` element of the two-particle reduced density matrix:
 
 ```math
-\\hat{ρ̂}^{(2)}_{ij, kl} =  \\hat a^†_{i} \\hat a^†_{j} \\hat a_{l} \\hat a_{k}
+ρ̂^{(2)}_{ij, kl} =  â^†_{i} â^†_{j} â_{l} â_{k}
 ```
 
 where `i`, `j`, `k`, and `l` (all `<: Int`) specify the mode numbers.
@@ -74,7 +80,7 @@ end
 
 TwoParticleExcitation(I::Int,J::Int,K::Int,L::Int) = TwoParticleExcitation{I,J,K,L}()
 
-function Base.show(io::IO, spd::TwoParticleExcitation{I,J,K,L}) where {I,J,K,L}
+function Base.show(io::IO, ::TwoParticleExcitation{I,J,K,L}) where {I,J,K,L}
     print(io, "TwoParticleExcitation($(I), $(J), $(K), $(L))")
 end
 
@@ -84,18 +90,22 @@ function allows_address_type(::TwoParticleExcitation{I,J,K,L}, ::Type{A}) where 
             K ≤ num_modes(A) && L ≤ num_modes(A)
 end
 
-function diagonal_element(spd::TwoParticleExcitation{I,J,K,L}, add::SingleComponentFockAddress) where {I,J,K,L}
+function diagonal_element(
+    ::TwoParticleExcitation{I,J,K,L}, addr::SingleComponentFockAddress
+) where {I,J,K,L}
     if (I, J) == (K, L) || (I, J) == (L, K)
-        src = find_mode(add, (L, K))
-        dst = find_mode(add,(I, J))
-        address, value = excitation(add, dst, src)
+        src = find_mode(addr, (L, K))
+        dst = find_mode(addr,(I, J))
+        _, value = excitation(addr, dst, src)
         return value
     else
         return 0.0
     end
 end
 
-function num_offdiagonals(spd::TwoParticleExcitation{I,J,K,L}, address::SingleComponentFockAddress) where {I,J,K,L}
+function num_offdiagonals(
+    ::TwoParticleExcitation{I,J,K,L}, ::SingleComponentFockAddress
+) where {I,J,K,L}
     if (I, J) == (K, L)
         return 0
     else
@@ -103,9 +113,11 @@ function num_offdiagonals(spd::TwoParticleExcitation{I,J,K,L}, address::SingleCo
     end
 end
 
-function get_offdiagonal(spd::TwoParticleExcitation{I,J,K,L}, add::SingleComponentFockAddress, chosen) where {I,J,K,L}
-    src = find_mode(add, (L, K))
-    dst = find_mode(add,(I, J))
-    address, value = excitation(add, (dst...,), (src...,))
+function get_offdiagonal(
+    ::TwoParticleExcitation{I,J,K,L}, addr::SingleComponentFockAddress, _
+) where {I,J,K,L}
+    src = find_mode(addr, (L, K))
+    dst = find_mode(addr,(I, J))
+    address, value = excitation(addr, (dst...,), (src...,))
     return address, value
 end

--- a/src/Interfaces/Interfaces.jl
+++ b/src/Interfaces/Interfaces.jl
@@ -39,7 +39,7 @@ Follow the links for the definitions of the interfaces!
 module Interfaces
 
 using LinearAlgebra: LinearAlgebra, diag
-using VectorInterface: VectorInterface, add, zerovector!
+using VectorInterface: VectorInterface, add, zerovector!, scalartype
 
 import OrderedCollections: freeze
 

--- a/src/Interfaces/Interfaces.jl
+++ b/src/Interfaces/Interfaces.jl
@@ -6,6 +6,7 @@ This module contains interfaces that can be used to extend and modify the algori
 # Interfaces
 Follow the links for the definitions of the interfaces!
 * [`AbstractHamiltonian`](@ref) for defining [`Hamiltonians`](@ref Main.Hamiltonians)
+* [`AbstractOperator`](@ref) for defining observable operators
 * [`AbstractDVec`](@ref) for defining data structures for `Rimu` as in [`DictVectors`](@ref Main.DictVectors)
 * [`StochasticStyle`](@ref) for controlling the stochastic algorithms used by
   [`ProjectorMonteCarloProblem`](@ref Main.ProjectorMonteCarloProblem) as implemented in
@@ -51,7 +52,8 @@ export
 export
     AbstractHamiltonian, diagonal_element, num_offdiagonals, get_offdiagonal, offdiagonals,
     random_offdiagonal, starting_address, allows_address_type,
-    LOStructure, IsDiagonal, IsHermitian, AdjointKnown, AdjointUnknown, has_adjoint
+    LOStructure, IsDiagonal, IsHermitian, AdjointKnown, AdjointUnknown, has_adjoint,
+    AbstractOperator
 
 include("stochasticstyles.jl")
 include("dictvectors.jl")

--- a/src/Interfaces/Interfaces.jl
+++ b/src/Interfaces/Interfaces.jl
@@ -21,7 +21,7 @@ Follow the links for the definitions of the interfaces!
 * [`random_offdiagonal`](@ref)
 * [`starting_address`](@ref)
 * [`LOStructure`](@ref)
-* [`allowed_address_type`](@ref)
+* [`allows_address_type`](@ref)
 
 ## working with  [`AbstractDVec`](@ref)s and [`StochasticStyle`](@ref)
 * [`deposit!`](@ref)
@@ -50,7 +50,7 @@ export
     apply_operator!, sort_into_targets!
 export
     AbstractHamiltonian, diagonal_element, num_offdiagonals, get_offdiagonal, offdiagonals,
-    random_offdiagonal, starting_address, allowed_address_type,
+    random_offdiagonal, starting_address, allows_address_type,
     LOStructure, IsDiagonal, IsHermitian, AdjointKnown, AdjointUnknown, has_adjoint
 
 include("stochasticstyles.jl")

--- a/src/Interfaces/hamiltonians.jl
+++ b/src/Interfaces/hamiltonians.jl
@@ -19,10 +19,10 @@ calculated with [`dot(x, op, y)`](@ref LinearAlgebra.dot).
 
 The `AbstractOperator` type is useful for defining operators that are not necessarily
 Hamiltonians, but that can be used in the context of a [`ProjectorMonteCarloProblem`](@ref)
-as observable operators in a [`ReplicaStrategy`](@ref), e.g. for defining correlation
-functions. In contrast to [`AbstractHamiltonian`](@ref)s, `AbstractOperator`s do not need
-to have a [`starting_address`](@ref). Moreover, the `eltype` of an `AbstractOperator` can
-be a vector value.
+as observable operators in a [`ReplicaStrategy`](@ref Rimu.ReplicaStrategy), e.g. for
+defining correlation functions. In contrast to [`AbstractHamiltonian`](@ref)s,
+`AbstractOperator`s do not need to have a [`starting_address`](@ref). Moreover, the
+`eltype` of an `AbstractOperator` can be a vector value.
 
 For concrete implementations see [`Hamiltonians`](@ref Main.Hamiltonians). In order to
 implement a Hamiltonian for use in [`ProjectorMonteCarloProblem`](@ref) or
@@ -77,7 +77,7 @@ VectorInterface.scalartype(::Type{<:AbstractOperator{T}}) where T = eltype(T)
 In place multiplication of `op` with `v` and storing the result in `w`. The result is
 returned. Note that `w` needs to have a `valtype` that can hold a product of instances
 of `eltype(op)` and `valtype(v)`. Moreover, the [`StochasticStyle`](@ref) of `w` needs to
-be [`<: IsDeterministic`](@ref IsDeterministic).
+be [`<: IsDeterministic`](@ref Rimu.StochasticStyles.IsDeterministic).
 
 Part of the [`AbstractOperator`](@ref) interface.
 

--- a/src/Interfaces/hamiltonians.jl
+++ b/src/Interfaces/hamiltonians.jl
@@ -14,15 +14,20 @@ module `DictVectors` and work well with addresses of type
 from the module `BitStringAddresses`.
 
 The defining feature of an `AbstractOperator` is that it can be applied to a vector with
-[`mul!(y, op, x)`](@ref LinearAlgebra.mul!) and that three-way dot products are defined with
-[`dot(x, op, y)`](@ref LinearAlgebra.mul!).
+[`mul!(y, op, x)`](@ref LinearAlgebra.mul!) and that three-way dot products can be
+calculated with [`dot(x, op, y)`](@ref LinearAlgebra.dot).
 
 The `AbstractOperator` type is useful for defining operators that are not necessarily
-Hamiltonians, but that can be used in the context of FCIQMC as observable operators, e.g.
-for defining correlation functions. For concrete implementations see
-[`Hamiltonians`](@ref Main.Hamiltonians). In order to implement a Hamiltonian for use in
-[`ProjectorMonteCarloProblem`](@ref) or [`ExactDiagonalizationProblem`](@ref) use the type
-[`AbstractHamiltonian`](@ref) instead, which is a subtype of `AbstractOperator`.
+Hamiltonians, but that can be used in the context of a [`ProjectorMonteCarloProblem`](@ref)
+as observable operators in a [`ReplicaStrategy`](@ref), e.g. for defining correlation
+functions. In contrast to [`AbstractHamiltonian`](@ref)s, `AbstractOperator`s do not need
+to have a [`starting_address`](@ref). Moreover, the `eltype` of an `AbstractOperator` can
+be a vector value.
+
+For concrete implementations see [`Hamiltonians`](@ref Main.Hamiltonians). In order to
+implement a Hamiltonian for use in [`ProjectorMonteCarloProblem`](@ref) or
+[`ExactDiagonalizationProblem`](@ref) use the type [`AbstractHamiltonian`](@ref) instead,
+which is a subtype of `AbstractOperator`.
 
 # Interface
 
@@ -70,7 +75,9 @@ VectorInterface.scalartype(::Type{<:AbstractOperator{T}}) where T = eltype(T)
 @doc """
     LinearAlgebra.mul!(w::AbstractDVec, op::AbstractOperator, v::AbstractDVec)
 In place multiplication of `op` with `v` and storing the result in `w`. The result is
-returned.
+returned. Note that `w` needs to have a `valtype` that can hold a product of instances
+of `eltype(op)` and `valtype(v)`. Moreover, the [`StochasticStyle`](@ref) of `w` needs to
+be [`<: IsDeterministic`](@ref IsDeterministic).
 
 Part of the [`AbstractOperator`](@ref) interface.
 

--- a/src/Interfaces/hamiltonians.jl
+++ b/src/Interfaces/hamiltonians.jl
@@ -32,8 +32,8 @@ Optional additional methods to implement:
 * [`LOStructure(::Type{typeof(lo)})`](@ref LOStructure): defaults to `AdjointUnknown`
 * [`dimension(::AbstractHamiltonian, addr)`](@ref Main.Hamiltonians.dimension): defaults to
   dimension of address space
-* [`allows_address_type(h::AbstractHamiltonian, ::Type{A})`](@ref): defaults to
-  `A :< typeof(starting_address(h))`
+* [`allows_address_type(h::AbstractHamiltonian, type)`](@ref): defaults to
+  `type :< typeof(starting_address(h))`
 * [`momentum(::AbstractHamiltonian)`](@ref Main.Hamiltonians.momentum): no default
 
 Provides the following functions and methods:

--- a/src/Interfaces/hamiltonians.jl
+++ b/src/Interfaces/hamiltonians.jl
@@ -59,7 +59,8 @@ See also [`Hamiltonians`](@ref Main.Hamiltonians), [`Interfaces`](@ref).
 """
 abstract type AbstractHamiltonian{T} end
 
-Base.eltype(::AbstractHamiltonian{T}) where {T} = T
+Base.eltype(::AbstractHamiltonian{T}) where {T} = T # could be vector value
+Base.valtype(h::AbstractHamiltonian) = eltype(h) # type of underlying scalar values
 
 """
     allows_address_type(operator, addr_or_type)

--- a/src/Interfaces/hamiltonians.jl
+++ b/src/Interfaces/hamiltonians.jl
@@ -32,8 +32,8 @@ Optional additional methods to implement:
 * [`LOStructure(::Type{typeof(lo)})`](@ref LOStructure): defaults to `AdjointUnknown`
 * [`dimension(::AbstractHamiltonian, addr)`](@ref Main.Hamiltonians.dimension): defaults to
   dimension of address space
-* [`allowed_address_type(h::AbstractHamiltonian)`](@ref): defaults to
-  `typeof(starting_address(h))`
+* [`allows_address_type(h::AbstractHamiltonian, ::Type{A})`](@ref): defaults to
+  `A :< typeof(starting_address(h))`
 * [`momentum(::AbstractHamiltonian)`](@ref Main.Hamiltonians.momentum): no default
 
 Provides the following functions and methods:
@@ -62,16 +62,22 @@ abstract type AbstractHamiltonian{T} end
 Base.eltype(::AbstractHamiltonian{T}) where {T} = T
 
 """
-    allowed_address_type(h::AbstractHamiltonian)
-Return the type of addresses that can be used with Hamiltonian `h`.
+    allows_address_type(operator, addr_or_type)
+Returns `true` if `addr_or_type` is a valid address for `operator`. Otherwise, returns
+`false`.
 
 Part of the [`AbstractHamiltonian`](@ref) interface.
 
-Defaults to `typeof(starting_address(h))`. Overload this function if the Hamiltonian can be
-used with addresses of different types.
+# Extended help
+Defaults to `addr_or_type <: typeof(starting_address(operator))`. Overload this function if
+the operator can be used with addresses of different types.
 """
-allowed_address_type(h::AbstractHamiltonian) = typeof(starting_address(h))
-allowed_address_type(::AbstractMatrix) = Integer
+@inline function allows_address_type(hamiltonian, ::Type{A}) where {A}
+    return A <: typeof(starting_address(hamiltonian))
+end
+function allows_address_type(op, address)
+    allows_address_type(op, typeof(address))
+end
 
 """
     diagonal_element(ham, address)

--- a/src/Interfaces/hamiltonians.jl
+++ b/src/Interfaces/hamiltonians.jl
@@ -218,10 +218,10 @@ Part of the [`AbstractHamiltonian`](@ref) interface.
 num_offdiagonals(m::AbstractMatrix, i) = length(offdiagonals(m, i))
 
 """
-    newadd, me = get_offdiagonal(ham, add, chosen)
+    newadd, me = get_offdiagonal(ham, address, chosen)
 
 Compute value `me` and new address `newadd` of a single (off-diagonal) matrix element in a
-Hamiltonian `ham`. The off-diagonal element is in the same column as address `add` and is
+Hamiltonian `ham`. The off-diagonal element is in the same column as address `address` and is
 indexed by integer index `chosen`.
 
 # Example
@@ -305,10 +305,11 @@ end
 
 """
     random_offdiagonal(offdiagonals::AbstractOffdiagonals)
-    random_offdiagonal(ham::AbstractHamiltonian, add)
+    random_offdiagonal(ham::AbstractHamiltonian, address)
+    -> newaddress, probability, matrixelement
 
 Generate a single random excitation, i.e. choose from one of the accessible off-diagonal
-elements in the column corresponding to address `add` of the Hamiltonian matrix represented
+elements in the column corresponding to `address` in the Hamiltonian matrix represented
 by `ham`. Alternatively, pass as argument an iterator over the accessible matrix elements.
 
 Part of the [`AbstractHamiltonian`](@ref) interface.
@@ -320,8 +321,8 @@ function random_offdiagonal(offdiagonals::AbstractVector)
     return naddress, 1.0/nl, melem
 end
 
-function random_offdiagonal(ham, add)
-    return random_offdiagonal(offdiagonals(ham, add))
+function random_offdiagonal(ham, address)
+    return random_offdiagonal(offdiagonals(ham, address))
 end
 
 @doc """

--- a/src/Interfaces/hamiltonians.jl
+++ b/src/Interfaces/hamiltonians.jl
@@ -28,21 +28,18 @@ for defining correlation functions. For concrete implementations see
 
 Basic interface methods to implement:
 - [`allows_address_type(op, type)`](@ref)
-
-and either
-- [`LinearAlgebra.mul!(y, op, x)`](@ref) and
-- [`Interfaces.dot_from_right(x, op, y)`](@ref)
-
-or, alternatively (these imply default implementations for the above):
 - [`diagonal_element(op, address)`](@ref)
 - [`num_offdiagonals(op, address)`](@ref) and
-- [`get_offdiagonal(op, address, chosen)`](@ref)
+- [`get_offdiagonal(op, address, chosen)`](@ref) or [`offdiagonals`](@ref)
 
 Optional additional methods to implement:
 - [`VectorInterface.scalartype(op)`](@ref): defaults to `eltype(eltype(op))`
 - [`LOStructure(::Type{typeof(op)})`](@ref LOStructure): defaults to `AdjointUnknown`
 - [`dimension(op, addr)`](@ref Main.Hamiltonians.dimension): defaults to dimension of
   address space
+
+In order to calculate observables efficiently, it may make sense to implement custom methods
+for [`Interfaces.dot_from_right(x, op, y)`](@ref) and [`LinearAlgebra.mul!(y, op, x)`](@ref).
 
 See also [`AbstractHamiltonian`](@ref), [`Interfaces`](@ref).
 """

--- a/src/Interfaces/hamiltonians.jl
+++ b/src/Interfaces/hamiltonians.jl
@@ -14,7 +14,8 @@ module `DictVectors` and work well with addresses of type
 from the module `BitStringAddresses`.
 
 The defining feature of an `AbstractOperator` is that it can be applied to a vector with
-`mul!(y, op, x)` and that three-way dot products are defined with `dot(x, op, y)`.
+[`mul!(y, op, x)`](@ref LinearAlgebra.mul!) and that three-way dot products are defined with
+[`dot(x, op, y)`](@ref LinearAlgebra.mul!).
 
 The `AbstractOperator` type is useful for defining operators that are not necessarily
 Hamiltonians, but that can be used in the context of FCIQMC as observable operators, e.g.
@@ -29,13 +30,13 @@ Basic interface methods to implement:
 - [`allows_address_type(op, type)`](@ref)
 
 and either
+- [`LinearAlgebra.mul!(y, op, x)`](@ref) and
+- [`Interfaces.dot_from_right(x, op, y)`](@ref)
+
+or, alternatively (these imply default implementations for the above):
 - [`diagonal_element(op, address)`](@ref)
 - [`num_offdiagonals(op, address)`](@ref) and
 - [`get_offdiagonal(op, address, chosen)`](@ref)
-
-or
-- `LinearAlgebra.mul!(y, op, x)` and
-- `DictVectors.dot_from_right(x, op, y)`
 
 Optional additional methods to implement:
 - [`VectorInterface.scalartype(op)`](@ref): defaults to `eltype(eltype(op))`
@@ -68,6 +69,35 @@ Part of the [`AbstractOperator`](@ref) interface.
     New types should only implement the method with the argument in the type domain.
 """
 VectorInterface.scalartype(::Type{<:AbstractOperator{T}}) where T = eltype(T)
+
+@doc """
+    LinearAlgebra.mul!(w::AbstractDVec, op::AbstractOperator, v::AbstractDVec)
+In place multiplication of `op` with `v` and storing the result in `w`. The result is
+returned.
+
+Part of the [`AbstractOperator`](@ref) interface.
+
+The default implementation relies of [`diagonal_element`](@ref) and [`offdiagonals`](@ref)
+to access the elements of the operator. The function can be overloaded for custom operators.
+"""
+LinearAlgebra.mul!
+
+@doc """
+    dot(w, op::AbstractOperator, v)
+
+Evaluate `w⋅op(v)` minimizing memory allocations.
+"""
+LinearAlgebra.dot
+
+@doc """
+    dot_from_right(w, op::AbstractOperator, v)
+
+Internal function evaluates the 3-argument `dot()` function in order from right
+to left.
+"""
+function dot_from_right(::W, ::O, ::V) where {W, O, V}
+    throw(ArgumentError("dot_from_right not implemented for types $W, $O, $V"))
+end
 
 """
     AbstractHamiltonian{T} <: AbstractOperator{T}

--- a/src/Interfaces/hamiltonians.jl
+++ b/src/Interfaces/hamiltonians.jl
@@ -5,7 +5,8 @@
     AbstractOperator{T}
 
 Supertype that provides an interface for linear operators over a linear space with elements
-of type `T` and general (custom type) indices called 'addresses'.
+of type `T` (returned by [`eltype`](@ref)) and general (custom type) indices called
+'addresses'.
 
 `AbstractOperator` instances operate on vectors of type [`AbstractDVec`](@ref) from the
 module `DictVectors` and work well with addresses of type
@@ -34,11 +35,11 @@ and either
 
 or
 - `LinearAlgebra.mul!(y, op, x)` and
-- `LinearAlgebra.dot(x, op, y)`
+- `DictVectors.dot_from_right(x, op, y)`
 
 Optional additional methods to implement:
-- [`valtype(op)`](@ref): defaults to `eltype(op)`
-- [`LOStructure(::Type{typeof(lo)})`](@ref LOStructure): defaults to `AdjointUnknown`
+- [`VectorInterface.scalartype(op)`](@ref): defaults to `eltype(eltype(op))`
+- [`LOStructure(::Type{typeof(op)})`](@ref LOStructure): defaults to `AdjointUnknown`
 - [`dimension(op, addr)`](@ref Main.Hamiltonians.dimension): defaults to dimension of
   address space
 
@@ -46,8 +47,27 @@ See also [`AbstractHamiltonian`](@ref), [`Interfaces`](@ref).
 """
 abstract type AbstractOperator{T} end
 
-Base.eltype(::AbstractOperator{T}) where {T} = T # could be vector value
-Base.valtype(h::AbstractOperator) = eltype(h) # type of underlying scalar values
+"""
+    eltype(op::AbstractOperator)
+Return the type of the elements of the operator. This can be a vector value. For the
+underlying scalar type use [`scalartype`](@ref).
+
+Part of the [`AbstractOperator`](@ref) interface.
+!!! note
+    New types should only implement the method with the argument in the type domain.
+"""
+Base.eltype(::Type{<:AbstractOperator{T}}) where {T} = T # could be vector value
+
+"""
+    scalartype(op::AbstractOperator)
+Return the type of the underlying scalar field of the operator. This may be different from
+the element type of the operator returned by [`eltype`](@ref), which can be a vector value.
+
+Part of the [`AbstractOperator`](@ref) interface.
+!!! note
+    New types should only implement the method with the argument in the type domain.
+"""
+VectorInterface.scalartype(::Type{<:AbstractOperator{T}}) where T = eltype(T)
 
 """
     AbstractHamiltonian{T} <: AbstractOperator{T}

--- a/src/Interfaces/hamiltonians.jl
+++ b/src/Interfaces/hamiltonians.jl
@@ -77,7 +77,7 @@ VectorInterface.scalartype(::Type{<:AbstractOperator{T}}) where T = eltype(T)
 In place multiplication of `op` with `v` and storing the result in `w`. The result is
 returned. Note that `w` needs to have a `valtype` that can hold a product of instances
 of `eltype(op)` and `valtype(v)`. Moreover, the [`StochasticStyle`](@ref) of `w` needs to
-be [`<: IsDeterministic`](@ref Rimu.StochasticStyles.IsDeterministic).
+be [`<:IsDeterministic`](@ref Rimu.StochasticStyles.IsDeterministic).
 
 Part of the [`AbstractOperator`](@ref) interface.
 
@@ -365,7 +365,7 @@ LOStructure(::Type) = AdjointUnknown()
 LOStructure(::AbstractMatrix) = AdjointKnown()
 
 # diagonal matrices have zero offdiagonal elements
-function num_offdiagonals(h::H, addr) where {H<:AbstractHamiltonian}
+function num_offdiagonals(h::H, addr) where {H<:AbstractOperator}
     return num_offdiagonals(LOStructure(H), h, addr)
 end
 num_offdiagonals(::IsDiagonal, _, _) = 0

--- a/src/Interfaces/stochasticstyles.jl
+++ b/src/Interfaces/stochasticstyles.jl
@@ -41,6 +41,7 @@ abstract type StochasticStyle{T} end
 StochasticStyle(::AbstractVector{T}) where T = default_style(T)
 
 Base.eltype(::Type{<:StochasticStyle{T}}) where {T} = T
+VectorInterface.scalartype(::Type{<:StochasticStyle{T}}) where {T} = T
 
 """
     StyleUnknown{T}() <: StochasticStyle

--- a/src/Rimu.jl
+++ b/src/Rimu.jl
@@ -44,6 +44,7 @@ include("helpers.jl") # non MPI-dependent helper functions
 
 include("Interfaces/Interfaces.jl")
 @reexport using .Interfaces
+using .Interfaces: dot_from_right
 include("BitStringAddresses/BitStringAddresses.jl")
 @reexport using .BitStringAddresses
 include("Hamiltonians/Hamiltonians.jl")

--- a/src/StochasticStyles/spawning.jl
+++ b/src/StochasticStyles/spawning.jl
@@ -378,6 +378,8 @@ end
 end
 
 # bypass branching code for Exact() sub-strategy
-@inline function spawn!(s::DynamicSemistochastic{<:Any, <:Exact}, args...)
-    return (1, 0, spawn!(s.strat, args...)...)
+@inline function spawn!(
+    s::DynamicSemistochastic{<:Any,<:Exact}, w, od::AbstractVector, args...
+)
+    return (1, 0, spawn!(s.strat, w, od, args...)...)
 end

--- a/src/StochasticStyles/spawning.jl
+++ b/src/StochasticStyles/spawning.jl
@@ -149,7 +149,7 @@ This function should be overloaded in the second form, with `offdiags` as an arg
 
 See [`SpawningStrategy`](@ref).
 """
-@inline function spawn!(s::SpawningStrategy, w, op, add, val, boost=1)
+@inline function spawn!(s::SpawningStrategy, w, op::AbstractOperator, add, val, boost=1)
     return spawn!(s, w, offdiagonals(op, add), add, val, boost)
 end
 

--- a/src/StochasticStyles/styles.jl
+++ b/src/StochasticStyles/styles.jl
@@ -62,6 +62,8 @@ function apply_column!(::IsStochastic2Pop, w, op, add, val, boost=1)
     return (spawns, deaths, clones, zombies)
 end
 
+const FloatOrComplexFloat = Union{AbstractFloat, Complex{<:AbstractFloat}}
+
 """
     IsDeterministic{T=Float64}(compression=NoCompression()) <: StochasticStyle{T}
 
@@ -71,7 +73,7 @@ resultant vector (after annihilations) can be triggered by setting the optional
 
 See also [`StochasticStyle`](@ref).
 """
-struct IsDeterministic{T<:AbstractFloat,C<:CompressionStrategy} <: StochasticStyle{T}
+struct IsDeterministic{T<:FloatOrComplexFloat,C<:CompressionStrategy} <: StochasticStyle{T}
     compression::C
 end
 function IsDeterministic{T}(compression::C=NoCompression()) where {T,C}
@@ -213,4 +215,5 @@ end
 
 default_style(::Type{T}) where {T<:Integer} = IsStochasticInteger{T}()
 default_style(::Type{T}) where {T<:AbstractFloat} = IsDeterministic{T}()
+default_style(::Type{T}) where {T<:Complex{<:AbstractFloat}} = IsDeterministic{T}()
 default_style(::Type{T}) where {T<:Complex{<:Integer}} = IsStochastic2Pop{T}()

--- a/src/projector_monte_carlo_problem.jl
+++ b/src/projector_monte_carlo_problem.jl
@@ -246,4 +246,3 @@ end
 
 num_replicas(::ProjectorMonteCarloProblem{N}) where N = N
 num_spectral_states(::ProjectorMonteCarloProblem{<:Any,S}) where {S} = S
-Base.valtype(p::ProjectorMonteCarloProblem) = valtype(p.hamiltonian)

--- a/src/projector_monte_carlo_problem.jl
+++ b/src/projector_monte_carlo_problem.jl
@@ -219,6 +219,12 @@ function ProjectorMonteCarloProblem(
         post_step_strategy = (post_step_strategy,)
     end
 
+    if !(eltype(hamiltonian)<: Real)
+        throw(ArgumentError("Only real-valued Hamiltonians are currently supported "*
+            "for ProjectorMonteCarloProblem. Please get in touch with the Rimu.jl " *
+            "developers if you need a complex-valued Hamiltonian!"))
+    end
+
     return ProjectorMonteCarloProblem{n_replicas,num_spectral_states(spectral_strategy)}(
         algorithm,
         hamiltonian,
@@ -240,3 +246,4 @@ end
 
 num_replicas(::ProjectorMonteCarloProblem{N}) where N = N
 num_spectral_states(::ProjectorMonteCarloProblem{<:Any,S}) where {S} = S
+Base.valtype(p::ProjectorMonteCarloProblem) = valtype(p.hamiltonian)

--- a/src/strategies_and_params/replicastrategy.jl
+++ b/src/strategies_and_params/replicastrategy.jl
@@ -58,31 +58,33 @@ check_transform(::NoStats, _) = nothing
 
 # TODO: add custom names
 """
-    AllOverlaps(n_replicas=2; operator=nothing, transform=nothing, vecnorm=true) <: ReplicaStrategy{n_replicas}
+    AllOverlaps(n_replicas=2; operator=nothing, transform=nothing, vecnorm=true)
+        <: ReplicaStrategy{n_replicas}
 
-Run `n_replicas` replicas and report overlaps between all pairs of replica vectors. If `operator` is
-not `nothing`, the overlap `dot(c1, operator, c2)` is reported as well. If `operator` is a tuple
-of operators, the overlaps are computed for all operators.
+Run `n_replicas` replicas and report overlaps between all pairs of replica vectors. If
+`operator` is not `nothing`, the overlap `dot(c1, operator, c2)` is reported as well. If
+`operator` is a tuple of operators, the overlaps are computed for all operators.
 
 Column names in the report are of the form `c{i}_dot_c{j}` for vector-vector overlaps, and
 `c{i}_Op{k}_c{j}` for operator overlaps.
 
 See [`ProjectorMonteCarloProblem`](@ref), [`ReplicaStrategy`](@ref) and
-[`n_replicas`](@ref) (for an interface for implementing operators).
+[`AbstractOperator`](@ref Interfaces.AbstractOperator) (for an interface for implementing
+operators).
 
 # Transformed Hamiltonians
 
-If a transformed Hamiltonian `G` has been passed to [`ProjectorMonteCarloProblem`](@ref) then overlaps can be calculated by
-passing the same transformed Hamiltonian to `AllOverlaps` by setting `transform=G`. A warning is given
-if these two Hamiltonians do not match.
+If a transformed Hamiltonian `G` has been passed to [`ProjectorMonteCarloProblem`](@ref)
+then overlaps can be calculated by passing the same transformed Hamiltonian to `AllOverlaps`
+by setting `transform=G`. A warning is given if these two Hamiltonians do not match.
 
 Implemented transformations are:
 
  * [`GutzwillerSampling`](@ref)
  * [`GuidingVectorSampling`](@ref)
 
-In the case of a transformed Hamiltonian the overlaps are defined as follows. For a similarity transformation
-`G` of the Hamiltonian (see e.g. [`GutzwillerSampling`](@ref).)
+In the case of a transformed Hamiltonian the overlaps are defined as follows. For a
+similarity transformation `G` of the Hamiltonian (see e.g. [`GutzwillerSampling`](@ref).)
 ```math
     \\hat{G} = f \\hat{H} f^{-1}.
 ```
@@ -95,13 +97,15 @@ where
 ```math
     | \\phi \\rangle = f | \\psi \\rangle
 ```
-is the (right) eigenvector of ``\\hat{G}`` and ``| \\psi \\rangle`` is an eigenvector of ``\\hat{H}``.
+is the (right) eigenvector of ``\\hat{G}`` and ``| \\psi \\rangle`` is an eigenvector of
+``\\hat{H}``.
 
 For a K-tuple of input operators ``(\\hat{A}_1, ..., \\hat{A}_K)``, overlaps of
-``\\langle \\phi | f^{-1} \\hat{A} f^{-1} | \\phi \\rangle`` are reported as `c{i}_Op{k}_c{j}`.
-The correct vector-vector overlap ``\\langle \\phi | f^{-2} | \\phi \\rangle`` is reported *last*
-as `c{i}_Op{K+1}_c{j}`. This is in addition to the *bare* vector-vector overlap
-``\\langle \\phi | f^{-2} | \\phi \\rangle`` that is reported as `c{i}_dot_c{j}`.
+``\\langle \\phi | f^{-1} \\hat{A} f^{-1} | \\phi \\rangle`` are reported as
+`c{i}_Op{k}_c{j}`. The correct vector-vector overlap ``\\langle \\phi | f^{-2} | \\phi
+\\rangle`` is reported *last* as `c{i}_Op{K+1}_c{j}`. This is in addition to the *bare*
+vector-vector overlap ``\\langle \\phi | f^{-2} | \\phi \\rangle`` that is reported as
+`c{i}_dot_c{j}`.
 
 In either case the `c{i}_dot_c{j}` overlap can be omitted with the flag `vecnorm=false`.
 """

--- a/test/DictVectors.jl
+++ b/test/DictVectors.jl
@@ -2,7 +2,7 @@ using LinearAlgebra
 using Random
 using Rimu
 using Rimu.DictVectors
-using Rimu.StochasticStyles: IsStochastic2Pop
+using Rimu.StochasticStyles: IsStochastic2Pop, StochasticStyle
 using StaticArrays
 using Suppressor
 using Test
@@ -290,6 +290,17 @@ end
         test_dvec_interface(DVec; capacity=200)
     end
 
+    @testset "DVec with StaticArray" begin
+        sa = SA[1.0 2.0; 3.0 4.0]
+        sai = SA[1 2; 3 4]
+        @test DVec(:a => sa) == DVec(:a => sai)
+        @test_throws ArgumentError DVec(:a => sai; style=IsDynamicSemistochastic())
+        dict = Dict(:a => sai)
+        @test_throws ArgumentError DVec(dict; style=IsDynamicSemistochastic())
+        @test DVec(Dict(:a => sa)) == DVec(:a => sa)
+        dv = DVec(:a => sai)
+        @test_throws ArgumentError empty(dv; style=IsDynamicSemistochastic())
+    end
 end
 
 @testset "InitiatorDVec" begin

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -181,22 +181,29 @@ end
                 FermiFS((1, 1, 1, 1, 0, 0, 0, 0)),
             ); t=[1, 2], u=[0 3; 3 0]
         ), BoseHubbardReal1D2C(BoseFS2C((1, 2, 3), (1, 0, 0))),
-        BoseHubbardMom1D2C(BoseFS2C((1, 2, 3), (1, 0, 0))), GutzwillerSampling(HubbardReal1D(BoseFS((1, 2, 3)); u=6); g=0.3),
+        BoseHubbardMom1D2C(BoseFS2C((1, 2, 3), (1, 0, 0))),
+        GutzwillerSampling(HubbardReal1D(BoseFS((1, 2, 3)); u=6); g=0.3),
         GutzwillerSampling(BoseHubbardMom1D2C(BoseFS2C((3, 2, 1), (1, 2, 3)); ua=6); g=0.3),
-        GutzwillerSampling(HubbardReal1D(BoseFS((1, 2, 3)); u=6 + 2im); g=0.3), MatrixHamiltonian(Float64[1 2; 2 0]),
+        GutzwillerSampling(HubbardReal1D(BoseFS((1, 2, 3)); u=6 + 2im); g=0.3),
+        MatrixHamiltonian(Float64[1 2; 2 0]),
         GutzwillerSampling(MatrixHamiltonian([1.0 2.0; 2.0 0.0]); g=0.3),
         TransformUndoer(
             GutzwillerSampling(MatrixHamiltonian([1.0 2.0; 2.0 0.0]); g=0.3)
-        ), Transcorrelated1D(CompositeFS(FermiFS((0, 0, 1, 1, 0)), FermiFS((0, 1, 1, 0, 0))); t=2),
-        Transcorrelated1D(CompositeFS(FermiFS((0, 0, 1, 0)), FermiFS((0, 1, 1, 0))); v=3, v_ho=1), HubbardMom1DEP(BoseFS((0, 0, 5, 0, 0))),
-        HubbardMom1DEP(CompositeFS(FermiFS((0, 1, 1, 0, 0)), FermiFS((0, 0, 1, 0, 0))), v_ho=5), ParitySymmetry(HubbardRealSpace(CompositeFS(BoseFS((1, 2, 0)), FermiFS((0, 1, 0))))),
+        ),
+        Transcorrelated1D(CompositeFS(FermiFS((0, 0, 1, 1, 0)), FermiFS((0, 1, 1, 0, 0))); t=2),
+        Transcorrelated1D(CompositeFS(FermiFS((0, 0, 1, 0)), FermiFS((0, 1, 1, 0))); v=3, v_ho=1),
+        HubbardMom1DEP(BoseFS((0, 0, 5, 0, 0))),
+        HubbardMom1DEP(CompositeFS(FermiFS((0, 1, 1, 0, 0)), FermiFS((0, 0, 1, 0, 0))), v_ho=5),
+        ParitySymmetry(HubbardRealSpace(CompositeFS(BoseFS((1, 2, 0)), FermiFS((0, 1, 0))))),
         TimeReversalSymmetry(HubbardMom1D(FermiFS2C((1, 0, 1), (0, 1, 1)))),
         TimeReversalSymmetry(BoseHubbardMom1D2C(BoseFS2C((0, 1, 1), (1, 0, 1)))),
         Stoquastic(HubbardMom1D(BoseFS((0, 5, 0)))),
-        momentum(HubbardMom1D(BoseFS((0, 5, 0)))), HOCartesianContactInteractions(BoseFS((2, 0, 0, 0))),
+        momentum(HubbardMom1D(BoseFS((0, 5, 0)))),
+        HOCartesianContactInteractions(BoseFS((2, 0, 0, 0))),
         HOCartesianEnergyConservedPerDim(BoseFS((2, 0, 0, 0))),
-        HOCartesianCentralImpurity(BoseFS((1, 0, 0, 0, 0))), FroehlichPolaron(OccupationNumberFS(1, 1, 1)),
-        FroehlichPolaron(OccupationNumberFS(1, 1, 1); momentum_cutoff=10.0), ParticleNumberOperator(OccupationNumberFS(1, 1, 1))
+        HOCartesianCentralImpurity(BoseFS((1, 0, 0, 0, 0))),
+        FroehlichPolaron(OccupationNumberFS(1, 1, 1)),
+        FroehlichPolaron(OccupationNumberFS(1, 1, 1); momentum_cutoff=10.0),
     )
         # test_hamiltonian_interface(H; test_spawning=false)
         test_hamiltonian_interface(H; test_spawning=!(H isa HOCartesianContactInteractions))

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -204,6 +204,7 @@ end
         HOCartesianCentralImpurity(BoseFS((1, 0, 0, 0, 0))),
         FroehlichPolaron(OccupationNumberFS(1, 1, 1)),
         FroehlichPolaron(OccupationNumberFS(1, 1, 1); momentum_cutoff=10.0),
+        momentum(HubbardMom1D(BoseFS(0, 1, 5, 1, 0))),
     )
         # test_hamiltonian_interface(H; test_spawning=false)
         test_hamiltonian_interface(H; test_spawning=!(H isa HOCartesianContactInteractions))

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -62,9 +62,9 @@ function test_hamiltonian_interface(H, addr=starting_address(H))
             @test dimension(H) == dimension(H, starting_address(H))
             @test dimension(addr) ≥ dimension(H, addr)
         end
-        @testset "allowed_address_type" begin
-            @test starting_address(H) isa allowed_address_type(H)
-            @test addr isa allowed_address_type(H)
+        @testset "allows_address_type" begin
+            @test allows_address_type(H, starting_address(H))
+            @test allows_address_type(H, addr)
         end
         @testset "offdiagonals" begin
             # `get_offdiagonal` is not mandatory but `offdiagonals` is

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -67,7 +67,7 @@ function test_hamiltonian_interface(H, addr=starting_address(H))
         end
         @testset "offdiagonals" begin
             # `get_offdiagonal` is not mandatory but `offdiagonals` is
-            if length(methods(get_offdiagonal, (typeof(H), typeof(address), Int))) > 0
+            if length(methods(get_offdiagonal, (typeof(H), typeof(addr), Int))) > 0
                 ods = [get_offdiagonal(H, addr, i) for i in 1:num_offdiagonals(H, addr)]
                 @test ods == offdiagonals(H, addr)
             end

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -226,6 +226,7 @@ end
         (DensityMatrixDiagonal(3), FermiFS(1, 0, 1)),
         (SingleParticleExcitation(2, 3), BoseFS(1, 2, 3, 4)),
         (TwoParticleExcitation(3, 2, 1, 4), BoseFS(1, 2, 3, 4)),
+        (Momentum(1), BoseFS(1, 2, 3, 4)),
     ]
         test_operator_interface(op, addr)
     end

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -31,11 +31,9 @@ function test_hamiltonian_interface(H, addr=starting_address(H))
             @test v′ == v″ == v‴ == v⁗
         end
         @testset "diagonal_element" begin
-            if eltype(H) <: Real
-                @test diagonal_element(H, addr) isa Real
-            else
-                @test norm(diagonal_element(H, addr)) ≥ 0
-            end
+            @test diagonal_element(H, addr) isa eltype(H)
+            @test eltype(diagonal_element(H, addr)) == scalartype(H)
+            @test norm(diagonal_element(H, addr)) ≥ 0
         end
         if !(H isa HOCartesianContactInteractions)  # offdiagonals not consistent with interface
             @testset "hopping" begin
@@ -912,9 +910,9 @@ using Rimu.Hamiltonians: circshift_dot
                 @test eval(Meta.parse(repr(g2_2))) == g2_2
                 @test eval(Meta.parse(repr(g2_3))) == g2_3
 
-                @test valtype(g2_1) == Float64
-                @test valtype(g2_2) == Float64
-                @test valtype(g2_3) == Float64
+                @test scalartype(g2_1) == Float64
+                @test scalartype(g2_2) == Float64
+                @test scalartype(g2_3) == Float64
 
                 @test_throws ArgumentError G2RealSpace(CubicGrid(3), 1, 0)
                 @test_throws ArgumentError G2RealSpace(CubicGrid(2, 2), 0, 0)

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -224,6 +224,8 @@ end
         (SuperfluidCorrelator(3), BoseFS(1, 2, 3, 1)),
         (StringCorrelator(3), BoseFS(1, 0, 3, 1)),
         (DensityMatrixDiagonal(3), FermiFS(1, 0, 1)),
+        (SingleParticleExcitation(2, 3), BoseFS(1, 2, 3, 4)),
+        (TwoParticleExcitation(3, 2, 1, 4), BoseFS(1, 2, 3, 4)),
     ]
         test_operator_interface(op, addr)
     end

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -912,6 +912,10 @@ using Rimu.Hamiltonians: circshift_dot
                 @test eval(Meta.parse(repr(g2_2))) == g2_2
                 @test eval(Meta.parse(repr(g2_3))) == g2_3
 
+                @test valtype(g2_1) == Float64
+                @test valtype(g2_2) == Float64
+                @test valtype(g2_3) == Float64
+
                 @test_throws ArgumentError G2RealSpace(CubicGrid(3), 1, 0)
                 @test_throws ArgumentError G2RealSpace(CubicGrid(2, 2), 0, 0)
                 @test_throws ArgumentError G2RealSpace(CubicGrid(1, 2, 3), -1, 2)

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -6,7 +6,7 @@ using Test
 using DataFrames
 using Suppressor
 using StaticArrays
-using Rimu.Hamiltonians: TransformUndoer
+using Rimu.Hamiltonians: TransformUndoer, AbstractOffdiagonals
 
 function exact_energy(ham)
     dv = DVec(starting_address(ham) => 1.0)
@@ -15,71 +15,108 @@ function exact_energy(ham)
 end
 
 """
+    test_operator_interface(op, addr; test_spawning=true)
+
+This function tests the interface of an operator `op` at address `addr` by checking that all
+required methods are defined.
+
+If `test_spawning` is `true`, tests are performed that require `offdiagonals` to return an
+`Hamiltonians.AbstractOffDiagonals`, which is a prerequisite for using the `spawn!`
+function. Otherwise, the spawning tests are skipped.
+"""
+function test_operator_interface(op, addr; test_spawning=true)
+    @testset "Operator interface: $(nameof(typeof(op)))" begin
+        @testset "diagonal_element" begin
+            @test diagonal_element(op, addr) isa eltype(op)
+            @test eltype(diagonal_element(op, addr)) == scalartype(op)
+        end
+        @testset "offdiagonals" begin
+            # `get_offdiagonal` is not mandatory and thus not tested
+            ods = offdiagonals(op, addr)
+            vec_ods = collect(ods)
+            eltype(vec_ods) == Tuple{typeof(addr), eltype(op)} == eltype(ods)
+            @test length(vec_ods) ≤ num_offdiagonals(op, addr)
+        end
+        if test_spawning
+            @testset "spawning" begin
+                ods = offdiagonals(op, addr)
+                @test ods isa AbstractOffdiagonals{typeof(addr),eltype(op)}
+                @test ods isa AbstractVector
+                @test size(ods) == (num_offdiagonals(op, addr),)
+                if length(ods) > 0
+                    @test random_offdiagonal(op, addr) isa Tuple{typeof(addr), <:Real, eltype(op)}
+                end
+            end
+        end
+        @testset "*, mul!, and call" begin
+            v = DVec(addr => scalartype(op)(2))
+            v1 = similar(v)
+            mul!(v1, op, v)
+            v2 = op * v
+            v3 = similar(v)
+            op(v3, v)
+            v4 = op(v)
+            @test v1 == v2 == v3 == v4
+            v5 = DVec(addr => diagonal_element(op, addr))
+            for (addr, val) in offdiagonals(op, addr)
+                v5[addr] += val
+            end
+            scale!(v5, scalartype(op)(2))
+            v5[addr] = v5[addr] # remove possible 0.0 from the diagonal
+            @test v5 == v1
+        end
+        @testset "three way dot" begin
+            v = DVec(addr => scalartype(op)(2))
+            v1 = op(v)
+            @test dot(v1, op, v) ≈ Interfaces.dot_from_right(v1, op, v) ≈ dot(v1, v1)
+            if test_spawning && scalartype(op) <: Real
+                # applying an operator on a PDVec uses spawn!, which requires
+                # offdiagonals to be an AbstractVector
+                # currently this only works for real operators as spawn! is not
+                # implemented for complex operators
+                pv = PDVec(v)
+                pv1 = op(pv)
+                @test dot(pv1, op, pv) ≈ Interfaces.dot_from_right(pv1, op, pv) ≈ dot(v1, v1)
+            end
+        end
+        @testset "LOStructure" begin
+            @test LOStructure(op) isa LOStructure
+            if LOStructure(op) isa IsHermitian
+                @test op' === op
+            elseif  LOStructure(op) isa IsDiagonal
+                @test num_offdiagonals(op, addr) == 0
+                if scalartype(op) <: Real
+                    @test op' === op
+                end
+            elseif LOStructure(op) isa AdjointKnown
+                @test begin op'; true; end # make sure no error is thrown
+            else
+                @test_throws ArgumentError op'
+            end
+        end
+        @testset "dimension" begin
+            @test dimension(addr) ≥ dimension(op, addr)
+        end
+        @testset "allows_address_type" begin
+            @test allows_address_type(op, addr)
+        end
+        @testset "show" begin
+            # Check that the result of show can be pasted into the REPL
+            @test eval(Meta.parse(repr(op))) == op
+        end
+    end
+end
+
+"""
     test_hamiltonian_interface(H, addr=starting_address(H))
 
 The main purpose of this test function is to check that all required methods are defined.
 """
-function test_hamiltonian_interface(H, addr=starting_address(H))
-    @testset "$(nameof(typeof(H)))" begin
-        @testset "*, mul!, and call" begin
-            v = DVec(addr => eltype(H)(2.0))
-            v′ = H(v)
-            v″ = H * v
-            v‴ = similar(v)
-            H(v‴, v)
-            v⁗ = similar(v)
-            mul!(v⁗, H, v)
-            @test v′ == v″ == v‴ == v⁗
-        end
-        @testset "diagonal_element" begin
-            @test diagonal_element(H, addr) isa eltype(H)
-            @test eltype(diagonal_element(H, addr)) == scalartype(H)
-            @test norm(diagonal_element(H, addr)) ≥ 0
-        end
-        if !(H isa HOCartesianContactInteractions)  # offdiagonals not consistent with interface
-            @testset "hopping" begin
-                h = offdiagonals(H, addr)
-                @test eltype(h) == Tuple{typeof(addr), eltype(H)}
-                @test length(h) == num_offdiagonals(H, addr)
-                for i in 1:length(h)
-                    @test h[i] == get_offdiagonal(H, addr, i)
-                    @test h[i] isa eltype(h)
-                end
-            end
-        end
-        @testset "LOStructure" begin
-            @test LOStructure(H) isa LOStructure
-            if LOStructure(H) isa IsHermitian || LOStructure(H) isa IsDiagonal
-                @test H' === H
-            elseif LOStructure(H) isa AdjointKnown
-                @test begin H'; true; end # make sure no error is thrown
-            else
-                @test_throws ArgumentError H'
-            end
-        end
-        @testset "dimension" begin
-            @test dimension(H) == dimension(H, starting_address(H))
-            @test dimension(addr) ≥ dimension(H, addr)
-        end
-        @testset "allows_address_type" begin
-            @test allows_address_type(H, starting_address(H))
-            @test allows_address_type(H, addr)
-        end
-        @testset "offdiagonals" begin
-            # `get_offdiagonal` is not mandatory but `offdiagonals` is
-            if length(methods(get_offdiagonal, (typeof(H), typeof(addr), Int))) > 0
-                ods = [get_offdiagonal(H, addr, i) for i in 1:num_offdiagonals(H, addr)]
-                @test ods == offdiagonals(H, addr)
-            end
-            number_of_nonzero_offdiagonals = length(DVec(offdiagonals(H, addr)))
-            @test number_of_nonzero_offdiagonals ≤ num_offdiagonals(H, addr)
-            @test number_of_nonzero_offdiagonals ≤ dimension(H, addr)
-        end
-        @testset "show" begin
-            # Check that the result of show can be pasted into the REPL
-            @test eval(Meta.parse(repr(H))) == H
-        end
+function test_hamiltonian_interface(H, addr=starting_address(H); test_spawning=true)
+    @testset "starting_address of $(nameof(typeof(H)))" begin
+        @test allows_address_type(H, starting_address(H))
     end
+    test_operator_interface(H, addr; test_spawning)
 end
 
 """
@@ -290,7 +327,8 @@ end
 
         ParticleNumberOperator(OccupationNumberFS(1, 1, 1))
     )
-        test_hamiltonian_interface(H)
+        # test_hamiltonian_interface(H; test_spawning=false)
+        test_hamiltonian_interface(H; test_spawning=!(H isa HOCartesianContactInteractions))
     end
 end
 

--- a/test/Interfaces.jl
+++ b/test/Interfaces.jl
@@ -32,6 +32,8 @@ using Test
 
     @test LOStructure(ham) == AdjointKnown()
     @test has_adjoint(ham)
+
+    @test_throws ArgumentError Interfaces.dot_from_right(1, 2, 3)
 end
 
 # using lomc! with a matrix was removed in Rimu.jl v0.12.0

--- a/test/StochasticStyles.jl
+++ b/test/StochasticStyles.jl
@@ -4,8 +4,18 @@ using Rimu.StochasticStyles
 
 using Rimu.StochasticStyles: projected_deposit!, diagonal_step!, spawn!
 using Rimu.StochasticStyles:
-    Exact, SingleSpawn, WithReplacement, WithoutReplacement, Bernoulli, DynamicSemistochastic
+    Exact, SingleSpawn, WithReplacement, WithoutReplacement, Bernoulli,
+    DynamicSemistochastic, IsStochastic2Pop
 
+@testset "default_style" begin
+    default_style_of_typeof(x) = default_style(typeof(x))
+    @test default_style_of_typeof(1) == IsStochasticInteger{Int}()
+    @test default_style_of_typeof(1.0) == IsDeterministic{Float64}()
+    @test default_style_of_typeof(1.0f0) == IsDeterministic{Float32}()
+    @test default_style_of_typeof(1im) == IsStochastic2Pop{Complex{Int}}()
+    @test default_style_of_typeof(1.0 + 1im) == IsDeterministic{ComplexF64}()
+    @test default_style_of_typeof([1.0f0 + 1im, 1.0f0 + 1im]) isa StyleUnknown
+end
 @testset "Generic Hamiltonian-free functions" begin
     matrix = [1 2 3; 4 5 6; 7 8 9]
     @test diagonal_element(matrix, 3) == 9

--- a/test/lomc.jl
+++ b/test/lomc.jl
@@ -156,6 +156,8 @@ Random.seed!(1234)
                 @test num_stats(df) == 3 * binomial(2, 2)
                 df, _ = lomc!(H, dv; replica_strategy=AllOverlaps(7; operator=(G, H)))
                 @test num_stats(df) == 3 * binomial(7, 2)
+                df, _ = lomc!(H, dv; replica_strategy=AllOverlaps(7; operator=[G, H]))
+                @test num_stats(df) == 3 * binomial(7, 2)
 
                 # Transformed operators: (3 + 1) * N choose 2 reports.
                 df, _ = lomc!(G, dv; replica_strategy=AllOverlaps(2; operator=(H, G), transform=G))

--- a/test/projector_monte_carlo_problem.jl
+++ b/test/projector_monte_carlo_problem.jl
@@ -10,7 +10,6 @@ using OrderedCollections: freeze
     h = HubbardReal1D(BoseFS(1,3))
     p = ProjectorMonteCarloProblem(h; threading=true)
     @test p.hamiltonian == h
-    @test valtype(p.hamiltonian) == valtype(h)
 
     @test Rimu.num_replicas(p) == 1
     @test startswith(sprint(show, p), "ProjectorMonteCarloProblem with 1 replica(s)")
@@ -76,7 +75,7 @@ using OrderedCollections: freeze
 
     # complex Hamiltonian
     h = HubbardReal1D(BoseFS(1, 3); u=1.0 + 1.0im)
-    @test valtype(h) <: Complex
+    @test scalartype(h) <: Complex
     @test_throws ArgumentError ProjectorMonteCarloProblem(h)
 end
 

--- a/test/projector_monte_carlo_problem.jl
+++ b/test/projector_monte_carlo_problem.jl
@@ -10,6 +10,7 @@ using OrderedCollections: freeze
     h = HubbardReal1D(BoseFS(1,3))
     p = ProjectorMonteCarloProblem(h; threading=true)
     @test p.hamiltonian == h
+    @test valtype(p.hamiltonian) == valtype(h)
 
     @test Rimu.num_replicas(p) == 1
     @test startswith(sprint(show, p), "ProjectorMonteCarloProblem with 1 replica(s)")
@@ -72,6 +73,11 @@ using OrderedCollections: freeze
     @test state_vectors(sm)[1] === dv1
     @test state_vectors(sm)[2] === dv2
     @test_throws BoundsError sm.state.spectral_states[3]
+
+    # complex Hamiltonian
+    h = HubbardReal1D(BoseFS(1, 3); u=1.0 + 1.0im)
+    @test valtype(h) <: Complex
+    @test_throws ArgumentError ProjectorMonteCarloProblem(h)
 end
 
 @testset "PMCSimulation" begin


### PR DESCRIPTION
Introduces the `AbstractOperator` operator type. It is similar to `AbstractHamiltonian` but there are less stringent requirements. The idea is that `AbstractOperator`s can be used to calculate three-way `dot` products, but they may not be suitable for use as a Hamiltonian in a `ProjectorMonteCarloProblem` or an `ExactDiagonalizationProblem`.

## Breaking changes
- Changes to the `AbstractHamiltonian` interface: The function `allowed_address_type` is removed and replaced by the function `allows_address_type`, which takes two arguments, an operator and a type.

## New features
- `AbstractOperator` is a new abstract type that can be used for operators that are to be used as observables, e.g. for calculating their `dot` products in the context of a `ReplicaStrategy`. `AbstractOperator` is a supertype of `AbstractHamiltonian` and has a similar interface but doesn't require `starting_address`.
- `VectorInterfaces.scalartype` is defined for `AbstractHamiltonian` and `AbstractOperator` to define the underlying scalar type. In contrast,`eltype` defines the type returned by `diagonal_element`, `offdiagonals`, and the three-way `dot` product. This may be an array for `AbstractOperator` only. For `AbstractHamiltonians` the `etype` and `scalartype` should be identical.
- Attempting to use a complex Hamiltonian with `ProjectorMonteCarloProblem` throws an error.