### PR TITLE
Adaptive Time Step

### DIFF
--- a/src/Interfaces/stochasticstyles.jl
+++ b/src/Interfaces/stochasticstyles.jl
@@ -126,6 +126,12 @@ end
 Return a tuple of stat names (`Symbol` or `String`) and a tuple of zeros of the same
 length. These will be reported as columns in the `DataFrame` returned by
 [`ProjectorMonteCarloProblem`](@ref Main.ProjectorMonteCarloProblem).
+The names should be unique and not contain spaces or special characters.
+
+For a `StochasticStyle`, the first three stats are the number of
+clones, deaths, and zombies.
+
+See also [`StochasticStyle`](@ref), [`CompressionStrategy`](@ref).
 """
 step_stats(v) = step_stats(StochasticStyle(v))
 

--- a/src/Interfaces/stochasticstyles.jl
+++ b/src/Interfaces/stochasticstyles.jl
@@ -1,5 +1,5 @@
 """
-    StochasticStyle(v)
+    StochasticStyle(v::AbstractDVec)
 
 Abstract type. When called as a function it returns the native style of the
 generalised vector `v` that determines how simulations are to proceed.
@@ -34,11 +34,10 @@ and optionally
 * [`CompressionStrategy(::StochasticStyle)`](@ref) for vector compression after
   annihilations,
 
-See also [`StochasticStyles`](@ref Main.StochasticStyles), [`Interfaces`](@ref).
+See also [`StochasticStyles`](@ref Main.StochasticStyles), [`Interfaces`](@ref),
+[`AbstractDVec`](@ref).
 """
 abstract type StochasticStyle{T} end
-
-StochasticStyle(::AbstractVector{T}) where T = default_style(T)
 
 Base.eltype(::Type{<:StochasticStyle{T}}) where {T} = T
 VectorInterface.scalartype(::Type{<:StochasticStyle{T}}) where {T} = T

--- a/src/Rimu.jl
+++ b/src/Rimu.jl
@@ -70,7 +70,7 @@ export ReportingStrategy, ReportDFAndInfo, ReportToFile
 export ReplicaStrategy, NoStats, AllOverlaps
 export PostStepStrategy, Projector, ProjectedEnergy, SignCoherence, WalkerLoneliness, Timer,
     SingleParticleDensity, single_particle_density
-export TimeStepStrategy, ConstantTimeStep, OvershootControl
+export TimeStepStrategy, ConstantTimeStep, AdaptiveTimeStep
 export localpart, walkernumber
 export smart_logger, default_logger
 export ProjectorMonteCarloProblem, SimulationPlan, state_vectors

--- a/src/StochasticStyles/styles.jl
+++ b/src/StochasticStyles/styles.jl
@@ -14,14 +14,14 @@ IsStochasticInteger() =  IsStochasticInteger{Int}()
 function step_stats(::IsStochasticInteger{T}) where {T}
     z = zero(T)
     return (
-        (:spawn_attempts, :spawns, :deaths, :clones, :zombies),
-        MultiScalar(0, z, z, z, z),
+        (:clones, :deaths, :zombies, :spawn_attempts, :spawns),
+        MultiScalar(z, z, z, 0, z),
     )
 end
 function apply_column!(::IsStochasticInteger, w, op, add, val::Real, boost=1)
     clones, deaths, zombies = diagonal_step!(w, op, add, val)
     attempts, spawns = spawn!(WithReplacement(), w, op, add, val, boost)
-    return (attempts, spawns, deaths, clones, zombies)
+    return (clones, deaths, zombies, attempts, spawns)
 end
 
 """
@@ -43,7 +43,7 @@ IsStochastic2Pop() = IsStochastic2Pop{Complex{Int}}()
 function step_stats(::IsStochastic2Pop{T}) where {T}
     z = zero(T)
     return (
-        (:spawns, :deaths, :clones, :zombies),
+        (:clones, :deaths, :zombies, :spawns),
         MultiScalar(z, z, z, z)
     )
 end
@@ -59,7 +59,7 @@ function apply_column!(::IsStochastic2Pop, w, op, add, val, boost=1)
 
     clones, deaths, zombies = diagonal_step!(w, op, add, val)
 
-    return (spawns, deaths, clones, zombies)
+    return (clones, deaths, zombies, spawns)
 end
 
 const FloatOrComplexFloat = Union{AbstractFloat, Complex{<:AbstractFloat}}
@@ -91,13 +91,17 @@ function Base.show(io::IO, s::IsDeterministic{T}) where {T}
     end
 end
 
-function step_stats(::IsDeterministic)
-    return (:exact_steps,), MultiScalar(0,)
+function step_stats(::IsDeterministic{T}) where {T}
+    z = zero(T)
+    return (
+        (:clones, :deaths, :zombies, :exact_steps,),
+        MultiScalar(z, z, z, 0)
+    )
 end
 function apply_column!(::IsDeterministic, w, op, add, val, boost=1)
-    diagonal_step!(w, op, add, val)
+    clones, deaths, zombies = diagonal_step!(w, op, add, val)
     spawn!(Exact(), w, op, add, val)
-    return (1,)
+    return (clones, deaths, zombies, 1)
 end
 
 """
@@ -117,12 +121,16 @@ IsStochasticWithThreshold(args...) = IsStochasticWithThreshold{Float64}(args...)
 IsStochasticWithThreshold{T}(t=1.0) where {T} = IsStochasticWithThreshold{T}(T(t))
 
 function step_stats(::IsStochasticWithThreshold{T}) where {T}
-    return ((:spawn_attempts, :spawns), MultiScalar(0, zero(T)))
+    z = zero(T)
+    return (
+        (:clones, :deaths, :zombies, :spawn_attempts, :spawns),
+        MultiScalar(z, z, z, 0, z)
+    )
 end
 function apply_column!(s::IsStochasticWithThreshold, w, op, add, val, boost=1)
-    diagonal_step!(w, op, add, val, s.threshold)
+    clones, deaths, zombies = diagonal_step!(w, op, add, val, s.threshold)
     attempts, spawns = spawn!(WithReplacement(s.threshold), w, op, add, val, boost)
-    return (attempts, spawns)
+    return (clones, deaths, zombies, attempts, spawns)
 end
 
 """
@@ -199,14 +207,14 @@ CompressionStrategy(s::IsDynamicSemistochastic) = s.compression
 function step_stats(::IsDynamicSemistochastic{T}) where {T}
     z = zero(T)
     return (
-        (:exact_steps, :inexact_steps, :spawn_attempts, :spawns),
-        MultiScalar(0, 0, 0, z),
+        (:clones, :deaths, :zombies, :exact_steps, :inexact_steps, :spawn_attempts, :spawns),
+        MultiScalar(z, z, z, 0, 0, 0, z),
     )
 end
 function apply_column!(s::IsDynamicSemistochastic, w, op, add, val, boost=1)
-    diagonal_step!(w, op, add, val, s.proj_threshold)
+    clones, deaths, zombies = diagonal_step!(w, op, add, val, s.proj_threshold)
     exact, inexact, attempts, spawns = spawn!(s.spawning, w, op, add, val, boost)
-    return (exact, inexact, attempts, spawns)
+    return (clones, deaths, zombies, exact, inexact, attempts, spawns)
 end
 
 default_style(::Type{T}) where {T<:Integer} = IsStochasticInteger{T}()

--- a/src/StochasticStyles/styles.jl
+++ b/src/StochasticStyles/styles.jl
@@ -94,10 +94,6 @@ end
 function step_stats(::IsDeterministic)
     return (:exact_steps,), MultiScalar(0,)
 end
-function apply_column!(::IsDeterministic, w, op::AbstractMatrix, add, val, boost=1)
-    w .+= op[:, add] .* val
-    return (1,)
-end
 function apply_column!(::IsDeterministic, w, op, add, val, boost=1)
     diagonal_step!(w, op, add, val)
     spawn!(Exact(), w, op, add, val)

--- a/src/fciqmc.jl
+++ b/src/fciqmc.jl
@@ -144,13 +144,13 @@ function advance!(algorithm::FCIQMC, report, state::ReplicaState, s_state::Singl
     tnorm, len = walkernumber_and_length(v)
 
     # Updates
-    time_step = update_time_step(time_step_strategy, time_step, tnorm)
-
-    shift_stats, proceed = update_shift_parameters!(
-        shift_strategy, shift_parameters, tnorm, v, pv, step, report
-    )
+    new_time_step = update_time_step(time_step_strategy, time_step, tnorm)
 
     @pack! s_state = v, pv, wm
+
+    shift_stats, proceed = update_shift_parameters!(
+        shift_strategy, shift_parameters, new_time_step, tnorm, s_state, step
+    )
     ### TO HERE
 
     if step % reporting_interval(state.reporting_strategy) == 0

--- a/src/fciqmc.jl
+++ b/src/fciqmc.jl
@@ -28,7 +28,7 @@ end
 Set up the initial shift parameters for the [`FCIQMC`](@ref) algorithm.
 """
 function set_up_initial_shift_parameters(algorithm::FCIQMC, hamiltonian,
-    starting_vectors::SMatrix{S,R}, shift, time_step
+    starting_vectors::SMatrix{S,R}, shift, time_step, boost
 ) where {S,R}
     shift_strategy = algorithm.shift_strategy
 
@@ -42,7 +42,7 @@ function set_up_initial_shift_parameters(algorithm::FCIQMC, hamiltonian,
         throw(ArgumentError("The number of shifts must match the number of starting vectors."))
     end
     initial_shift_parameters = Tuple(map(zip(starting_vectors, initial_shifts)) do (sv, s)
-        initialise_shift_parameters(shift_strategy, s, walkernumber(sv), time_step)
+        initialise_shift_parameters(shift_strategy, s, walkernumber(sv), time_step, boost)
     end)
     @assert length(initial_shift_parameters) == S * R
     return SMatrix{S,R}(initial_shift_parameters)
@@ -127,7 +127,7 @@ function advance!(algorithm::FCIQMC, report, state::ReplicaState, s_state::Singl
 
     @unpack reporting_strategy = state
     @unpack hamiltonian, v, pv, wm, id, shift_parameters = s_state
-    @unpack shift, pnorm, time_step = shift_parameters
+    @unpack shift, pnorm, time_step, boost = shift_parameters
     @unpack shift_strategy, time_step_strategy = algorithm
     step = state.step[]
 
@@ -136,7 +136,9 @@ function advance!(algorithm::FCIQMC, report, state::ReplicaState, s_state::Singl
     transition_op = FirstOrderTransitionOperator(shift_parameters, hamiltonian)
 
     # Step
-    step_stat_names, step_stat_values, wm, pv = apply_operator!(wm, pv, v, transition_op)
+    step_stat_names, step_stat_values, wm, pv = apply_operator!(
+        wm, pv, v, transition_op, boost
+    )
     # pv was mutated and now contains the new vector.
     v, pv = (pv, v)
 

--- a/src/fciqmc.jl
+++ b/src/fciqmc.jl
@@ -140,11 +140,15 @@ function advance!(algorithm::FCIQMC, report, state::ReplicaState, s_state::Singl
     # pv was mutated and now contains the new vector.
     v, pv = (pv, v)
 
+    deaths, clones, zombies = step_stat_values[1:3] # stats from the StochasticStyle
+
     # Stats:
     tnorm, len = walkernumber_and_length(v)
 
     # Updates
-    new_time_step = update_time_step(time_step_strategy, time_step, tnorm)
+    new_time_step = update_time_step(
+        time_step_strategy, time_step, deaths, clones, zombies, tnorm, len
+    )
 
     @pack! s_state = v, pv, wm
 

--- a/src/pmc_simulation.jl
+++ b/src/pmc_simulation.jl
@@ -86,12 +86,12 @@ function PMCSimulation(problem::ProjectorMonteCarloProblem; copy_vectors=true)
     @assert vectors isa SMatrix{n_spectral,n_replicas}
 
     # set up initial_shift_parameters
-    shift, time_step = nothing, nothing
-
     shift_parameters = if initial_shift_parameters isa Union{NamedTuple, DefaultShiftParameters}
         # we have previously stored shift and time_step
-        @unpack shift, time_step = initial_shift_parameters
-        set_up_initial_shift_parameters(algorithm, hamiltonian, vectors, shift, time_step)
+        @unpack shift, time_step, boost = initial_shift_parameters
+        set_up_initial_shift_parameters(
+            algorithm, hamiltonian, vectors, shift, time_step, boost
+        )
     else
         SMatrix{n_spectral,n_replicas}(initial_shift_parameters...)
     end

--- a/src/projector_monte_carlo_problem.jl
+++ b/src/projector_monte_carlo_problem.jl
@@ -66,7 +66,7 @@ julia> simulation.success[]
 true
 
 julia> size(DataFrame(simulation))
-(100, 9)
+(100, 12)
 ```
 
 # Further keyword arguments:

--- a/src/projector_monte_carlo_problem.jl
+++ b/src/projector_monte_carlo_problem.jl
@@ -76,6 +76,7 @@ julia> size(DataFrame(simulation))
     duration of the simulation. Takes precedence over `last_step` and `walltime`.
 - `ζ = 0.08`: Damping parameter for the shift update.
 - `ξ = ζ^2/4`: Forcing parameter for the shift update.
+- `boost = 1.0`: Boost factor for the spawning process.
 - `shift_strategy = DoubleLogUpdate(; target_walkers, ζ, ξ)`: How to update the `shift`,
     see [`ShiftStrategy`](@ref).
 - `time_step_strategy = ConstantTimeStep()`: Adjust time step or not, see
@@ -146,6 +147,7 @@ function ProjectorMonteCarloProblem(
     initiator = false,
     threading = nothing,
     time_step = 0.01,
+    boost = 1.0,
     starting_step = 0,
     last_step = 100,
     walltime = Inf,
@@ -199,7 +201,7 @@ function ProjectorMonteCarloProblem(
     # here we just store the initial shift and time_step if initial_shift_parameters is not
     # provided
     if isnothing(initial_shift_parameters)
-        initial_shift_parameters = (; shift, time_step)
+        initial_shift_parameters = (; shift, time_step, boost)
     end
 
     shift_strategy = algorithm.shift_strategy

--- a/src/strategies_and_params/shiftstrategy.jl
+++ b/src/strategies_and_params/shiftstrategy.jl
@@ -29,7 +29,7 @@ abstract type ShiftStrategy end
 Default mutable struct for storing the shift parameters.
 
 See [`ShiftStrategy`](@ref), [`initialise_shift_parameters`](@ref),
-[`update_shift_paramters`](@ref).
+[`update_shift_paramters!`](@ref).
 """
 mutable struct DefaultShiftParameters{S, N}
     shift::S # for current time step

--- a/src/strategies_and_params/shiftstrategy.jl
+++ b/src/strategies_and_params/shiftstrategy.jl
@@ -35,7 +35,7 @@ mutable struct DefaultShiftParameters{S, N}
     shift::S # for current time step
     pnorm::N # norm from previous time step
     time_step::Float64
-    boost::Float64 # boost factor
+    boost::Float64 # boost factor for spawning
     counter::Int
     shift_mode::Bool
 end
@@ -44,7 +44,7 @@ end
     initialise_shift_parameters(
         s::ShiftStrategy, shift, norm, time_step, boost=1.0, counter=0, shift_mode=false
     ) -> DefaultShiftParameters
-Initiatlise a struct to store the shift parameters.
+Initialise a struct to store the shift parameters.
 
 See [`ShiftStrategy`](@ref), [`update_shift_parameters!`](@ref),
 [`DefaultShiftParameters`](@ref).

--- a/src/strategies_and_params/shiftstrategy.jl
+++ b/src/strategies_and_params/shiftstrategy.jl
@@ -29,7 +29,7 @@ abstract type ShiftStrategy end
 Default mutable struct for storing the shift parameters.
 
 See [`ShiftStrategy`](@ref), [`initialise_shift_parameters`](@ref),
-[`update_shift_paramters!`](@ref).
+[`update_shift_parameters!`](@ref).
 """
 mutable struct DefaultShiftParameters{S, N}
     shift::S # for current time step

--- a/src/strategies_and_params/shiftstrategy.jl
+++ b/src/strategies_and_params/shiftstrategy.jl
@@ -1,7 +1,8 @@
 """
     ShiftStrategy
 Abstract type for defining the strategy for controlling the norm, potentially by updating
-the `shift`. Passed as a parameter to [`ProjectorMonteCarloProblem`](@ref) or to [`FCIQMC`](@ref).
+the `shift`. Passed as a parameter to [`ProjectorMonteCarloProblem`](@ref) or to
+[`FCIQMC`](@ref).
 
 ## Implemented strategies:
 
@@ -27,27 +28,34 @@ abstract type ShiftStrategy end
     DefaultShiftParameters
 Default mutable struct for storing the shift parameters.
 
-See [`ShiftStrategy`](@ref), [`initialise_shift_parameters`](@ref).
+See [`ShiftStrategy`](@ref), [`initialise_shift_parameters`](@ref),
+[`update_shift_paramters`](@ref).
 """
 mutable struct DefaultShiftParameters{S, N}
     shift::S # for current time step
     pnorm::N # norm from previous time step
     time_step::Float64
+    boost::Float64 # boost factor
     counter::Int
     shift_mode::Bool
 end
 
 """
-    initialise_shift_parameters(s::ShiftStrategy, shift, norm, time_step, counter=0, shift_mode=false)
+    initialise_shift_parameters(
+        s::ShiftStrategy, shift, norm, time_step, boost=1.0, counter=0, shift_mode=false
+    ) -> DefaultShiftParameters
 Initiatlise a struct to store the shift parameters.
 
-See [`ShiftStrategy`](@ref), [`update_shift_parameters!`](@ref), [`DefaultShiftParameters`](@ref).
+See [`ShiftStrategy`](@ref), [`update_shift_parameters!`](@ref),
+[`DefaultShiftParameters`](@ref).
 """
 function initialise_shift_parameters(
     ::ShiftStrategy, shift, norm, time_step,
-    counter=0, shift_mode=false
+    boost=1.0, counter=0, shift_mode=false
 )
-    return DefaultShiftParameters(shift, norm, time_step, counter, shift_mode)
+    return DefaultShiftParameters(
+        shift, norm, Float64(time_step), Float64(boost), counter, shift_mode
+    )
 end
 
 """
@@ -63,7 +71,8 @@ Update the `shift_parameters` according to strategy `s`. See [`ShiftStrategy`](@
 Returns a named tuple of the shift statistics and a boolean `proceed` indicating whether
 the simulation should proceed.
 
-See [`initialise_shift_parameters`](@ref), [`ShiftStrategy`](@ref).
+See [`initialise_shift_parameters`](@ref), [`ShiftStrategy`](@ref),
+[`DefaultShiftParameters`](@ref).
 """
 update_shift_parameters!
 

--- a/src/strategies_and_params/timestepstrategy.jl
+++ b/src/strategies_and_params/timestepstrategy.jl
@@ -48,10 +48,10 @@ function AdaptiveTimeStep(; damp_zombies=0.9, grow=1.01)
     return AdaptiveTimeStep(damp_zombies, grow)
 end
 
-function update_time_step(::AdaptiveTimeStep, time_step, _, _, zombies, _...)
+function update_time_step(s::AdaptiveTimeStep, time_step, _, _, zombies, _...)
     if  zombies > 0
-        return time_step * damp_zombies^zombies # decrease time step
+        return time_step * s.damp_zombies^zombies # decrease time step
     else
-        return time_step * grow # increase time step
+        return time_step * s.grow # increase time step
     end
 end

--- a/src/strategies_and_params/timestepstrategy.jl
+++ b/src/strategies_and_params/timestepstrategy.jl
@@ -4,14 +4,19 @@
 Abstract type for strategies for updating the time step with
 [`update_time_step()`](@ref). Implemented strategies:
 
-   * [`ConstantTimeStep`](@ref)
+* [`ConstantTimeStep`](@ref)
+* [`AdaptiveTimeStep`](@ref)
+
+See also [`FCIQMC`](@ref).
 """
 abstract type TimeStepStrategy end
 
 """
-    ConstantTimeStep <: TimeStepStrategy
+    ConstantTimeStep() <: TimeStepStrategy
 
-Keep `time_step` constant.
+Keep the `time_step` constant.
+
+See also [`TimeStepStrategy`](@ref), [`FCIQMC`](@ref).
 """
 struct ConstantTimeStep <: TimeStepStrategy end
 
@@ -19,20 +24,34 @@ struct ConstantTimeStep <: TimeStepStrategy end
     update_time_step(s<:TimeStepStrategy, time_step, deaths, clones, zombies, tnorm, len)
     -> new_time_step
 Update the time step according to the strategy `s`.
+
+See also [`TimeStepStrategy`](@ref).
 """
 update_time_step(::ConstantTimeStep, time_step, args...) = time_step
 
 """
-    AdaptiveTimeStep <: TimeStepStrategy
+    AdaptiveTimeStep(; damp_zombies=0.9, grow=1.01) <: TimeStepStrategy
 
 Adapt the time step to avoid zombies.
+
+## Parameters
+* `damp_zombies`: factor by which to decrease the time step for each zombie.
+* `grow`: factor by which to increase the time step when there are no zombies.
+
+See also [`TimeStepStrategy`](@ref), [`FCIQMC`](@ref).
 """
-struct AdaptiveTimeStep <: TimeStepStrategy end
+struct AdaptiveTimeStep <: TimeStepStrategy
+    damp_zombies::Float64
+    grow::Float64
+end
+function AdaptiveTimeStep(; damp_zombies=0.9, grow=1.01)
+    return AdaptiveTimeStep(damp_zombies, grow)
+end
 
 function update_time_step(::AdaptiveTimeStep, time_step, _, _, zombies, _...)
     if  zombies > 0
-        return time_step * 0.9^zombies
+        return time_step * damp_zombies^zombies # decrease time step
     else
-        return time_step * 1.01 # increase by 1%
+        return time_step * grow # increase time step
     end
 end

--- a/src/strategies_and_params/timestepstrategy.jl
+++ b/src/strategies_and_params/timestepstrategy.jl
@@ -16,7 +16,23 @@ Keep `time_step` constant.
 struct ConstantTimeStep <: TimeStepStrategy end
 
 """
-    update_time_step(s<:TimeStepStrategy, time_step, tnorm) -> new_time_step
+    update_time_step(s<:TimeStepStrategy, time_step, deaths, clones, zombies, tnorm, len)
+    -> new_time_step
 Update the time step according to the strategy `s`.
 """
 update_time_step(::ConstantTimeStep, time_step, args...) = time_step
+
+"""
+    AdaptiveTimeStep <: TimeStepStrategy
+
+Adapt the time step to avoid zombies.
+"""
+struct AdaptiveTimeStep <: TimeStepStrategy end
+
+function update_time_step(::AdaptiveTimeStep, time_step, _, _, zombies, _...)
+    if  zombies > 0
+        return time_step * 0.9^zombies
+    else
+        return time_step * 1.01 # increase by 1%
+    end
+end

--- a/test/RMPI.jl
+++ b/test/RMPI.jl
@@ -11,13 +11,13 @@ using Test
         dv = DVec(starting_address(ham) => 10; style=IsDynamicSemistochastic())
         v = MPIData(dv; setup)
         df, state = lomc!(ham,v)
-        @test size(df) == (100, 9)
+        @test size(df) == (100, 12)
     end
     # need to do mpi_one_sided separately
     dv = DVec(starting_address(ham)=>10; style=IsDynamicSemistochastic())
     v = RMPI.mpi_one_sided(dv; capacity = 1000)
     df, state = lomc!(ham,v)
-    @test size(df) == (100, 9)
+    @test size(df) == (100, 12)
 end
 
 @testset "sort_and_count!" begin

--- a/test/StochasticStyles.jl
+++ b/test/StochasticStyles.jl
@@ -31,20 +31,6 @@ end
     deposit!(vec, 1, 2, 1 => 2)
     deposit!(vec, 4, -2, 1 => 2)
     @test vec == [3, 2, 3, 2, 5]
-
-    @test StochasticStyle(vec) == IsStochasticInteger{Int64}()
-    @test StochasticStyle(Float32.(vec)) == IsDeterministic{Float32}()
-
-    names, values = step_stats(vec)
-    @test names == (:spawn_attempts, :spawns, :deaths, :clones, :zombies)
-    @test values == Rimu.MultiScalar((0, 0, 0, 0, 0))
-
-    w = [1.0, 2.0, 3.0]
-
-    @test apply_column!(w, matrix, 1, 2) == (1, )
-    @test w[1] == 1.0 + 2 * matrix[1, 1]
-    @test w[2] == 2.0 + 2 * matrix[2, 1]
-    @test w[3] == 3.0 + 2 * matrix[3, 1]
 end
 
 @testset "projected_deposit!" begin

--- a/test/projector_monte_carlo_problem.jl
+++ b/test/projector_monte_carlo_problem.jl
@@ -220,3 +220,11 @@ using Rimu: num_replicas, num_spectral_states
     @test solve!(sm; last_step=300, reporting_strategy=ReportDFAndInfo()) === sm
     @test size(sm.df)[1] == 200 # the report was not emptied
 end
+
+@testset "AdaptiveTimeStep" begin
+    h = HubbardReal1D(BoseFS(1, 3))
+    p = ProjectorMonteCarloProblem(h; time_step_strategy=AdaptiveTimeStep())
+    sm = solve(p)
+    @test sm.success == true
+    @test "time_step" in names(sm.df)
+end


### PR DESCRIPTION
## New Features
- `AdaptiveTimeStep`, a new `TimeStepStrategy` aimed at maximising the time step but avoiding zombies.
- `boost` is accepted as a keyword argument for `ProjectorMonteCarloProblem` to control the number of spawns: The approximate number of spawning attempts for the coefficient `c` is `boost *  c`.

## Changed behaviour
- report now contains `deaths`, `clones`, and `zombies` for all `StochasticStyle`s; the column order has changed
- `apply_column` is now required to return `deaths`, `clones`, and `zombies` as the first three stats
- `DefaultShiftParameters` now contains a new field `boost`
