### PR TITLE
Reduce allocations in `ReducedDensityMatrix`

### DIFF
--- a/src/DictVectors/DictVectors.jl
+++ b/src/DictVectors/DictVectors.jl
@@ -26,7 +26,7 @@ using ..Interfaces: Interfaces, AbstractDVec, AdjointUnknown,
 using ..StochasticStyles: StochasticStyles, IsDeterministic
 
 import ..Interfaces: deposit!, storage, StochasticStyle, default_style, freeze, localpart,
-    working_memory
+    working_memory, sum_mutating!
 
 export deposit!, storage, walkernumber, walkernumber_and_length, dot_from_right
 export DVec, InitiatorDVec, PDVec, PDWorkingMemory

--- a/src/Hamiltonians/Hamiltonians.jl
+++ b/src/Hamiltonians/Hamiltonians.jl
@@ -65,6 +65,7 @@ using TupleTools: TupleTools
 
 using ..BitStringAddresses
 using ..Interfaces
+using ..Interfaces: sum_mutating!
 import ..Interfaces: diagonal_element, num_offdiagonals, get_offdiagonal, starting_address,
     offdiagonals, random_offdiagonal, LOStructure, allows_address_type
 

--- a/src/Hamiltonians/Hamiltonians.jl
+++ b/src/Hamiltonians/Hamiltonians.jl
@@ -99,7 +99,7 @@ if VERSION < v"1.10"
     # used for ReducedDensityMatrix
     function hermitianpart!(A)
         A .= (A + A') / 2
-        return A
+        return Hermitian(A)
     end
 end
 

--- a/src/Hamiltonians/Hamiltonians.jl
+++ b/src/Hamiltonians/Hamiltonians.jl
@@ -95,6 +95,14 @@ export HOCartesianContactInteractions, HOCartesianEnergyConservedPerDim, HOCarte
 export AxialAngularMomentumHO
 export get_all_blocks, fock_to_cart
 
+if VERSION < v"1.10"
+    # used for ReducedDensityMatrix
+    function hermitianpart!(A)
+        A .= (A + A') / 2
+        return A
+    end
+end
+
 include("abstract.jl")
 include("offdiagonals.jl")
 include("geometry.jl")

--- a/src/Hamiltonians/reduced_density_matrix.jl
+++ b/src/Hamiltonians/reduced_density_matrix.jl
@@ -206,9 +206,9 @@ function Interfaces.dot_from_right(
         ReducedDensityMatrixCalculcator!{P}(left, dim),
         pairs(right)
     )
-    return (ρ .+ ρ') ./ 2
+    return hermitianpart!(ρ) # (ρ .+ ρ') ./ 2
 end
-# This struct used to calculate matrix elements of `ReducedDensityMatrix`
+# This struct is used to calculate matrix elements of `ReducedDensityMatrix`
 # It was introduced because passing a function to `sum` in `dot_from_right` was causing
 # type instabilites.
 """

--- a/src/Hamiltonians/reduced_density_matrix.jl
+++ b/src/Hamiltonians/reduced_density_matrix.jl
@@ -153,8 +153,8 @@ julia> dvec_b = PDVec(BoseFS{2,2}(1,1)=>0.5, BoseFS{2,2}(2,0)=>0.5)
 julia> Op1 = ReducedDensityMatrix(1)
 ReducedDensityMatrix(1)
 
-julia> dot(dvec_b,Op1,dvec_b) |> Matrix
-2×2 Matrix{Float64}:
+julia> dot(dvec_b,Op1,dvec_b)
+2×2 Hermitian{Float64, Matrix{Float64}}:
  0.75      0.353553
  0.353553  0.25
 
@@ -169,8 +169,8 @@ julia> dvec_f = PDVec(FermiFS{2,4}(1,1,0,0)=>0.5, FermiFS{2,4}(0,1,1,0)=>0.5)
   fs"|⋅↑↑⋅⟩" => 0.5
   fs"|↑↑⋅⋅⟩" => 0.5
 
-julia> dot(dvec_f,Op2,dvec_f) |> Matrix
-6×6 Matrix{Float64}:
+julia> dot(dvec_f,Op2,dvec_f)
+6×6 Hermitian{Float64, Matrix{Float64}}:
  0.25  0.0  0.25  0.0  0.0  0.0
  0.0   0.0  0.0   0.0  0.0  0.0
  0.25  0.0  0.25  0.0  0.0  0.0

--- a/src/Hamiltonians/reduced_density_matrix.jl
+++ b/src/Hamiltonians/reduced_density_matrix.jl
@@ -153,7 +153,7 @@ julia> dvec_b = PDVec(BoseFS{2,2}(1,1)=>0.5, BoseFS{2,2}(2,0)=>0.5)
 julia> Op1 = ReducedDensityMatrix(1)
 ReducedDensityMatrix(1)
 
-julia> dot(dvec_b,Op1,dvec_b)
+julia> dot(dvec_b,Op1,dvec_b) |> Matrix
 2×2 Matrix{Float64}:
  0.75      0.353553
  0.353553  0.25
@@ -169,7 +169,7 @@ julia> dvec_f = PDVec(FermiFS{2,4}(1,1,0,0)=>0.5, FermiFS{2,4}(0,1,1,0)=>0.5)
   fs"|⋅↑↑⋅⟩" => 0.5
   fs"|↑↑⋅⋅⟩" => 0.5
 
-julia> dot(dvec_f,Op2,dvec_f)
+julia> dot(dvec_f,Op2,dvec_f) |> Matrix
 6×6 Matrix{Float64}:
  0.25  0.0  0.25  0.0  0.0  0.0
  0.0   0.0  0.0   0.0  0.0  0.0

--- a/src/Hamiltonians/reduced_density_matrix.jl
+++ b/src/Hamiltonians/reduced_density_matrix.jl
@@ -123,29 +123,34 @@ function get_offdiagonal(
 end
 
 """
-    ReducedDensityMatrix(P; ele_type = Float64) <: AbstractOperator{Matrix{ele_type}}
+    ReducedDensityMatrix(p; ELTYPE = Float64) <: AbstractOperator{Matrix{ELTYPE}}
 
-Represent the P-particle reduced density matrix:
-
-```math
-\\hat{ρ}^{(n)}_{j_1,...,j_1,k_1,...,k_n} =  \\prod_{i}^{n} â^†_{j_i} \\prod_{l}^{n} â_{k_{n+1-l}}
-```
-
-The indices `j_i` and `k_i` (all `<: Int`) represent the single particle sites on a lattice.
-These indices are chosen in a specific pattern to ensure that unique elements of the
-reduced density matrix are calculated. This calculation will provide sufficient information
-for interpreting the largest eigenvalue. Additionally, the indices follow specific patterns
-as they run in the following manner:
+A matrix-valued operator that can be used to calculate the `p`-particle reduced density
+matrix. The matrix elements are defined as:
 
 ```math
-j_n > ... > j_{i+1} > j_{i} > ... > j_1 \\And k_n> ... > k_{i+1} > k_{i} > ... > k_1
+\\hat{ρ}^{(p)}_{j_1,...,j_1,k_1,...,k_p} =  \\prod_{i=1}^{p} â^†_{j_i} \\prod_{l=p}^{1} â_{k_{l}}
 ```
-This specific pattern has a drawback: for n > 1, addr cannot be of <:BoseFS.
+
+The integer indices `j_i` and `k_i` represent single particle modes. For efficiency they are
+chosen to be distinct and ordered:
+
+```math
+j_1 < j_2 < \\ldots < j_{p} \\quad \\land \\quad k_1 < k_2 < \\ldots < k_{p}
+```
+`ReducedDensityMatrix` can be used to construct the single-particle reduced density matrix
+(with `p == 1`) for fermionic and bosonic Fock spaces with address types
+[`<: SingleComponentFockAddress`](@ref SingleComponentFockAddress).
+For higher order reduced density matrices with `p > 1` only fermionic Fock addresses
+([`FermiFS`](@ref)) are supported due to the ordering of indices.
+
+`ReducedDensityMatrix` can be used with [`dot`](@ref) or [`AllOverlaps`](@ref) to calculate
+the whole matrix in one go.
 
 # Examples
 
 ```jldoctest
-julia> dvec_b = PDVec(BoseFS{2,2}(1,1)=>0.5, BoseFS{2,2}(2,0)=>0.5)
+julia> dvec_b = PDVec(BoseFS(1,1)=>0.5, BoseFS(2,0)=>0.5)
 2-element PDVec: style = IsDeterministic{Float64}()
   fs"|2 0⟩" => 0.5
   fs"|1 1⟩" => 0.5
@@ -164,7 +169,7 @@ ReducedDensityMatrix(2)
 julia> dot(dvec_b,Op2,dvec_b)
 ERROR: ArgumentError: ReducedDensityMatrix(<:BoseFS, P > 1) is not measurable
 
-julia> dvec_f = PDVec(FermiFS{2,4}(1,1,0,0)=>0.5, FermiFS{2,4}(0,1,1,0)=>0.5)
+julia> dvec_f = PDVec(FermiFS(1,1,0,0)=>0.5, FermiFS(0,1,1,0)=>0.5)
 2-element PDVec: style = IsDeterministic{Float64}()
   fs"|⋅↑↑⋅⟩" => 0.5
   fs"|↑↑⋅⋅⟩" => 0.5
@@ -178,15 +183,12 @@ julia> dot(dvec_f,Op2,dvec_f)
  0.0   0.0  0.0   0.0  0.0  0.0
  0.0   0.0  0.0   0.0  0.0  0.0
 ```
-# See also
-* [`single_particle_density`](@ref)
-* [`SingleParticleDensity`](@ref)
-* [`SingleParticleExcitation`](@ref)
-* [`TwoParticleExcitation`](@ref)
+See also [`single_particle_density`](@ref), [`SingleParticleDensity`](@ref),
+[`SingleParticleExcitation`](@ref), [`TwoParticleExcitation`](@ref).
 """
 struct ReducedDensityMatrix{TT, P} <: AbstractOperator{Matrix{TT}} end
-ReducedDensityMatrix(P::Int; ele_type = Float64) = ReducedDensityMatrix{ele_type, P}()
-ReducedDensityMatrix(;P::Int = 1, ele_type = Float64) = ReducedDensityMatrix{ele_type, P}()
+ReducedDensityMatrix(P::Int; ELTYPE = Float64) = ReducedDensityMatrix{ELTYPE, P}()
+ReducedDensityMatrix(;P::Int = 1, ELTYPE = Float64) = ReducedDensityMatrix{ELTYPE, P}()
 function Base.show(io::IO, op::ReducedDensityMatrix{<:Any, P}) where {P}
     print(io, "ReducedDensityMatrix($P)")
 end
@@ -196,8 +198,8 @@ LOStructure(::Type{<:ReducedDensityMatrix}) = IsHermitian()
 function Interfaces.dot_from_right(
     left::AbstractDVec, op::ReducedDensityMatrix{<:Any, P}, right::AbstractDVec
 ) where {P}
-    if all((keytype(left) <: BoseFS, P > 1))
-         throw(ArgumentError("ReducedDensityMatrix(<:BoseFS, P > 1) is not measurable"))
+    if P > 1 && !(left.address_type <: FermiFS)
+         throw(ArgumentError("ReducedDensityMatrix(p) with `p > 1` requires `FermiFS`` addresses"))
     end
     dim = binomial(num_modes(keytype(left)), P)
     T = promote_type(Float64, valtype(left), valtype(right))

--- a/src/Interfaces/Interfaces.jl
+++ b/src/Interfaces/Interfaces.jl
@@ -39,7 +39,7 @@ Follow the links for the definitions of the interfaces!
 module Interfaces
 
 using LinearAlgebra: LinearAlgebra, diag
-using VectorInterface: VectorInterface, add, zerovector!, scalartype
+using VectorInterface: VectorInterface, add, add!, zerovector!, scalartype
 
 import OrderedCollections: freeze
 

--- a/src/Interfaces/Interfaces.jl
+++ b/src/Interfaces/Interfaces.jl
@@ -48,7 +48,7 @@ export
     CompressionStrategy, NoCompression, compress!
 export
     AbstractDVec, deposit!, storage, localpart, freeze, working_memory,
-    apply_operator!, sort_into_targets!
+    apply_operator!, sort_into_targets!, sum_mutating!
 export
     AbstractHamiltonian, diagonal_element, num_offdiagonals, get_offdiagonal, offdiagonals,
     random_offdiagonal, starting_address, allows_address_type,

--- a/src/Interfaces/dictvectors.jl
+++ b/src/Interfaces/dictvectors.jl
@@ -158,9 +158,6 @@ Add the sum of elements in `iterator` to `accumulator`, storing the result in `a
 If `f!` is provided, it must accept two arguments, the first being the
 accumulator and the second the element of the iterator. Otherwise, `add!` is used.
 
-`sum_mutating!` can be used to perform a parallel reduction operation on [`PDVec`](@ref)s
-for vector-valued results while minimizing allocations. This is MPI parallelized.
-
 See also [`mapreduce`](@ref).
 """
 sum_mutating!(accu, iterator; kwargs...) = sum_mutating!(accu, add!, iterator; kwargs...)

--- a/src/Interfaces/dictvectors.jl
+++ b/src/Interfaces/dictvectors.jl
@@ -150,3 +150,22 @@ according to thread- or MPI-level parallelism.
 Returns the new `target` and `source`, as the sorting process may involve swapping them.
 """
 sort_into_targets!(dv::T, wm::T, stats) where {T} = wm, dv, stats
+
+"""
+    sum_mutating!(accumulator, [f! = add!], iterator)
+
+Add the sum of elements in `iterator` to `accumulator`, storing the result in `accumulator`.
+If `f!` is provided, it must accept two arguments, the first being the
+accumulator and the second the element of the iterator. Otherwise, `add!` is used.
+
+`sum_mutating!` can be used to perform a parallel reduction operation on [`PDVec`](@ref)s
+for vector-valued results while minimizing allocations. This is MPI parallelized.
+
+See also [`mapreduce`](@ref).
+"""
+sum_mutating!(accu, iterator; kwargs...) = sum_mutating!(accu, add!, iterator; kwargs...)
+
+function sum_mutating!(accu, f!, iterator; kwargs...)
+    sum(x -> f!(accu, x), iterator)
+    return accu
+end

--- a/src/Interfaces/dictvectors.jl
+++ b/src/Interfaces/dictvectors.jl
@@ -166,6 +166,8 @@ See also [`mapreduce`](@ref).
 sum_mutating!(accu, iterator; kwargs...) = sum_mutating!(accu, add!, iterator; kwargs...)
 
 function sum_mutating!(accu, f!, iterator; kwargs...)
-    sum(x -> f!(accu, x), iterator)
+    for x in iterator
+        f!(accu, x; kwargs...)
+    end
     return accu
 end

--- a/test/DictVectors.jl
+++ b/test/DictVectors.jl
@@ -301,6 +301,21 @@ end
         dv = DVec(:a => sai)
         @test_throws ArgumentError empty(dv; style=IsDynamicSemistochastic())
     end
+
+    @testset "sum_mutating!" begin
+        ks = 1:10
+        vs = [rand(3, 3) for _ in 1:10]
+        ps = map(Pair, ks, vs)
+
+        u = DVec(Dict(ps))
+        accu = rand(3, 3)
+        @test accu + sum(vs) ≈ sum_mutating!(accu, values(u))
+
+        function f!(a, b)
+            a .+= b.^2
+        end
+        @test sum_mutating!(zeros(3,3), f!, values(u)) ≈ sum(m->m.^2, vs)
+    end
 end
 
 @testset "InitiatorDVec" begin
@@ -447,6 +462,21 @@ using Rimu.DictVectors: num_segments, is_distributed, SegmentedBuffer, replace_c
                 @test dot(pv1, op, pv2, wm) ≈ dot(pv1, op, dv2)
             end
         end
+    end
+
+    @testset "sum_mutating!" begin
+        ks = 1:10
+        vs = [rand(3, 3) for _ in 1:10]
+        ps = map(Pair, ks, vs)
+
+        u = PDVec(Dict(ps))
+        accu = rand(3, 3)
+        @test accu + sum(vs) ≈ sum_mutating!(accu, values(u))
+
+        function f!(a, b)
+            a .+= b .^ 2
+        end
+        @test sum_mutating!(zeros(3, 3), f!, values(u)) ≈ sum(m -> m .^ 2, vs)
     end
 
     @testset "interface tests" begin


### PR DESCRIPTION
## New features

* New function `sum_mutating!` allows parallel reductions from `PDVec`s over vector-valued results while minimizing allocations.

## Changed behavior

Allocations and GC load is reduced leading to a 1.5x speedup when calculating a  dot product with a `ReducedDensityMatrix(2)` on four threads.

**Old code:**
```julia-repl
julia> @benchmark dot($v2, $rdmop, $v2)
BenchmarkTools.Trial: 6 samples with 1 evaluation.
 Range (min … max):  843.080 ms … 953.016 ms  ┊ GC (min … max): 15.06% … 20.26%
 Time  (median):     900.043 ms               ┊ GC (median):    18.58%
 Time  (mean ± σ):   900.078 ms ±  44.495 ms  ┊ GC (mean ± σ):  18.69% ±  2.93%

  █           █     █                          █      █       █  
  █▁▁▁▁▁▁▁▁▁▁▁█▁▁▁▁▁█▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█▁▁▁▁▁▁█▁▁▁▁▁▁▁█ ▁
  843 ms           Histogram: frequency by time          953 ms <

 Memory estimate: 2.76 GiB, allocs estimate: 77248.

```

**New code (this PR):**
```julia-repl
julia> @benchmark dot($v2, $rdmop, $v2)
BenchmarkTools.Trial: 9 samples with 1 evaluation.
 Range (min … max):  516.414 ms … 615.814 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     593.440 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   587.321 ms ±  30.741 ms  ┊ GC (mean ± σ):  0.00% ± 0.00%

  █                                  █  █  █     █   █      ███  
  █▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█▁▁█▁▁█▁▁▁▁▁█▁▁▁█▁▁▁▁▁▁███ ▁
  516 ms           Histogram: frequency by time          616 ms <

 Memory estimate: 1.10 MiB, allocs estimate: 55.

julia> length(v2)
12870
```