### PR TITLE
Fix normalisation in `single_particle_density`

### DIFF
--- a/src/strategies_and_params/poststepstrategy.jl
+++ b/src/strategies_and_params/poststepstrategy.jl
@@ -267,20 +267,16 @@ julia> single_particle_density(v; component=1)
 
 * [`SingleParticleDensity`](@ref)
 """
-function single_particle_density(dvec; component=0)
+function single_particle_density(dvec::AbstractDVec; component=0)
     K = keytype(dvec)
     V = float(valtype(dvec))
     M = num_modes(K)
-    N = num_particles(K)
 
-    result = mapreduce(
-        +, pairs(dvec);
-        init=MultiScalar(ntuple(_ -> zero(V), Val(M)))
-    ) do (k, v)
+    result = sum(pairs(dvec); init=MultiScalar(ntuple(_ -> zero(V), Val(M)))) do (k, v)
         MultiScalar(v^2 .* single_particle_density(k; component))
     end
 
-    return result.tuple ./ sum(result.tuple) .* N
+    return result.tuple ./ norm(dvec)
 end
 
 function single_particle_density(add::SingleComponentFockAddress; component=0)

--- a/src/strategies_and_params/poststepstrategy.jl
+++ b/src/strategies_and_params/poststepstrategy.jl
@@ -260,14 +260,14 @@ julia> single_particle_density(v)
 (0.2, 1.0, 1.6, 1.0, 0.2)
 
 julia> single_particle_density(v; component=1)
-(0.0, 1.6, 1.6, 0.4, 0.4)
+(0.0, 0.8, 0.8, 0.2, 0.2)
 ```
 
 # See also
 
 * [`SingleParticleDensity`](@ref)
 """
-function single_particle_density(dvec::AbstractDVec; component=0)
+function single_particle_density(dvec; component=0)
     K = keytype(dvec)
     V = float(valtype(dvec))
     M = num_modes(K)

--- a/src/strategies_and_params/poststepstrategy.jl
+++ b/src/strategies_and_params/poststepstrategy.jl
@@ -273,7 +273,7 @@ function single_particle_density(dvec; component=0)
     M = num_modes(K)
 
     result = sum(pairs(dvec); init=MultiScalar(ntuple(_ -> zero(V), Val(M)))) do (k, v)
-        MultiScalar(v^2 .* single_particle_density(k; component))
+        MultiScalar(abs2(v) .* single_particle_density(k; component))
     end
 
     return result.tuple ./ sum(abs2, dvec)

--- a/src/strategies_and_params/poststepstrategy.jl
+++ b/src/strategies_and_params/poststepstrategy.jl
@@ -276,7 +276,7 @@ function single_particle_density(dvec::AbstractDVec; component=0)
         MultiScalar(v^2 .* single_particle_density(k; component))
     end
 
-    return result.tuple ./ norm(dvec)
+    return result.tuple ./ sum(abs2, dvec)
 end
 
 function single_particle_density(add::SingleComponentFockAddress; component=0)

--- a/test/lomc.jl
+++ b/test/lomc.jl
@@ -516,7 +516,9 @@ Random.seed!(1234)
                 @test single_particle_density(address) == (1, 3, 3)
                 @test single_particle_density(address; component=1) == (1, 2, 3)
                 @test single_particle_density(address; component=2) == (0, 1, 0)
-                @test single_particle_density(DVec(address => 1); component=2) == (0, 7, 0)
+                @test single_particle_density(DVec(address => 1); component=0) == (1, 3, 3)
+                @test single_particle_density(DVec(address => 2); component=1) == (2, 4, 6)
+                @test single_particle_density(DVec(address => 3); component=2) == (0, 3, 0)
             end
         end
     end

--- a/test/lomc.jl
+++ b/test/lomc.jl
@@ -517,8 +517,8 @@ Random.seed!(1234)
                 @test single_particle_density(address; component=1) == (1, 2, 3)
                 @test single_particle_density(address; component=2) == (0, 1, 0)
                 @test single_particle_density(DVec(address => 1); component=0) == (1, 3, 3)
-                @test single_particle_density(DVec(address => 2); component=1) == (2, 4, 6)
-                @test single_particle_density(DVec(address => 3); component=2) == (0, 3, 0)
+                @test single_particle_density(DVec(address => 2); component=1) == (1, 2, 3)
+                @test single_particle_density(DVec(address => 3); component=2) == (0, 1, 0)
             end
         end
     end


### PR DESCRIPTION
The `single_particle_density` was not normalized properly when computing densities of specific components. This PR fixes it.

Before:
```julia
julia> addr = FermiFS2C((1, 1, 1, 1), (1, 0, 0, 0))
julia> single_particle_density(addr; component=2)
(1, 0, 0, 0)
julia> DVec(addr => 1)
julia> single_particle_density(dvec; component=2)
(5, 0, 0, 0) # <- multiplied by the total number of particles for some reason
```
after:
```julia
julia> addr = FermiFS2C((1, 1, 1, 1), (1, 0, 0, 0))
julia> single_particle_density(addr; component=2)
(1, 0, 0, 0)
julia> DVec(addr => 1)
julia> single_particle_density(dvec; component=2)
(1, 0, 0, 0)
```