### PR TITLE
Fix offdiagonals in two particle density matrix

### DIFF
--- a/src/Hamiltonians/reduced_density_matrix.jl
+++ b/src/Hamiltonians/reduced_density_matrix.jl
@@ -34,9 +34,10 @@ function diagonal_element(
 ) where {I,J}
     if I != J
         return 0.0
+    else
+        src = find_mode(addr, J)
+        return src.occnum
     end
-    src = find_mode(addr, J)
-    return src.occnum
 end
 
 function num_offdiagonals(
@@ -53,7 +54,7 @@ function get_offdiagonal(
     ::SingleParticleExcitation{I,J}, addr::SingleComponentFockAddress, _
 ) where {I,J}
     src = find_mode(addr, J)
-    dst = find_mode(addr,I)
+    dst = find_mode(addr, I)
     address, value = excitation(addr, (dst,), (src,))
     return address, value
 end
@@ -95,9 +96,8 @@ function diagonal_element(
 ) where {I,J,K,L}
     if (I, J) == (K, L) || (I, J) == (L, K)
         src = find_mode(addr, (L, K))
-        dst = find_mode(addr,(I, J))
-        _, value = excitation(addr, dst, src)
-        return value
+        dst = find_mode(addr, (I, J))
+        return excitation(addr, dst, src)[2]
     else
         return 0.0
     end
@@ -106,7 +106,7 @@ end
 function num_offdiagonals(
     ::TwoParticleExcitation{I,J,K,L}, ::SingleComponentFockAddress
 ) where {I,J,K,L}
-    if (I, J) == (K, L)
+    if (I, J) == (K, L) || (I, J) == (L, K)
         return 0
     else
         return 1
@@ -117,7 +117,7 @@ function get_offdiagonal(
     ::TwoParticleExcitation{I,J,K,L}, addr::SingleComponentFockAddress, _
 ) where {I,J,K,L}
     src = find_mode(addr, (L, K))
-    dst = find_mode(addr,(I, J))
-    address, value = excitation(addr, (dst...,), (src...,))
+    dst = find_mode(addr, (I, J))
+    address, value = excitation(addr, dst, src)
     return address, value
 end

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -1261,7 +1261,7 @@ using Rimu.Hamiltonians: circshift_dot
         end
         @test num_offdiagonals(SingleParticleExcitation(1,2), addr_bose) == 1
         @test LOStructure(SingleParticleExcitation(1,2)) == AdjointUnknown()
-        @test num_offdiagonals(TwoParticleExcitation(1,2,2,1), addr_bose) == 1
+        @test num_offdiagonals(TwoParticleExcitation(1,2,2,1), addr_bose) == 0
         @test LOStructure(TwoParticleExcitation(1,2,2,1)) == AdjointUnknown()
     end
 end


### PR DESCRIPTION
Before this PR, this happened
```
offdiagonals(TwoParticleExcitation(2,1,1,2), FermiFS(1,1,1,0,0,0))
1-element Rimu.Hamiltonians.Offdiagonals{FermiFS{3, 6, BitString{6, 1, UInt8}}, Float64, TwoParticleExcitation{2, 1, 1, 2}}:
 (fs"|↑↑↑⋅⋅⋅⟩", -1.0)
```
which is wrong.