### PR TITLE
`AbstractObservable` supertype

### DIFF
--- a/docs/src/hamiltonians.md
+++ b/docs/src/hamiltonians.md
@@ -70,15 +70,18 @@ Stoquastic
 ```
 
 ## Observables
-Observables are [`AbstractOperator`](@ref)s that represent a physical
-observable. Their expectation values can be sampled during a
-[`ProjectorMonteCarloProblem`](@ref) simulation by passing
-them into a suitable [`ReplicaStrategy`](@ref), e.g. 
-[`AllOverlaps`](@ref).  [`AbstractOperator`](@ref) is a supertype of 
-[`AbstractHamiltonian`](@ref) and has less stringent 
-requirements. Some observables are also [`AbstractHamiltonian`](@ref)s.
+`Rimu.jl` offers two other supertypes for operators that are less 
+restrictive than [`AbstractHamiltonian`](@ref). 
+[`AbstractObservable`](@ref) and [`AbstractOperator`](@ref)s both
+can represent a physical observable. Their expectation values can be sampled during a [`ProjectorMonteCarloProblem`](@ref) simulation by 
+passing them into a suitable [`ReplicaStrategy`](@ref), e.g. 
+[`AllOverlaps`](@ref). Some observables are also [`AbstractHamiltonian`](@ref)s. The full type hierarchy is
+```julia
+AbstractHamiltonian{T} <: AbstractOperator{T} <: AbstractObservable{T}
+```
 
 ```@docs
+AbstractObservable
 AbstractOperator
 ParticleNumberOperator
 G2RealCorrelator

--- a/src/Interfaces/Interfaces.jl
+++ b/src/Interfaces/Interfaces.jl
@@ -53,7 +53,7 @@ export
     AbstractHamiltonian, diagonal_element, num_offdiagonals, get_offdiagonal, offdiagonals,
     random_offdiagonal, starting_address, allows_address_type,
     LOStructure, IsDiagonal, IsHermitian, AdjointKnown, AdjointUnknown, has_adjoint,
-    AbstractOperator
+    AbstractOperator, AbstractObservable
 
 include("stochasticstyles.jl")
 include("dictvectors.jl")

--- a/src/Interfaces/hamiltonians.jl
+++ b/src/Interfaces/hamiltonians.jl
@@ -2,7 +2,59 @@
 ### This file contains abstract types, interfaces and traits.
 ###
 """
-    AbstractOperator{T}
+    AbstractObservable{T}
+
+Most permissive supertype for operators in the type hierarchy:
+
+    AbstractHamiltonian{T} <: AbstractOperator{T} <: AbstractObservable{T}
+
+`AbstractObservable` provides an interface for operators that can appear in a three-way dot
+product [`dot(x, op, y)`](@ref LinearAlgebra.dot) with two vectors of type
+[`AbstractDVec`](@ref). The result is a value of type `T`, which is also returned by the
+[`eltype`](@ref) function. This may be a vector type associated with a scalar type returned
+by the [`scalartype`](@ref) function.
+
+The `AbstractObservable` type is useful for defining observables that can be calculated in
+the context of a [`ProjectorMonteCarloProblem`](@ref) using [`AllOverlaps`](@ref).
+
+# Interface
+
+Basic interface methods to implement:
+- [`Interfaces.dot_from_right(x, op, y)`](@ref)
+- [`allows_address_type(op, type)`](@ref)
+
+Optional additional methods to implement:
+- [`VectorInterface.scalartype(op)`](@ref): defaults to `eltype(eltype(op))`
+- [`LOStructure(::Type{typeof(op)})`](@ref LOStructure): defaults to `AdjointUnknown`
+
+See also [`AbstractOperator`](@ref), [`AbstractHamiltonian`](@ref), [`Interfaces`](@ref).
+"""
+abstract type AbstractObservable{T} end
+
+"""
+    eltype(op::AbstractObservable)
+Return the type of the elements of the operator. This can be a vector value. For the
+underlying scalar type use [`scalartype`](@ref).
+
+Part of the [`AbstractObservable`](@ref) interface.
+!!! note
+    New types should only implement the method with the argument in the type domain.
+"""
+Base.eltype(::Type{<:AbstractObservable{T}}) where {T} = T # could be vector value
+
+"""
+    scalartype(op::AbstractObservable)
+Return the type of the underlying scalar field of the operator. This may be different from
+the element type of the operator returned by [`eltype`](@ref), which can be a vector value.
+
+Part of the [`AbstractObservable`](@ref) interface.
+!!! note
+    New types should only implement the method with the argument in the type domain.
+"""
+VectorInterface.scalartype(::Type{<:AbstractObservable{T}}) where {T} = eltype(T)
+
+"""
+    AbstractOperator{T} <: AbstractObservable{T}
 
 Supertype that provides an interface for linear operators over a linear space with elements
 of type `T` (returned by [`eltype`](@ref)) and general (custom type) indices called
@@ -22,12 +74,18 @@ Hamiltonians, but that can be used in the context of a [`ProjectorMonteCarloProb
 as observable operators in a [`ReplicaStrategy`](@ref Rimu.ReplicaStrategy), e.g. for
 defining correlation functions. In contrast to [`AbstractHamiltonian`](@ref)s,
 `AbstractOperator`s do not need to have a [`starting_address`](@ref). Moreover, the
-`eltype` of an `AbstractOperator` can be a vector value.
+`eltype` of an `AbstractOperator` can be a vector value whereas
+[`AbstractHamiltonian`](@ref)s requre a scalar `eltype`.
+
+    AbstractHamiltonian{T} <: AbstractOperator{T} <: AbstractObservable{T}
+
+The `AbstractOperator` type is part of the [`AbstractObservable`](@ref) hierarchy. It is
+more restrictive than `AbstractObservable` in that it requires the interface for the
+generation of diagonal and off-diagonal elements.
 
 For concrete implementations see [`Hamiltonians`](@ref Main.Hamiltonians). In order to
 implement a Hamiltonian for use in [`ProjectorMonteCarloProblem`](@ref) or
-[`ExactDiagonalizationProblem`](@ref) use the type [`AbstractHamiltonian`](@ref) instead,
-which is a subtype of `AbstractOperator`.
+[`ExactDiagonalizationProblem`](@ref) use the type [`AbstractHamiltonian`](@ref) instead.
 
 # Interface
 
@@ -48,29 +106,7 @@ for [`Interfaces.dot_from_right(x, op, y)`](@ref) and [`LinearAlgebra.mul!(y, op
 
 See also [`AbstractHamiltonian`](@ref), [`Interfaces`](@ref).
 """
-abstract type AbstractOperator{T} end
-
-"""
-    eltype(op::AbstractOperator)
-Return the type of the elements of the operator. This can be a vector value. For the
-underlying scalar type use [`scalartype`](@ref).
-
-Part of the [`AbstractOperator`](@ref) interface.
-!!! note
-    New types should only implement the method with the argument in the type domain.
-"""
-Base.eltype(::Type{<:AbstractOperator{T}}) where {T} = T # could be vector value
-
-"""
-    scalartype(op::AbstractOperator)
-Return the type of the underlying scalar field of the operator. This may be different from
-the element type of the operator returned by [`eltype`](@ref), which can be a vector value.
-
-Part of the [`AbstractOperator`](@ref) interface.
-!!! note
-    New types should only implement the method with the argument in the type domain.
-"""
-VectorInterface.scalartype(::Type{<:AbstractOperator{T}}) where T = eltype(T)
+abstract type AbstractOperator{T} <: AbstractObservable{T} end
 
 @doc """
     LinearAlgebra.mul!(w::AbstractDVec, op::AbstractOperator, v::AbstractDVec)
@@ -87,14 +123,14 @@ to access the elements of the operator. The function can be overloaded for custo
 LinearAlgebra.mul!
 
 @doc """
-    dot(w, op::AbstractOperator, v)
+    dot(w, op::AbstractObservable, v)
 
 Evaluate `w⋅op(v)` minimizing memory allocations.
 """
 LinearAlgebra.dot
 
 @doc """
-    dot_from_right(w, op::AbstractOperator, v)
+    dot_from_right(w, op::AbstractObservable, v)
 
 Internal function evaluates the 3-argument `dot()` function in order from right
 to left.
@@ -159,7 +195,7 @@ Alternatively to the above, [`offdiagonals`](@ref) can be implemented instead of
 when iterating [`offdiagonals`](@ref).
 
 See also [`Hamiltonians`](@ref Main.Hamiltonians), [`Interfaces`](@ref),
-[`AbstractOperator`](@ref).
+[`AbstractOperator`](@ref), [`AbstractObservable`](@ref).
 """
 abstract type AbstractHamiltonian{T} <: AbstractOperator{T} end
 

--- a/src/Interfaces/hamiltonians.jl
+++ b/src/Interfaces/hamiltonians.jl
@@ -15,7 +15,8 @@ product [`dot(x, op, y)`](@ref LinearAlgebra.dot) with two vectors of type
 by the [`scalartype`](@ref) function.
 
 The `AbstractObservable` type is useful for defining observables that can be calculated in
-the context of a [`ProjectorMonteCarloProblem`](@ref) using [`AllOverlaps`](@ref).
+the context of a [`ProjectorMonteCarloProblem`](@ref) using
+[`AllOverlaps`](@ref Main.Hamiltonians).
 
 # Interface
 

--- a/src/Interfaces/hamiltonians.jl
+++ b/src/Interfaces/hamiltonians.jl
@@ -39,7 +39,7 @@ underlying scalar type use [`scalartype`](@ref).
 
 Part of the [`AbstractObservable`](@ref) interface.
 !!! note
-    New types should only implement the method with the argument in the type domain.
+    New types do not have to implement this method explicitly. An implementation is provided based on the [`AbstractObservable`](@ref)'s type parameter.
 """
 Base.eltype(::Type{<:AbstractObservable{T}}) where {T} = T # could be vector value
 
@@ -50,7 +50,7 @@ the element type of the operator returned by [`eltype`](@ref), which can be a ve
 
 Part of the [`AbstractObservable`](@ref) interface.
 !!! note
-    New types should only implement the method with the argument in the type domain.
+    New types do not have to implement this method explicitly. An implementation is provided based on the [`AbstractObservable`](@ref)'s type parameter.
 """
 VectorInterface.scalartype(::Type{<:AbstractObservable{T}}) where {T} = eltype(T)
 

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -15,6 +15,44 @@ function exact_energy(ham)
 end
 
 """
+    test_observable_interface(obs, addr)
+
+This function tests the interface of an observable `obs` at address `addr` by checking that
+all required methods are defined.
+"""
+function test_observable_interface(obs, addr)
+    @testset "Observable interface: $(nameof(typeof(obs)))" begin
+        @testset "three way dot" begin # this works with vector valued operators
+            v = DVec(addr => scalartype(obs)(2))
+            @test dot(v, obs, v) isa eltype(obs)
+            @test dot(v, obs, v) ≈ Interfaces.dot_from_right(v, obs, v)
+        end
+        @testset "LOStructure" begin
+            @test LOStructure(obs) isa LOStructure
+            if LOStructure(obs) isa IsHermitian
+                @test obs' === obs
+            elseif  LOStructure(obs) isa IsDiagonal
+                @test num_offdiagonals(obs, addr) == 0
+                if scalartype(obs) <: Real
+                    @test obs' === obs
+                end
+            elseif LOStructure(obs) isa AdjointKnown
+                @test begin obs'; true; end # make sure no error is thrown
+            else
+                @test_throws ArgumentError obs'
+            end
+        end
+        @testset "allows_address_type" begin
+            @test allows_address_type(obs, addr)
+        end
+        @testset "show" begin
+            # Check that the result of show can be pasted into the REPL
+            @test eval(Meta.parse(repr(obs))) == obs
+        end
+    end
+end
+
+"""
     test_operator_interface(op, addr; test_spawning=true)
 
 This function tests the interface of an operator `op` at address `addr` by checking that all
@@ -25,6 +63,8 @@ If `test_spawning` is `true`, tests are performed that require `offdiagonals` to
 function. Otherwise, the spawning tests are skipped.
 """
 function test_operator_interface(op, addr; test_spawning=true)
+    test_observable_interface(op, addr)
+
     @testset "Operator interface: $(nameof(typeof(op)))" begin
         @testset "diagonal_element" begin
             @test diagonal_element(op, addr) isa eltype(op)
@@ -48,37 +88,14 @@ function test_operator_interface(op, addr; test_spawning=true)
                 end
             end
         end
-        @testset "three way dot" begin # this works with vector valued operators
+        @testset "mul!" begin # this works with vector valued operators
             v = DVec(addr => scalartype(op)(2))
-            @test dot(v, op, v) isa eltype(op)
             w = empty(v, eltype(op); style=IsDeterministic{scalartype(op)}())
             mul!(w, op, v) # operator vector product
             @test dot(v, op, v) ≈ Interfaces.dot_from_right(v, op, v) ≈ dot(v, w)
         end
-        @testset "LOStructure" begin
-            @test LOStructure(op) isa LOStructure
-            if LOStructure(op) isa IsHermitian
-                @test op' === op
-            elseif  LOStructure(op) isa IsDiagonal
-                @test num_offdiagonals(op, addr) == 0
-                if scalartype(op) <: Real
-                    @test op' === op
-                end
-            elseif LOStructure(op) isa AdjointKnown
-                @test begin op'; true; end # make sure no error is thrown
-            else
-                @test_throws ArgumentError op'
-            end
-        end
         @testset "dimension" begin
             @test dimension(addr) ≥ dimension(op, addr)
-        end
-        @testset "allows_address_type" begin
-            @test allows_address_type(op, addr)
-        end
-        @testset "show" begin
-            # Check that the result of show can be pasted into the REPL
-            @test eval(Meta.parse(repr(op))) == op
         end
     end
 end


### PR DESCRIPTION
This PR introduces the `AbstractObservable` supertype, which is a less restrictive operator type for implementing observables. 

The full type hierarchy is
```julia
AbstractHamiltonian{T} <: AbstractOperator{T} <: AbstractObservable{T}
```
A function is provided for testing the `AbstractObservable` interface in the testing suite.