### PR TITLE
Fix `num_particles` for `OccupationNumberFS`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Rimu"
 uuid = "c53c40cc-bd84-11e9-2cf4-a9fde2b9386e"
 authors = ["Joachim Brand <j.brand@massey.ac.nz>"]
-version = "0.12.1"
+version = "0.12.2"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Rimu"
 uuid = "c53c40cc-bd84-11e9-2cf4-a9fde2b9386e"
 authors = ["Joachim Brand <j.brand@massey.ac.nz>"]
-version = "0.12.2"
+version = "0.12.1"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/src/BitStringAddresses/occupationnumberfs.jl
+++ b/src/BitStringAddresses/occupationnumberfs.jl
@@ -71,7 +71,7 @@ Base.isless(a::OccupationNumberFS, b::OccupationNumberFS) = isless(b.onr, a.onr)
 Base.:(==)(a::OccupationNumberFS, b::OccupationNumberFS) = a.onr == b.onr
 Base.hash(ofs::OccupationNumberFS, h::UInt) = hash(ofs.onr, h)
 
-num_particles(ofs::OccupationNumberFS) = Int(sum(onr(ofs)))
+num_particles(ofs::OccupationNumberFS) = sum(Int, onr(ofs))
 # `num_modes` does not have to be defined here, because it is defined for the abstract type
 
 """

--- a/test/BitStringAddresses.jl
+++ b/test/BitStringAddresses.jl
@@ -543,6 +543,7 @@ end
     @testset "Properties of OccupationNumberFS" begin
         @test num_modes(ofs) == 3
         @test num_particles(ofs) == 6
+        @test num_particles(OccupationNumberFS(86, 84, 86)) == 256
         @test num_occupied_modes(ofs) == 3
         @test onr(ofs) == ofs.onr == SVector{3,UInt8}(1, 2, 3)
         @test occupation_number_representation(ofs) == onr(ofs)


### PR DESCRIPTION
# Changes
- In the previous version of the code, the occupation numbers were summed first, then converted to `Int`, which caused integer overflow for large occupation numbers. This PR fixes this issue.