### PR TITLE
Feature/ExtendedHubbardMom1D

### DIFF
--- a/docs/src/hamiltonians.md
+++ b/docs/src/hamiltonians.md
@@ -31,6 +31,7 @@ ExtendedHubbardReal1D
 HubbardMom1D
 BoseHubbardMom1D2C
 HubbardMom1DEP
+ExtendedHubbardMom1D
 ```
 
 ### Harmonic oscillator models

--- a/src/Hamiltonians/ExtendedHubbardMom1D.jl
+++ b/src/Hamiltonians/ExtendedHubbardMom1D.jl
@@ -111,14 +111,14 @@ end
 @inline function get_offdiagonal(
     ham::ExtendedHubbardMom1D{<:Any,M,A}, address::A, chosen, map=OccupiedModeMap(address)
 ) where {M,A<:SingleComponentFockAddress}
-    address, onproduct,_,_,q = extended_momentum_transfer_excitation(address, chosen, map)
+    address, onproduct,_,_,q = momentum_transfer_excitation(address, chosen, map)
     return address, ham.u/(2*M)*onproduct + ((ham.v * cos((q)*((2*π)/M)))/(M))*onproduct
 end
 
 @inline function get_offdiagonal(
     ham::ExtendedHubbardMom1D{<:Any,M,A}, address::A, chosen, map=OccupiedModeMap(address)
 ) where {M,A<:FermiFS}
-    address, onproduct,_,_,q = extended_momentum_transfer_excitation(address, chosen, map)
+    address, onproduct,_,_,q = momentum_transfer_excitation(address, chosen, map)
     return address, -((ham.v * cos((q)*((2*π)/M)))/(M))*onproduct
 end
 momentum(ham::ExtendedHubbardMom1D) = MomentumMom1D(ham)

--- a/src/Hamiltonians/ExtendedHubbardMom1D.jl
+++ b/src/Hamiltonians/ExtendedHubbardMom1D.jl
@@ -112,6 +112,6 @@ end
     ham::ExtendedHubbardMom1D{<:Any,M,A}, address::A, chosen, map=OccupiedModeMap(address)
 ) where {M,A<:FermiFS}
     address, onproduct,_,_,q = momentum_transfer_excitation(address, chosen, map)
-    return address, -((ham.v * cos((q)*((2*π)/M)))/(M))*onproduct
+    return address, -ham.v * onproduct * cos(q * 2π / M) / M
 end
 momentum(ham::ExtendedHubbardMom1D) = MomentumMom1D(ham)

--- a/src/Hamiltonians/ExtendedHubbardMom1D.jl
+++ b/src/Hamiltonians/ExtendedHubbardMom1D.jl
@@ -1,7 +1,8 @@
 """
     ExtendedHubbardMom1D(address; u=1.0, t=1.0, v=1.0, dispersion=hubbard_dispersion, boundary_condition = 0.0)
 
-Implements a one-dimensional extended Hubbard chain in momentum space.
+Implements a one-dimensional extended Hubbard chain, also known as the ``t - V`` model, 
+in momentum space.
 
 ```math
 \\hat{H} =  \\sum_{k} ϵ_k n_k + \\frac{1}{2M} \\sum_{kpqr} (u + 2v \\cos(q-p)) a^†_{r} a^†_{q} a_p a_k δ_{r+q,p+k}

--- a/src/Hamiltonians/ExtendedHubbardMom1D.jl
+++ b/src/Hamiltonians/ExtendedHubbardMom1D.jl
@@ -105,7 +105,7 @@ end
     ham::ExtendedHubbardMom1D{<:Any,M,A}, address::A, chosen, map=OccupiedModeMap(address)
 ) where {M,A<:SingleComponentFockAddress}
     address, onproduct,_,_,q = momentum_transfer_excitation(address, chosen, map)
-    return address, ham.u/(2*M)*onproduct + ((ham.v * cos((q)*((2*π)/M)))/(M))*onproduct
+    return address, ham.u * onproduct / 2M + ham.v * cos(q * 2π / M) * onproduct / M
 end
 
 @inline function get_offdiagonal(

--- a/src/Hamiltonians/ExtendedHubbardMom1D.jl
+++ b/src/Hamiltonians/ExtendedHubbardMom1D.jl
@@ -93,8 +93,8 @@ end
 @inline function momentum_transfer_diagonal(
     h::ExtendedHubbardMom1D{<:Any,M,<:BoseFS}, map
 ) where {M}
-    return h.u / 2M *momentum_transfer_diagonal(map) 
-    + h.v/ M * dot(cos.(h.ks), map) * extended_momentum_transfer_diagonal(map, (2*π)/M) 
+    return (h.u/ 2M) * momentum_transfer_diagonal(map) 
+    + (h.v/ M) * extended_momentum_transfer_diagonal(map, (2*π)/M) 
 end
 
 @inline function momentum_transfer_diagonal(

--- a/src/Hamiltonians/ExtendedHubbardMom1D.jl
+++ b/src/Hamiltonians/ExtendedHubbardMom1D.jl
@@ -1,0 +1,128 @@
+"""
+    ExtendedHubbardMom1D(address; u=1.0, t=1.0, v=1.0, dispersion=hubbard_dispersion, boundary_condition = 0.0)
+
+Implements a one-dimensional extended Hubbard chain in momentum space.
+
+```math
+\\hat{H} =  \\sum_{k} ϵ_k n_k + \\frac{1}{2M} \\sum_{kpqr} (u + 2v \\cos(q-p)) a^†_{r} a^†_{q} a_p a_k δ_{r+q,p+k}
+```
+
+# Arguments
+
+* `address`: the starting address, defines number of particles and sites.
+* `u`: the interaction parameter.
+* `t`: the hopping strength.
+* `boundary_condition`: `θ <: Number`: hopping over the boundary incurs a
+    factor ``\\exp(iθ)`` for a hop to the right and ``\\exp(−iθ)`` for a hop to the left.
+
+* `dispersion`: defines ``ϵ_k =``` dispersion(t, k + θ)`
+    - [`hubbard_dispersion`](@ref): ``ϵ_k = -2 (\\Re(t) \\cos(k + θ) + \\Im(t) \\sin(k + θ))``
+    - [`continuum_dispersion`](@ref): ``ϵ_k = \\Re(t) (k + θ)^2 - 2 \\Im(t) (k + θ)``
+
+# See also
+
+* [`HubbardMom1D`](@ref)
+* [`HubbardReal1D`](@ref)
+* [`ExtendedHubbardReal1D`](@ref)
+"""
+struct ExtendedHubbardMom1D{TT,M,AD<:AbstractFockAddress,U,V,T,BOUNDARY_CONDITION} <: AbstractHamiltonian{TT}
+    address::AD # default starting address, should have N particles and M modes
+    ks::SVector{M,TT} # values for k
+    kes::SVector{M,TT} # values for kinetic energy
+end
+
+function ExtendedHubbardMom1D(
+    address::SingleComponentFockAddress;
+    u=1.0, v=1.0, t=1.0, dispersion = hubbard_dispersion, boundary_condition = 0.0
+)
+    M = num_modes(address)
+    U, V, T= promote(float(u), float(v), float(t))
+    step = 2π/M
+    if isodd(M)
+        start = -π*(1+1/M) + step
+    else
+        start = -π + step
+    end
+    kr = range(start; step = step, length = M)
+    ks = SVector{M}(kr)
+    kes = SVector{M}(dispersion.(T , kr .+ boundary_condition))
+    return ExtendedHubbardMom1D{typeof(U),M,typeof(address),U,V,T,boundary_condition}(address, ks, kes)
+end
+
+function Base.show(io::IO, h::ExtendedHubbardMom1D)
+    compact_addr = repr(h.address, context=:compact => true) # compact print address
+    print(io, "ExtendedHubbardMom1D($(compact_addr); u=$(h.u), v=$(h.v), t=$(h.t), boundary_condition=$(h.boundary_condition))")
+end
+
+function starting_address(h::ExtendedHubbardMom1D)
+    return h.address
+end
+
+dimension(::ExtendedHubbardMom1D, address) = number_conserving_dimension(address)
+
+LOStructure(::Type{<:ExtendedHubbardMom1D{<:Real}}) = IsHermitian()
+
+Base.getproperty(h::ExtendedHubbardMom1D, s::Symbol) = getproperty(h, Val(s))
+Base.getproperty(h::ExtendedHubbardMom1D, ::Val{:ks}) = getfield(h, :ks)
+Base.getproperty(h::ExtendedHubbardMom1D, ::Val{:kes}) = getfield(h, :kes)
+Base.getproperty(h::ExtendedHubbardMom1D, ::Val{:address}) = getfield(h, :address)
+Base.getproperty(h::ExtendedHubbardMom1D{<:Any,<:Any,<:Any,U}, ::Val{:u}) where {U} = U
+Base.getproperty(h::ExtendedHubbardMom1D{<:Any,<:Any,<:Any,<:Any,V}, ::Val{:v}) where {V} = V
+Base.getproperty(h::ExtendedHubbardMom1D{<:Any,<:Any,<:Any,<:Any,<:Any,T}, ::Val{:t}) where {T} = T
+Base.getproperty(h::ExtendedHubbardMom1D{<:Any,<:Any,<:Any,<:Any,<:Any,<:Any,BOUNDARY_CONDITION}, 
+    ::Val{:boundary_condition}) where {BOUNDARY_CONDITION} = BOUNDARY_CONDITION
+
+ks(h::ExtendedHubbardMom1D) = getfield(h, :ks)
+
+# standard interface function
+function num_offdiagonals(ham::ExtendedHubbardMom1D, address::SingleComponentFockAddress)
+    singlies, doublies = num_singly_doubly_occupied_sites(address)
+    return num_offdiagonals(ham, address, singlies, doublies)
+end
+
+# 4-argument version
+@inline function num_offdiagonals(ham::ExtendedHubbardMom1D, ::SingleComponentFockAddress, singlies, doublies)
+    M = num_modes(ham)
+    return singlies * (singlies - 1) * (M - 2) + doublies * (M - 1)
+end
+
+@inline function momentum_transfer_diagonal(
+    h::ExtendedHubbardMom1D{<:Any,M,<:BoseFS}, map
+) where {M}
+    return h.u / 2M *momentum_transfer_diagonal(map) 
+    + h.v/ M * dot(cos.(h.ks), map) * extended_momentum_transfer_diagonal(map,M) 
+end
+
+@inline function momentum_transfer_diagonal(
+    h::ExtendedHubbardMom1D{<:Any,M,<:FermiFS}, map
+) where {M}
+    return (h.v/ M) * extended_momentum_transfer_diagonal(map, M)
+end
+
+@inline function diagonal_element(h::ExtendedHubbardMom1D, address::SingleComponentFockAddress)
+    map = OccupiedModeMap(address)
+    return dot(h.kes, map) + momentum_transfer_diagonal(h, map)
+end
+
+@inline function get_offdiagonal(
+    ham::ExtendedHubbardMom1D{<:Any,M,A}, address::A, chosen, map=OccupiedModeMap(address)
+) where {M,A<:BoseFS}
+    address, onproduct,_,_,q = momentum_transfer_excitation(address, chosen, map)
+    return address, ham.u/(2*M)*onproduct + ((ham.v * cos((q)*((2*π)/M)))/(M))*onproduct
+end
+
+@inline function get_offdiagonal(
+    ham::ExtendedHubbardMom1D{<:Any,M,A}, address::A, chosen, map=OccupiedModeMap(address)
+) where {M,A<:FermiFS}
+    address, onproduct,_,_,q = momentum_transfer_excitation(address, chosen, map)
+    return address, -((ham.v * cos((q)*((2*π)/M)))/(M))*onproduct
+end
+
+function offdiagonals(h::ExtendedHubbardMom1D, a::SingleComponentFockAddress)
+    map = OccupiedModeMap(a)
+    singlies = length(map)
+    doublies = count(i -> i.occnum ≥ 2, map)
+    num = num_offdiagonals(h, a, singlies, doublies)
+    return OffdiagonalsBoseMom1D(h, a, num, map)
+end
+momentum(ham::ExtendedHubbardMom1D) = MomentumMom1D(ham)

--- a/src/Hamiltonians/ExtendedHubbardMom1D.jl
+++ b/src/Hamiltonians/ExtendedHubbardMom1D.jl
@@ -94,7 +94,7 @@ end
     h::ExtendedHubbardMom1D{<:Any,M,<:BoseFS}, map
 ) where {M}
     return h.u / 2M *momentum_transfer_diagonal(map) 
-    + h.v/ M * dot(cos.(h.ks), map) * extended_momentum_transfer_diagonal(map,M) 
+    + h.v/ M * dot(cos.(h.ks), map) * extended_momentum_transfer_diagonal(map, (2*π)/M) 
 end
 
 @inline function momentum_transfer_diagonal(

--- a/src/Hamiltonians/ExtendedHubbardMom1D.jl
+++ b/src/Hamiltonians/ExtendedHubbardMom1D.jl
@@ -111,22 +111,14 @@ end
 @inline function get_offdiagonal(
     ham::ExtendedHubbardMom1D{<:Any,M,A}, address::A, chosen, map=OccupiedModeMap(address)
 ) where {M,A<:BoseFS}
-    address, onproduct,_,_,q = momentum_transfer_excitation(address, chosen, map)
+    address, onproduct,_,_,q = extended_momentum_transfer_excitation(address, chosen, map)
     return address, ham.u/(2*M)*onproduct + ((ham.v * cos((q)*((2*π)/M)))/(M))*onproduct
 end
 
 @inline function get_offdiagonal(
     ham::ExtendedHubbardMom1D{<:Any,M,A}, address::A, chosen, map=OccupiedModeMap(address)
 ) where {M,A<:FermiFS}
-    address, onproduct,_,_,q = momentum_transfer_excitation(address, chosen, map)
+    address, onproduct,_,_,q = extended_momentum_transfer_excitation(address, chosen, map)
     return address, -((ham.v * cos((q)*((2*π)/M)))/(M))*onproduct
-end
-
-function offdiagonals(h::ExtendedHubbardMom1D, a::SingleComponentFockAddress)
-    map = OccupiedModeMap(a)
-    singlies = length(map)
-    doublies = count(i -> i.occnum ≥ 2, map)
-    num = num_offdiagonals(h, a, singlies, doublies)
-    return OffdiagonalsBoseMom1D(h, a, num, map)
 end
 momentum(ham::ExtendedHubbardMom1D) = MomentumMom1D(ham)

--- a/src/Hamiltonians/ExtendedHubbardMom1D.jl
+++ b/src/Hamiltonians/ExtendedHubbardMom1D.jl
@@ -90,13 +90,13 @@ end
     return singlies * (singlies - 1) * (M - 2) + doublies * (M - 1)
 end
 
-@inline function diagonal_element(h::ExtendedHubbardMom1D, address::SingleComponentFockAddress)
+@inline function diagonal_element(h::ExtendedHubbardMom1D{<:Any,M,A}, address::A) where {M,A<:SingleComponentFockAddress}
     map = OccupiedModeMap(address)
     return dot(h.kes, map) + (h.u/ 2M) * momentum_transfer_diagonal(map) 
         + (h.v/ M) * extended_momentum_transfer_diagonal(map, (2*π)/M)
 end
 
-@inline function diagonal_element(h::ExtendedHubbardMom1D, address::FermiFS)
+@inline function diagonal_element(h::ExtendedHubbardMom1D{<:Any,M,A}, address::A) where {M,A<:FermiFS}
     map = OccupiedModeMap(address)
     return dot(h.kes, map) + (h.v/ M) * extended_momentum_transfer_diagonal(map, M)
 end

--- a/src/Hamiltonians/ExtendedHubbardMom1D.jl
+++ b/src/Hamiltonians/ExtendedHubbardMom1D.jl
@@ -90,22 +90,15 @@ end
     return singlies * (singlies - 1) * (M - 2) + doublies * (M - 1)
 end
 
-@inline function momentum_transfer_diagonal(
-    h::ExtendedHubbardMom1D{<:Any,M,<:SingleComponentFockAddress}, map
-) where {M}
-    return (h.u/ 2M) * momentum_transfer_diagonal(map) 
-    + (h.v/ M) * extended_momentum_transfer_diagonal(map, (2*π)/M) 
-end
-
-@inline function momentum_transfer_diagonal(
-    h::ExtendedHubbardMom1D{<:Any,M,<:FermiFS}, map
-) where {M}
-    return (h.v/ M) * extended_momentum_transfer_diagonal(map, M)
-end
-
 @inline function diagonal_element(h::ExtendedHubbardMom1D, address::SingleComponentFockAddress)
     map = OccupiedModeMap(address)
-    return dot(h.kes, map) + momentum_transfer_diagonal(h, map)
+    return dot(h.kes, map) + (h.u/ 2M) * momentum_transfer_diagonal(map) 
+        + (h.v/ M) * extended_momentum_transfer_diagonal(map, (2*π)/M)
+end
+
+@inline function diagonal_element(h::ExtendedHubbardMom1D, address::FermiFS)
+    map = OccupiedModeMap(address)
+    return dot(h.kes, map) + (h.v/ M) * extended_momentum_transfer_diagonal(map, M)
 end
 
 @inline function get_offdiagonal(

--- a/src/Hamiltonians/ExtendedHubbardMom1D.jl
+++ b/src/Hamiltonians/ExtendedHubbardMom1D.jl
@@ -1,5 +1,8 @@
 """
-    ExtendedHubbardMom1D(address; u=1.0, t=1.0, v=1.0, dispersion=hubbard_dispersion, boundary_condition = 0.0)
+    ExtendedHubbardMom1D(
+        address; 
+        u=1.0, t=1.0, v=1.0, dispersion=hubbard_dispersion, boundary_condition = 0.0
+    )
 
 Implements a one-dimensional extended Hubbard chain, also known as the ``t - V`` model, 
 in momentum space.

--- a/src/Hamiltonians/ExtendedHubbardMom1D.jl
+++ b/src/Hamiltonians/ExtendedHubbardMom1D.jl
@@ -93,12 +93,12 @@ end
 @inline function diagonal_element(h::ExtendedHubbardMom1D{<:Any,M,A}, address::A) where {M,A<:SingleComponentFockAddress}
     map = OccupiedModeMap(address)
     return dot(h.kes, map) + (h.u/ 2M) * momentum_transfer_diagonal(map) 
-        + (h.v/ M) * extended_momentum_transfer_diagonal(map, (2*π)/M)
+        + (h.v/ M) * extended_momentum_transfer_diagonal(map, 2π / M)
 end
 
 @inline function diagonal_element(h::ExtendedHubbardMom1D{<:Any,M,A}, address::A) where {M,A<:FermiFS}
     map = OccupiedModeMap(address)
-    return dot(h.kes, map) + (h.v/ M) * extended_momentum_transfer_diagonal(map, M)
+    return dot(h.kes, map) + (h.v/ M) * extended_momentum_transfer_diagonal(map, 2π / M)
 end
 
 @inline function get_offdiagonal(

--- a/src/Hamiltonians/ExtendedHubbardMom1D.jl
+++ b/src/Hamiltonians/ExtendedHubbardMom1D.jl
@@ -91,7 +91,7 @@ end
 end
 
 @inline function momentum_transfer_diagonal(
-    h::ExtendedHubbardMom1D{<:Any,M,<:BoseFS}, map
+    h::ExtendedHubbardMom1D{<:Any,M,<:SingleComponentFockAddress}, map
 ) where {M}
     return (h.u/ 2M) * momentum_transfer_diagonal(map) 
     + (h.v/ M) * extended_momentum_transfer_diagonal(map, (2*π)/M) 
@@ -110,7 +110,7 @@ end
 
 @inline function get_offdiagonal(
     ham::ExtendedHubbardMom1D{<:Any,M,A}, address::A, chosen, map=OccupiedModeMap(address)
-) where {M,A<:BoseFS}
+) where {M,A<:SingleComponentFockAddress}
     address, onproduct,_,_,q = extended_momentum_transfer_excitation(address, chosen, map)
     return address, ham.u/(2*M)*onproduct + ((ham.v * cos((q)*((2*π)/M)))/(M))*onproduct
 end

--- a/src/Hamiltonians/ExtendedHubbardMom1D.jl
+++ b/src/Hamiltonians/ExtendedHubbardMom1D.jl
@@ -92,8 +92,8 @@ end
 
 @inline function diagonal_element(h::ExtendedHubbardMom1D{<:Any,M,A}, address::A) where {M,A<:SingleComponentFockAddress}
     map = OccupiedModeMap(address)
-    return dot(h.kes, map) + (h.u/ 2M) * momentum_transfer_diagonal(map) 
-        + (h.v/ M) * extended_momentum_transfer_diagonal(map, 2π / M)
+    return (dot(h.kes, map) + (h.u/ 2M) * momentum_transfer_diagonal(map) 
+        + (h.v/ M) * extended_momentum_transfer_diagonal(map, 2π / M))
 end
 
 @inline function diagonal_element(h::ExtendedHubbardMom1D{<:Any,M,A}, address::A) where {M,A<:FermiFS}

--- a/src/Hamiltonians/ExtendedHubbardMom1D.jl
+++ b/src/Hamiltonians/ExtendedHubbardMom1D.jl
@@ -49,7 +49,7 @@ function ExtendedHubbardMom1D(
     end
     kr = range(start; step = step, length = M)
     ks = SVector{M}(kr)
-    kes = SVector{M}(dispersion.(T , kr .+ boundary_condition))
+    kes = SVector{M}(dispersion.(T , kr .+ (boundary_condition/M)))
     return ExtendedHubbardMom1D{typeof(U),M,typeof(address),U,V,T,boundary_condition}(address, ks, kes)
 end
 

--- a/src/Hamiltonians/Hamiltonians.jl
+++ b/src/Hamiltonians/Hamiltonians.jl
@@ -103,11 +103,11 @@ include("MatrixHamiltonian.jl")
 
 include("HubbardReal1D.jl")
 include("HubbardReal1DEP.jl")
+include("ExtendedHubbardMom1D.jl")
 include("HubbardMom1D.jl")
 include("HubbardMom1DEP.jl")
 include("HubbardRealSpace.jl")
 include("ExtendedHubbardReal1D.jl")
-include("ExtendedHubbardMom1D.jl")
 
 include("BoseHubbardReal1D2C.jl")
 include("BoseHubbardMom1D2C.jl")

--- a/src/Hamiltonians/Hamiltonians.jl
+++ b/src/Hamiltonians/Hamiltonians.jl
@@ -71,7 +71,7 @@ import ..Interfaces: diagonal_element, num_offdiagonals, get_offdiagonal, starti
 export dimension, rayleigh_quotient, momentum
 
 export MatrixHamiltonian
-export HubbardReal1D, HubbardMom1D, ExtendedHubbardReal1D, HubbardRealSpace
+export HubbardReal1D, HubbardMom1D, ExtendedHubbardReal1D, ExtendedHubbardMom1D, HubbardRealSpace
 export HubbardReal1DEP, shift_lattice, shift_lattice_inv
 export HubbardMom1DEP
 export BoseHubbardMom1D2C, BoseHubbardReal1D2C
@@ -107,6 +107,7 @@ include("HubbardMom1D.jl")
 include("HubbardMom1DEP.jl")
 include("HubbardRealSpace.jl")
 include("ExtendedHubbardReal1D.jl")
+include("ExtendedHubbardMom1D.jl")
 
 include("BoseHubbardReal1D2C.jl")
 include("BoseHubbardMom1D2C.jl")

--- a/src/Hamiltonians/HubbardMom1D.jl
+++ b/src/Hamiltonians/HubbardMom1D.jl
@@ -132,7 +132,7 @@ function num_offdiagonals(ham::HubbardMom1D, address::SingleComponentFockAddress
     singlies, doublies = num_singly_doubly_occupied_sites(address)
     return num_offdiagonals(ham, address, singlies, doublies)
 end
-
+num_offdiagonals(ham::HubbardMom1D, address::FermiFS) = 0
 # 4-argument version
 @inline function num_offdiagonals(ham::HubbardMom1D, ::SingleComponentFockAddress, singlies, doublies)
     M = num_modes(ham)
@@ -174,6 +174,10 @@ end
 @inline function diagonal_element(h::HubbardMom1D, address::SingleComponentFockAddress)
     map = OccupiedModeMap(address)
     return dot(h.kes, map) + momentum_transfer_diagonal(h, map)
+end
+@inline function diagonal_element(h::HubbardMom1D, address::FermiFS)
+    map = OccupiedModeMap(address)
+    return dot(h.kes, map)
 end
 @inline function diagonal_element(h::HubbardMom1D, address::FermiFS2C)
     map_a = OccupiedModeMap(address.components[1])

--- a/src/Hamiltonians/HubbardMom1D.jl
+++ b/src/Hamiltonians/HubbardMom1D.jl
@@ -218,7 +218,7 @@ struct OffdiagonalsBoseMom1D{
     map::O
 end
 
-function offdiagonals(h::union(HubbardMom1D, ExtendedHubbardMom1D), a::SingleComponentFockAddress)
+function offdiagonals(h::HubbardMom1D, a::SingleComponentFockAddress)
     map = OccupiedModeMap(a)
     singlies = length(map)
     doublies = count(i -> i.occnum ≥ 2, map)

--- a/src/Hamiltonians/HubbardMom1D.jl
+++ b/src/Hamiltonians/HubbardMom1D.jl
@@ -181,6 +181,7 @@ end
     return dot(h.kes, map_a) + dot(h.kes, map_b) +
         momentum_transfer_diagonal(h, map_a, map_b)
 end
+
 @inline function get_offdiagonal(
     ham::HubbardMom1D{<:Any,M,A}, address::A, chosen, map=OccupiedModeMap(address)
 ) where {M,A<:SingleComponentFockAddress}

--- a/src/Hamiltonians/HubbardMom1D.jl
+++ b/src/Hamiltonians/HubbardMom1D.jl
@@ -183,11 +183,6 @@ end
 end
 @inline function get_offdiagonal(
     ham::HubbardMom1D{<:Any,M,A}, address::A, chosen, map=OccupiedModeMap(address)
-) where {M,A<:FermiFS}
-    return address, 0.0
-end
-@inline function get_offdiagonal(
-    ham::HubbardMom1D{<:Any,M,A}, address::A, chosen, map=OccupiedModeMap(address)
 ) where {M,A<:SingleComponentFockAddress}
     address, onproduct = momentum_transfer_excitation(address, chosen, map)
     return address, ham.u/(2*M)*onproduct

--- a/src/Hamiltonians/HubbardMom1D.jl
+++ b/src/Hamiltonians/HubbardMom1D.jl
@@ -184,9 +184,14 @@ end
 
 @inline function get_offdiagonal(
     ham::HubbardMom1D{<:Any,M,A}, address::A, chosen, map=OccupiedModeMap(address)
-) where {M,A<:SingleComponentFockAddress}
+) where {M,A<:BoseFS}
     address, onproduct = momentum_transfer_excitation(address, chosen, map)
     return address, ham.u/(2*M)*onproduct
+end
+@inline function get_offdiagonal(
+    ham::HubbardMom1D{<:Any,M,A}, address::A, chosen, map=OccupiedModeMap(address)
+) where {M,A<:FermiFS}
+    return address, 0
 end
 @inline function get_offdiagonal(
     ham::HubbardMom1D{<:Any,M,A}, address::A, chosen,

--- a/src/Hamiltonians/HubbardMom1D.jl
+++ b/src/Hamiltonians/HubbardMom1D.jl
@@ -184,14 +184,9 @@ end
 
 @inline function get_offdiagonal(
     ham::HubbardMom1D{<:Any,M,A}, address::A, chosen, map=OccupiedModeMap(address)
-) where {M,A<:BoseFS}
+) where {M,A<:SingleComponentFockAddress}
     address, onproduct = momentum_transfer_excitation(address, chosen, map)
     return address, ham.u/(2*M)*onproduct
-end
-@inline function get_offdiagonal(
-    ham::HubbardMom1D{<:Any,M,A}, address::A, chosen, map=OccupiedModeMap(address)
-) where {M,A<:FermiFS}
-    return address, 0
 end
 @inline function get_offdiagonal(
     ham::HubbardMom1D{<:Any,M,A}, address::A, chosen,

--- a/src/Hamiltonians/HubbardMom1D.jl
+++ b/src/Hamiltonians/HubbardMom1D.jl
@@ -218,7 +218,7 @@ struct OffdiagonalsBoseMom1D{
     map::O
 end
 
-function offdiagonals(h::HubbardMom1D, a::SingleComponentFockAddress)
+function offdiagonals(h::union(HubbardMom1D, ExtendedHubbardMom1D), a::SingleComponentFockAddress)
     map = OccupiedModeMap(a)
     singlies = length(map)
     doublies = count(i -> i.occnum ≥ 2, map)

--- a/src/Hamiltonians/HubbardMom1D.jl
+++ b/src/Hamiltonians/HubbardMom1D.jl
@@ -181,7 +181,11 @@ end
     return dot(h.kes, map_a) + dot(h.kes, map_b) +
         momentum_transfer_diagonal(h, map_a, map_b)
 end
-
+@inline function get_offdiagonal(
+    ham::HubbardMom1D{<:Any,M,A}, address::A, chosen, map=OccupiedModeMap(address)
+) where {M,A<:FermiFS}
+    return address, 0.0
+end
 @inline function get_offdiagonal(
     ham::HubbardMom1D{<:Any,M,A}, address::A, chosen, map=OccupiedModeMap(address)
 ) where {M,A<:SingleComponentFockAddress}

--- a/src/Hamiltonians/HubbardMom1DEP.jl
+++ b/src/Hamiltonians/HubbardMom1DEP.jl
@@ -58,7 +58,7 @@ is an external harmonic potential in momentum space,
 * `u`: the interaction parameter.
 * `t`: the hopping strength.
 * `dispersion`: defines ``ϵ_k =``` t*dispersion(k)`
-    - [`hubbard_dispersion`](@ref): ``ϵ_k = -2( \\Re(t) cos(k) + \\Im(t) sin(k))``
+    - [`hubbard_dispersion`](@ref): ``ϵ_k = -2[\\Re(t) \\cos(k) + \\Im(t) \\sin(k)]``
     - [`continuum_dispersion`](@ref): ``ϵ_k = \\Re(t) k^2 - 2 \\Im(t) k``
 * `v_ho`: strength of the external harmonic oscillator potential ``v_\\mathrm{ho}``.
 

--- a/src/Hamiltonians/HubbardMom1DEP.jl
+++ b/src/Hamiltonians/HubbardMom1DEP.jl
@@ -57,7 +57,7 @@ is an external harmonic potential in momentum space,
 * `address`: the starting address, defines number of particles and sites.
 * `u`: the interaction parameter.
 * `t`: the hopping strength.
-* `dispersion`: defines ``ϵ_k =``` t*dispersion(k)`
+* `dispersion`: defines ``ϵ_k =``` dispersion(t, k)`
     - [`hubbard_dispersion`](@ref): ``ϵ_k = -2[\\Re(t) \\cos(k) + \\Im(t) \\sin(k)]``
     - [`continuum_dispersion`](@ref): ``ϵ_k = \\Re(t) k^2 - 2 \\Im(t) k``
 * `v_ho`: strength of the external harmonic oscillator potential ``v_\\mathrm{ho}``.

--- a/src/Hamiltonians/excitations.jl
+++ b/src/Hamiltonians/excitations.jl
@@ -142,9 +142,8 @@ end
 The diagonal part of nearest neighbour [`momentum_transfer_excitation`](@ref).
 """
 
-function extended_momentum_transfer_diagonal(map::OccupiedModeMap,M::Int)
+function extended_momentum_transfer_diagonal(map::OccupiedModeMap, step)
     onproduct = 0
-    step = (2*π)/M
     for i in 1:length(map)
         occ_i = map[i].occnum
         onproduct += occ_i * (occ_i - 1)

--- a/src/Hamiltonians/excitations.jl
+++ b/src/Hamiltonians/excitations.jl
@@ -195,11 +195,11 @@ function momentum_transfer_diagonal(map::BoseOccupiedModeMap)
 end
 
 """
-    extended_momentum_transfer_diagonal(map, M)
+    extended_momentum_transfer_diagonal(map, step)
 
-The diagonal part of nearest neighbour [`momentum_transfer_excitation`](@ref).
+The diagonal part of nearest neighbour term [`momentum_transfer_excitation`](@ref) in [`ExtendedHubbardMom1D`](@ref).
+Where `step` is the separation between the two nearest single-particle momentum.
 """
-
 function extended_momentum_transfer_diagonal(map::OccupiedModeMap, step)
     onproduct = 0
     for i in 1:length(map)

--- a/src/Hamiltonians/excitations.jl
+++ b/src/Hamiltonians/excitations.jl
@@ -140,7 +140,7 @@ end
     extended_momentum_transfer_diagonal(map, step)
 
 The diagonal part of nearest neighbour term [`momentum_transfer_excitation`](@ref) in [`ExtendedHubbardMom1D`](@ref).
-Where `step` is the separation between the two nearest single-particle momentum.
+Where `step` is the separation of single-particle momenta in the momentum grid.
 """
 function extended_momentum_transfer_diagonal(map::OccupiedModeMap, step)
     onproduct = 0

--- a/src/Hamiltonians/excitations.jl
+++ b/src/Hamiltonians/excitations.jl
@@ -79,10 +79,6 @@ See [`excitation`](@ref), [`OccupiedModeMap`](@ref).
     return excitation(add, dst_indices, src_indices)..., src_modes..., -mom_change
 end
 
-function momentum_transfer_excitation(add::FermiFS, chosen::Integer, map; fold=true)
-    return add, 0.0, 0, 0, 0
-end
-
 @inline function momentum_transfer_excitation(
     add_a, add_b, chosen, map_a, map_b; fold=true
 )
@@ -125,7 +121,7 @@ end
 """
     momentum_transfer_diagonal(map)
 
-The diagonal part of [`momentum_transfer_excitation`](@ref).
+The diagonal part of onsite [`momentum_transfer_excitation`](@ref).
 """
 function momentum_transfer_diagonal(map::BoseOccupiedModeMap)
     onproduct = 0
@@ -139,6 +135,27 @@ function momentum_transfer_diagonal(map::BoseOccupiedModeMap)
     end
     return float(onproduct)
 end
+
+"""
+    extended_momentum_transfer_diagonal(map, M)
+
+The diagonal part of nearest neighbour [`momentum_transfer_excitation`](@ref).
+"""
+
+function extended_momentum_transfer_diagonal(map::OccupiedModeMap,M::Int)
+    onproduct = 0
+    step = (2*π)/M
+    for i in 1:length(map)
+        occ_i = map[i].occnum
+        onproduct += occ_i * (occ_i - 1)
+        for j in 1:i-1
+            occ_j = map[j].occnum
+            onproduct += 2*occ_i * occ_j * (1 - cos((map[j].mode - map[i].mode)*step))
+        end
+    end
+    return float(onproduct)
+end
+
 function momentum_transfer_diagonal(
     map_a::FermiOccupiedModeMap, map_b::FermiOccupiedModeMap
 )

--- a/src/Hamiltonians/excitations.jl
+++ b/src/Hamiltonians/excitations.jl
@@ -79,6 +79,64 @@ See [`excitation`](@ref), [`OccupiedModeMap`](@ref).
     return excitation(add, dst_indices, src_indices)..., src_modes..., -mom_change
 end
 
+function momentum_transfer_excitation(add::FermiFS, chosen::Integer, map; fold=true)
+    return add, 0.0, 0, 0, 0
+end
+
+function extended_momentum_transfer_excitation(add::SingleComponentFockAddress, chosen::Integer, map; fold=true)
+    M = num_modes(add)
+    singlies = length(map) # number of at least singly occupied modes
+
+    double = chosen - singlies * (singlies - 1) * (M - 2)
+
+    if double > 0
+        # Both moves from the same mode.
+        double, mom_change = fldmod1(double, M - 1)
+        idx = first(map) # placeholder
+        for i in map
+            double -= i.occnum ≥ 2
+            if double == 0
+                idx = i
+                break
+            end
+        end
+        src_indices = (idx, idx)
+    else
+        # Moves from different modes.
+        pair, mom_change = fldmod1(chosen, M - 2)
+        fst, snd = fldmod1(pair, singlies - 1) # where the holes are to be made
+        if snd < fst # put them in ascending order
+            f_hole = snd
+            s_hole = fst
+        else
+            f_hole = fst
+            s_hole = snd + 1 # as we are counting through all singlies
+        end
+        src_indices = (map[f_hole], map[s_hole])
+        f_mode = src_indices[1].mode
+        s_mode = src_indices[2].mode
+        if mom_change ≥ s_mode - f_mode
+            mom_change += 1 # to avoid putting particles back into the holes
+        end
+    end
+    # For higher dimensions, replace mod1 here with some geometry.
+    src_modes = (src_indices[1].mode, src_indices[2].mode)
+    dst_modes = (src_modes[1] + mom_change, src_modes[2] - mom_change)
+    if fold
+        dst_modes = (mod1(dst_modes[1], M), mod1(dst_modes[2], M))
+    elseif !(1 ≤ dst_modes[1] ≤ M && 1 ≤ dst_modes[2] ≤ M)
+        # Using a positive momentum change would have folded, so we try to use its negative
+        # equivalent.
+        mom_change = mom_change - M
+        dst_modes = (src_modes[1] + mom_change, src_modes[2] - mom_change)
+        if !(1 ≤ dst_modes[1] ≤ M && 1 ≤ dst_modes[2] ≤ M)
+            return add, 0.0, src_modes..., -mom_change
+        end
+    end
+    dst_indices = find_mode(add, dst_modes)
+    return excitation(add, dst_indices, src_indices)..., src_modes..., -mom_change
+end
+
 @inline function momentum_transfer_excitation(
     add_a, add_b, chosen, map_a, map_b; fold=true
 )

--- a/src/Hamiltonians/excitations.jl
+++ b/src/Hamiltonians/excitations.jl
@@ -142,19 +142,6 @@ end
 The diagonal part of nearest neighbour term [`momentum_transfer_excitation`](@ref) in [`ExtendedHubbardMom1D`](@ref).
 Where `step` is the separation of single-particle momenta in the momentum grid.
 """
-function extended_momentum_transfer_diagonal(map::FermiOccupiedModeMap,step::Float64)
-    onproduct = 0
-    for i in 1:length(map)
-        occ_i = map[i].occnum
-        onproduct += occ_i * (occ_i - 1)
-        for j in 1:i-1
-            occ_j = map[j].occnum
-            onproduct += 2*occ_i * occ_j * (1 - cos((map[j].mode - map[i].mode)*step))
-        end
-    end
-    return float(onproduct)
-end
-
 function extended_momentum_transfer_diagonal(map::OccupiedModeMap, step)
     onproduct = 0
     for i in 1:length(map)
@@ -163,6 +150,19 @@ function extended_momentum_transfer_diagonal(map::OccupiedModeMap, step)
         for j in 1:i-1
             occ_j = map[j].occnum
             onproduct += 2 * occ_i * occ_j * (1 + cos((map[j].mode - map[i].mode)*step))
+        end
+    end
+    return float(onproduct)
+end
+
+function extended_momentum_transfer_diagonal(map::FermiOccupiedModeMap,step)
+    onproduct = 0
+    for i in 1:length(map)
+        occ_i = map[i].occnum
+        onproduct += occ_i * (occ_i - 1)
+        for j in 1:i-1
+            occ_j = map[j].occnum
+            onproduct += 2*occ_i * occ_j * (1 - cos((map[j].mode - map[i].mode)*step))
         end
     end
     return float(onproduct)

--- a/src/Hamiltonians/excitations.jl
+++ b/src/Hamiltonians/excitations.jl
@@ -142,10 +142,8 @@ end
 The diagonal part of nearest neighbour term [`momentum_transfer_excitation`](@ref) in [`ExtendedHubbardMom1D`](@ref).
 Where `step` is the separation of single-particle momenta in the momentum grid.
 """
-function extended_momentum_transfer_diagonal(map::FermiOccupiedModeMap,M::Int)
+function extended_momentum_transfer_diagonal(map::FermiOccupiedModeMap,step::Float64)
     onproduct = 0
-    step = (2*π)/M
-    println("ok")
     for i in 1:length(map)
         occ_i = map[i].occnum
         onproduct += occ_i * (occ_i - 1)

--- a/src/Hamiltonians/excitations.jl
+++ b/src/Hamiltonians/excitations.jl
@@ -142,6 +142,21 @@ end
 The diagonal part of nearest neighbour term [`momentum_transfer_excitation`](@ref) in [`ExtendedHubbardMom1D`](@ref).
 Where `step` is the separation of single-particle momenta in the momentum grid.
 """
+function extended_momentum_transfer_diagonal(map::FermiOccupiedModeMap,M::Int)
+    onproduct = 0
+    step = (2*π)/M
+    println("ok")
+    for i in 1:length(map)
+        occ_i = map[i].occnum
+        onproduct += occ_i * (occ_i - 1)
+        for j in 1:i-1
+            occ_j = map[j].occnum
+            onproduct += 2*occ_i * occ_j * (1 - cos((map[j].mode - map[i].mode)*step))
+        end
+    end
+    return float(onproduct)
+end
+
 function extended_momentum_transfer_diagonal(map::OccupiedModeMap, step)
     onproduct = 0
     for i in 1:length(map)
@@ -149,7 +164,7 @@ function extended_momentum_transfer_diagonal(map::OccupiedModeMap, step)
         onproduct += occ_i * (occ_i - 1)
         for j in 1:i-1
             occ_j = map[j].occnum
-            onproduct += 2*occ_i * occ_j * (1 - cos((map[j].mode - map[i].mode)*step))
+            onproduct += 2 * occ_i * occ_j * (1 + cos((map[j].mode - map[i].mode)*step))
         end
     end
     return float(onproduct)

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -1885,7 +1885,7 @@ end
     addr = FermiFS{3,6}(0,1,1,1,0,0)
     for boundary_condition in ([i*π for i in 0.0:0.2:1.0])
         HR = ExtendedHubbardReal1D(addr; boundary_condition)
-        HM = ExtendedHubbardMom1D(addr; boundary_condition= boundary_condition/6)
+        HM = ExtendedHubbardMom1D(addr; boundary_condition = boundary_condition/6)
         @test round.(eigvals(Matrix(HM)), digits=8) ⊆ round.(eigvals(Matrix(HR)), digits=8)
     end
 end

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -1884,8 +1884,8 @@ end
 @testset "Comparison of ExtendedHubbardMom1D with ExtendedHubbardReal1D" begin
     addr = FermiFS{3,6}(0,1,1,1,0,0)
     for boundary_condition in ([i*π for i in 0.0:0.2:1.0])
-        HR = ExtendedHubbardMom1D(addr; boundary_condition)
-        HM = ExtendedHubbardReal1D(addr; boundary_conition= boundary_condition/6)
+        HR = ExtendedHubbardReal1D(addr; boundary_condition)
+        HM = ExtendedHubbardMom1D(addr; boundary_condition= boundary_condition/6)
         @test round.(eigvals(Matrix(HM)), digits=8) ⊆ round.(eigvals(Matrix(HR)), digits=8)
     end
 end

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -1885,7 +1885,7 @@ end
     addr = FermiFS{3,6}(0,1,1,1,0,0)
     for boundary_condition in ([i*π for i in 0.0:0.2:1.0]...,)
         HR = ExtendedHubbardReal1D(addr; boundary_condition)
-        HM = ExtendedHubbardMom1D(addr; boundary_condition = boundary_condition/6)
+        HM = ExtendedHubbardMom1D(addr; boundary_condition = (boundary_condition/6))
         @test round.(eigvals(Matrix(HM)), digits=8) ⊆ round.(eigvals(Matrix(HR)), digits=8)
     end
 end

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -177,6 +177,7 @@ end
         ExtendedHubbardMom1D(BoseFS(1, 0, 2, 1); u=1 + 0.5im),
         ExtendedHubbardMom1D(BoseFS(1, 0, 2, 1); t=1 + 0.5im),
         ExtendedHubbardMom1D(OccupationNumberFS(1,2,0,0); u=1.0, v=2.0, t=3.0),
+        ExtendedHubbardMom1D(FermiFS(1,1,0,0); u=1.0, v=2.0, t=3.0),
         HubbardRealSpace(BoseFS((1, 2, 3)); u=[1], t=[3]),
         HubbardRealSpace(FermiFS((1, 1, 1, 1, 1, 0, 0, 0)); u=[0], t=[3]),
         HubbardRealSpace(

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -176,6 +176,7 @@ end
         ExtendedHubbardMom1D(BoseFS((1, 0, 0, 0, 1)); u=1.0, v=2.0, t=3.0),
         ExtendedHubbardMom1D(BoseFS(1, 0, 2, 1); u=1 + 0.5im),
         ExtendedHubbardMom1D(BoseFS(1, 0, 2, 1); t=1 + 0.5im),
+        ExtendedHubbardMom1D(OccupationNumberFS(1,2,0,0); u=1.0, v=2.0, t=3.0),
         HubbardRealSpace(BoseFS((1, 2, 3)); u=[1], t=[3]),
         HubbardRealSpace(FermiFS((1, 1, 1, 1, 1, 0, 0, 0)); u=[0], t=[3]),
         HubbardRealSpace(

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -1883,7 +1883,7 @@ end
 
 @testset "Comparison of ExtendedHubbardMom1D with ExtendedHubbardReal1D" begin
     addr = FermiFS{3,6}(0,1,1,1,0,0)
-    for (j,boundary_condition) in enumerate([i*π for i in 0.0:0.2:1.0])
+    for boundary_condition in ([i*π for i in 0.0:0.2:1.0]...,)
         HR = ExtendedHubbardReal1D(addr; boundary_condition)
         HM = ExtendedHubbardMom1D(addr; boundary_condition = boundary_condition/6)
         @test round.(eigvals(Matrix(HM)), digits=8) ⊆ round.(eigvals(Matrix(HR)), digits=8)

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -173,6 +173,9 @@ end
         ExtendedHubbardReal1D(BoseFS((1, 0, 0, 0, 1)); u=1.0, v=2.0, t=3.0),
         ExtendedHubbardReal1D(BoseFS(1, 0, 2, 1); u=1 + 0.5im),
         ExtendedHubbardReal1D(BoseFS(1, 0, 2, 1); t=1 + 0.5im),
+        ExtendedHubbardMom1D(BoseFS((1, 0, 0, 0, 1)); u=1.0, v=2.0, t=3.0),
+        ExtendedHubbardMom1D(BoseFS(1, 0, 2, 1); u=1 + 0.5im),
+        ExtendedHubbardMom1D(BoseFS(1, 0, 2, 1); t=1 + 0.5im),
         HubbardRealSpace(BoseFS((1, 2, 3)); u=[1], t=[3]),
         HubbardRealSpace(FermiFS((1, 1, 1, 1, 1, 0, 0, 0)); u=[0], t=[3]),
         HubbardRealSpace(
@@ -672,6 +675,7 @@ end
             for H in (
                 HubbardMom1D(BoseFS((2,2,2)), u=6),
                 ExtendedHubbardReal1D(BoseFS((1,1,1,1,1,1,1,1,1,1,1,1)), u=6, t=2.0),
+                ExtendedHubbardMom1D(BoseFS((1,1,1,1,1,1,1,1,1,1,1,1)), u=6, t=2.0),
                 BoseHubbardMom1D2C(BoseFS2C((1,2,3), (1,0,0)), ub=2.0),
             )
                 # GutzwillerSampling with parameter zero is exactly equal to the original H
@@ -702,6 +706,7 @@ end
                 HubbardReal1D(BoseFS((2,2,2)), u=6),
                 HubbardMom1D(BoseFS((2,2,2)), u=6),
                 ExtendedHubbardReal1D(BoseFS((1,1,1,1,1,1,1,1,1,1,1,1)), u=6, t=2.0),
+                ExtendedHubbardMom1D(BoseFS((1,1,1,1,1,1,1,1,1,1,1,1)), u=6, t=2.0),
                 # BoseHubbardMom1D2C(BoseFS2C((1,2,3), (1,0,0)), ub=2.0), # multicomponent not implemented for G2RealCorrelator
             )
                 # energy
@@ -785,6 +790,7 @@ end
                 HubbardReal1D(BoseFS((2,2,2)), u=6),
                 HubbardMom1D(BoseFS((2,2,2)), u=6),
                 ExtendedHubbardReal1D(BoseFS((1,1,1,1,1,1,1,1,1,1,1,1)), u=6, t=2.0),
+                ExtendedHubbardMom1D(BoseFS((1,1,1,1,1,1,1,1,1,1,1,1)), u=6, t=2.0),
                 # BoseHubbardMom1D2C(BoseFS2C((1,2,3), (1,0,0)), ub=2.0), # multicomponent not implemented for G2RealCorrelator
             )
                 # energy
@@ -854,6 +860,7 @@ end
         for H in (
             HubbardMom1D(BoseFS((2,2,2)), u=6),
             ExtendedHubbardReal1D(BoseFS((1,1,1,1,1,1,1,1,1,1,1,1)), u=6, t=2.0),
+            ExtendedHubbardMom1D(BoseFS((1,1,1,1,1,1,1,1,1,1,1,1)), u=6, t=2.0),
             BoseHubbardMom1D2C(BoseFS2C((1,2,3), (1,0,0)), ub=2.0),
         )
             @test_throws ArgumentError Rimu.Hamiltonians.TransformUndoer(H)
@@ -1261,7 +1268,7 @@ using Rimu.Hamiltonians: circshift_dot
         end
         @test num_offdiagonals(SingleParticleExcitation(1,2), addr_bose) == 1
         @test LOStructure(SingleParticleExcitation(1,2)) == AdjointUnknown()
-        @test num_offdiagonals(TwoParticleExcitation(1,2,2,1), addr_bose) == 0
+        @test num_offdiagonals(TwoParticleExcitation(1,2,2,1), addr_bose) == 1
         @test LOStructure(TwoParticleExcitation(1,2,2,1)) == AdjointUnknown()
     end
 end

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -1883,7 +1883,7 @@ end
 
 @testset "Comparison of ExtendedHubbardMom1D with ExtendedHubbardReal1D" begin
     addr = FermiFS{3,6}(0,1,1,1,0,0)
-    for (_,boundary_condition) in enumerate([i*π for i in 0.0:0.2:1.0])
+    for (j,boundary_condition) in enumerate([i*π for i in 0.0:0.2:1.0])
         HR = ExtendedHubbardReal1D(addr; boundary_condition)
         HM = ExtendedHubbardMom1D(addr; boundary_condition = boundary_condition/6)
         @test round.(eigvals(Matrix(HM)), digits=8) ⊆ round.(eigvals(Matrix(HR)), digits=8)

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -1883,7 +1883,7 @@ end
 
 @testset "Comparison of ExtendedHubbardMom1D with ExtendedHubbardReal1D" begin
     addr = FermiFS{3,6}(0,1,1,1,0,0)
-    for boundary_condition in ([i*π for i in 0.0:0.2:1.0])
+    for (_,boundary_condition) in enumerate([i*π for i in 0.0:0.2:1.0])
         HR = ExtendedHubbardReal1D(addr; boundary_condition)
         HM = ExtendedHubbardMom1D(addr; boundary_condition = boundary_condition/6)
         @test round.(eigvals(Matrix(HM)), digits=8) ⊆ round.(eigvals(Matrix(HR)), digits=8)

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -1268,7 +1268,7 @@ using Rimu.Hamiltonians: circshift_dot
         end
         @test num_offdiagonals(SingleParticleExcitation(1,2), addr_bose) == 1
         @test LOStructure(SingleParticleExcitation(1,2)) == AdjointUnknown()
-        @test num_offdiagonals(TwoParticleExcitation(1,2,2,1), addr_bose) == 1
+        @test num_offdiagonals(TwoParticleExcitation(1,2,2,1), addr_bose) == 0
         @test LOStructure(TwoParticleExcitation(1,2,2,1)) == AdjointUnknown()
     end
 end

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -1880,3 +1880,12 @@ end
     @test LOStructure(h) isa IsDiagonal
     @test_throws ArgumentError adjoint(h2)
 end
+
+@testset "Comparison of ExtendedHubbardMom1D with ExtendedHubbardReal1D" begin
+    addr = FermiFS{3,6}(0,1,1,1,0,0)
+    for boundary_condition in ([i*π for i in 0.0:0.2:1.0])
+        HR = ExtendedHubbardMom1D(addr; boundary_condition)
+        HM = ExtendedHubbardReal1D(addr; boundary_conition= boundary_condition/6)
+        @test round.(eigvals(Matrix(HM)), digits=8) ⊆ round.(eigvals(Matrix(HR)), digits=8)
+    end
+end

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -1882,10 +1882,14 @@ end
 end
 
 @testset "Comparison of ExtendedHubbardMom1D with ExtendedHubbardReal1D" begin
-    addr = FermiFS{3,6}(0,1,1,1,0,0)
+    addr_f = FermiFS{3,6}(0,1,1,1,0,0)
+    addr_b = BoseFS{3,6}(0,0,3,0,0,0)
     for boundary_condition in ([i*π for i in 0.0:0.2:1.0]...,)
-        HR = ExtendedHubbardReal1D(addr; boundary_condition)
-        HM = ExtendedHubbardMom1D(addr; boundary_condition)
-        @test round.(eigvals(Matrix(HM)), digits=8) ⊆ round.(eigvals(Matrix(HR)), digits=8)
+        HR_f = ExtendedHubbardReal1D(addr_f; boundary_condition)
+        HM_f = ExtendedHubbardMom1D(addr_f; boundary_condition)
+        HR_b = ExtendedHubbardReal1D(addr_b; boundary_condition)
+        HM_b = ExtendedHubbardMom1D(addr_b; boundary_condition)
+        @test round.(eigvals(Matrix(HM_f)), digits=8) ⊆ round.(eigvals(Matrix(HR_f)), digits=8)
+        @test round.(eigvals(Matrix(HM_b)), digits=8) ⊆ round.(eigvals(Matrix(HR_b)), digits=8)
     end
 end

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -1885,7 +1885,7 @@ end
     addr = FermiFS{3,6}(0,1,1,1,0,0)
     for boundary_condition in ([i*π for i in 0.0:0.2:1.0]...,)
         HR = ExtendedHubbardReal1D(addr; boundary_condition)
-        HM = ExtendedHubbardMom1D(addr; boundary_condition = (boundary_condition/6))
+        HM = ExtendedHubbardMom1D(addr; boundary_condition)
         @test round.(eigvals(Matrix(HM)), digits=8) ⊆ round.(eigvals(Matrix(HR)), digits=8)
     end
 end


### PR DESCRIPTION
# `ExtendedHubbardMom1D`
- A new model (i.e. ``ExtendedHubbardMom1D``) is added to the Rimu.
- The model is an extended version of ``HubbardMom1D`` in Rimu.
- Furthermore, the model is equipped with a ```theta```-twisted boundary condition inspired by the "ExtendedHubbardReal1D".