### PR TITLE
Reduce the number of collective MPI calls

### DIFF
--- a/docs/src/dictvectors.md
+++ b/docs/src/dictvectors.md
@@ -42,6 +42,7 @@ In addition, Rimu defines the following function.
 
 ```@docs
 walkernumber
+walkernumber_and_length
 dot_from_right
 ```
 

--- a/src/DictVectors/DictVectors.jl
+++ b/src/DictVectors/DictVectors.jl
@@ -26,7 +26,7 @@ using ..StochasticStyles: StochasticStyles, IsDeterministic
 import ..Interfaces: deposit!, storage, StochasticStyle, default_style, freeze, localpart,
     working_memory
 
-export deposit!, storage, walkernumber, dot_from_right
+export deposit!, storage, walkernumber, walkernumber_and_length, dot_from_right
 export DVec, InitiatorDVec, PDVec, PDWorkingMemory
 
 export InitiatorRule, Initiator, SimpleInitiator, NonInitiator, CoherentInitiator

--- a/src/DictVectors/DictVectors.jl
+++ b/src/DictVectors/DictVectors.jl
@@ -12,6 +12,7 @@ module DictVectors
 using Folds: Folds
 using LinearAlgebra: LinearAlgebra, I, dot, ⋅, mul!, normalize!, rank
 using Random: Random
+using StaticArrays: SVector
 using VectorInterface: VectorInterface, add, add!, inner, norm, scalartype,
     scale, scale!, zerovector, zerovector!, zerovector!!
 

--- a/src/DictVectors/abstractdvec.jl
+++ b/src/DictVectors/abstractdvec.jl
@@ -252,6 +252,14 @@ walkernumber(::StochasticStyle, v) = dot(Norm1ProjectorPPop(), v)
 # complex walkers as two populations
 # the following default is fast and generic enough to be good for real walkers and
 
+"""
+    walkernumber_and_length(v)
+
+Compute [`walkernumber`](@ref) and `length` at the same time. When MPI is used, this is more
+efficient than calling them separately.
+"""
+walkernumber_and_length(v) = walkernumber(v), length(v)
+
 ###
 ### Vector-operator functions
 ###

--- a/src/DictVectors/communicators.jl
+++ b/src/DictVectors/communicators.jl
@@ -486,11 +486,13 @@ function mpi_exchange_alltoall!(
         throw(ArgumentError("mismatch in number of columns ($nrows and $(dst.nrows))."))
     end
 
-    resize!(dst.counts, length(src.counts))
-    MPI.Alltoall!(MPI.UBuffer(src.counts, 1), MPI.UBuffer(dst.counts, 1), comm)
-
     resize!(dst.offsets, length(src.offsets))
     MPI.Alltoall!(MPI.UBuffer(src.offsets, nrows), MPI.UBuffer(dst.offsets, nrows), comm)
+
+    resize!(dst.counts, length(src.counts))
+    for i in eachindex(dst.counts)
+        dst.counts[i] = dst.offsets[i * nrows]
+    end
 
     resize!(dst.buffer, sum(dst.counts))
     send_vbuff = MPI.VBuffer(src.buffer, src.counts)

--- a/src/DictVectors/pdvec.jl
+++ b/src/DictVectors/pdvec.jl
@@ -855,7 +855,7 @@ function walkernumber_and_length(t::PDVec)
     t_local = localpart(t)
     wn = walkernumber(t_local)
     len = length(t_local)
-    result = merge_remote_reductions(t.communicator, add, (wn, len))
+    result = merge_remote_reductions(t.communicator, +, SVector(wn, len))
     return (result[1], Int(result[2]))
 end
 

--- a/src/DictVectors/pdvec.jl
+++ b/src/DictVectors/pdvec.jl
@@ -851,6 +851,14 @@ function LinearAlgebra.dot(t::PDVec, ops::Tuple, source::PDVec, w=nothing)
     end
 end
 
+function walkernumber_and_length(t::PDVec)
+    t_local = localpart(t)
+    wn = walkernumber(t_local)
+    len = length(t_local)
+    result = merge_remote_reductions(t.communicator, add, (wn, len))
+    return (result[1], Int(result[2]))
+end
+
 """
     FrozenPDVec
 

--- a/src/fciqmc.jl
+++ b/src/fciqmc.jl
@@ -140,9 +140,8 @@ function advance!(algorithm::FCIQMC, report, state::ReplicaState, s_state::Singl
     # pv was mutated and now contains the new vector.
     v, pv = (pv, v)
 
-    # Stats
-    tnorm = walkernumber(v)
-    len = length(v)
+    # Stats:
+    tnorm, len = walkernumber_and_length(v)
 
     # Updates
     time_step = update_time_step(time_step_strategy, time_step, tnorm)


### PR DESCRIPTION
# Changes
- Add `walkernumber_and_length` which computes `walkernumber` and `length` with single `MPI.Allreduce!` call.
- Perform all-to-all communication with two `Alltoall[v]!` calls instead of three.
- Remove `wait_time` tracking from MPI as it involves a synchronizing call. This should be done with profiling tools instead.