### PR TITLE
Consistently apply snake_case

### DIFF
--- a/src/Hamiltonians/HubbardRealSpace.jl
+++ b/src/Hamiltonians/HubbardRealSpace.jl
@@ -266,7 +266,7 @@ function Base.show(io::IO, h::HubbardRealSpace{C}) where C
         println(io, "  u = ", Float64.(h.u), ",")
     end
     !isnothing(h.v) && println(io, "  v = ", Float64.(h.v), ",")
-    println(io, ")")
+    print(io, ")")
 end
 
 # Overload equality due to stored potential energy arrays.

--- a/src/fciqmc.jl
+++ b/src/fciqmc.jl
@@ -177,11 +177,11 @@ function advance!(algorithm::FCIQMC, report, state::ReplicaState, s_state::Singl
         end
         return false
     end
-    if len > state.maxlength[]
+    if len > state.max_length[]
         if length(state.spectral_states) > 1
-            @error "`maxlength` reached in single state $(s_state.id). Aborting."
+            @error "`max_length` reached in single state $(s_state.id). Aborting."
         else
-            @error "`maxlength` reached. Aborting."
+            @error "`max_length` reached. Aborting."
         end
         return false
     end

--- a/src/fciqmc.jl
+++ b/src/fciqmc.jl
@@ -170,19 +170,11 @@ function advance!(algorithm::FCIQMC, report, state::ReplicaState, s_state::Singl
     end
 
     if len == 0
-        if length(state.spectral_states) > 1
-            @error "population in single state $(s_state.id) is dead. Aborting."
-        else
-            @error "population is dead. Aborting."
-        end
+        @error "Population in state $(s_state.id) is dead. Aborting."
         return false
     end
     if len > state.max_length[]
-        if length(state.spectral_states) > 1
-            @error "`max_length` reached in single state $(s_state.id). Aborting."
-        else
-            @error "`max_length` reached. Aborting."
-        end
+        @error "`max_length` reached in state $(s_state.id). Aborting."
         return false
     end
     return proceed # Bool

--- a/src/lomc.jl
+++ b/src/lomc.jl
@@ -118,6 +118,8 @@ function lomc!(
     maxlength = nothing,
     wm = nothing
 )
+    @warn "The use of `lomc!` is deprecated. Use `ProjectorMonteCarloProblem` and `solve` instead."
+
     if !isnothing(wm)
         @warn "The `wm` argument has been removed and will be ignored."
     end
@@ -193,11 +195,14 @@ function lomc!(
 end
 
 function lomc!(::AbstractMatrix, v=nothing; kwargs...)
+    @warn "The use of `lomc!` is deprecated. Use `ProjectorMonteCarloProblem` and `solve` instead."
     throw(ArgumentError("Using lomc! with a matrix is no longer supported. Use `MatrixHamiltonian` instead."))
 end
 
 # methods for backward compatibility
 function lomc!(state::ReplicaState, df=DataFrame(); laststep=0, name="lomc!", metadata=nothing)
+    @warn "The use of `lomc!` is deprecated. Use `ProjectorMonteCarloProblem` and `solve` instead."
+
     if !iszero(laststep)
         state = @set state.simulation_plan.last_step = laststep
     end

--- a/src/lomc.jl
+++ b/src/lomc.jl
@@ -55,9 +55,9 @@ julia> address = BoseFS(1,2,3);
 
 julia> hamiltonian = HubbardReal1D(address);
 
-julia> df1, state = lomc!(hamiltonian; targetwalkers=500, laststep=100);
+julia> df1, state = @suppress lomc!(hamiltonian; targetwalkers=500, laststep=100);
 
-julia> df2, _ = lomc!(state, df1; laststep=200, metadata=(;info="cont")); # Continuation run
+julia> df2, _ = @suppress lomc!(state, df1; laststep=200, metadata=(;info="cont")); # Continuation run
 
 julia> size(df1)
 (100, 9)

--- a/src/lomc.jl
+++ b/src/lomc.jl
@@ -156,7 +156,7 @@ function lomc!(
         replica_strategy = replica,
         reporting_strategy = r_strat,
         post_step_strategy = post_step,
-        maxlength,
+        max_length = maxlength,
         metadata,
         display_name = name,
         random_seed = false
@@ -201,7 +201,7 @@ function lomc!(state::ReplicaState, df=DataFrame(); laststep=0, name="lomc!", me
     if !iszero(laststep)
         state = @set state.simulation_plan.last_step = laststep
     end
-    @unpack spectral_states, maxlength, step, simulation_plan,
+    @unpack spectral_states, max_length, step, simulation_plan,
     reporting_strategy, post_step_strategy, replica_strategy = state
     first_replica = first(state) # SingleState
     @unpack hamiltonian = first_replica
@@ -213,7 +213,7 @@ function lomc!(state::ReplicaState, df=DataFrame(); laststep=0, name="lomc!", me
         replica_strategy,
         reporting_strategy,
         post_step_strategy,
-        maxlength=maxlength[],
+        max_length=max_length[],
         simulation_plan,
         metadata,
         display_name=name,

--- a/src/pmc_simulation.jl
+++ b/src/pmc_simulation.jl
@@ -242,7 +242,7 @@ end
 
 Advance the simulation by one step.
 
-Calling [`solve!`](@ref) will advance the simulation until the last step or the walltime is
+Calling [`solve!`](@ref) will advance the simulation until the last step or the wall time is
 exceeded. When completing the simulation without calling [`solve!`](@ref), the simulation
 report needs to be finalised by calling [`Rimu.finalize_report!`](@ref).
 
@@ -300,7 +300,7 @@ end
     solve(::ProjectorMonteCarloProblem)::PMCSimulation
 
 Initialize and solve a [`ProjectorMonteCarloProblem`](@ref) until the last step is completed
-or the walltime limit is reached.
+or the wall time limit is reached.
 
 See also [`init`](@ref), [`solve!`](@ref), [`step!`](@ref), [`Rimu.PMCSimulation`](@ref),
 and [`solve(::ExactDiagonalizationProblem)`](@ref).
@@ -310,16 +310,17 @@ CommonSolve.solve
 """
     solve!(sm::PMCSimulation; kwargs...)::PMCSimulation
 
-Solve a [`Rimu.PMCSimulation`](@ref) until the last step is completed or the walltime limit
+Solve a [`Rimu.PMCSimulation`](@ref) until the last step is completed or the wall time limit
 is reached.
 
-To continue a previously completed simulation, set a new `last_step` or `walltime` using the
-keyword arguments. Optionally, changes can be made to the `replica_strategy`, the
+To continue a previously completed simulation, set a new `last_step` or `wall_time` using
+the keyword arguments. Optionally, changes can be made to the `replica_strategy`, the
 `post_step_strategy`, or the `reporting_strategy`.
 
 # Optional keyword arguments:
 * `last_step = nothing`: Set the last step to a new value and continue the simulation.
-* `walltime = nothing`: Set the allowed walltime to a new value and continue the simulation.
+* `wall_time = nothing`: Set the allowed wall time to a new value and continue the
+    simulation.
 * `reset_time = false`: Reset the `elapsed_time` counter and continue the simulation.
 * `empty_report = false`: Empty the report before continuing the simulation.
 * `replica_strategy = nothing`: Change the replica strategy. Requires the number of replicas
@@ -335,7 +336,7 @@ See also [`ProjectorMonteCarloProblem`](@ref), [`init`](@ref), [`solve`](@ref),
 """
 function CommonSolve.solve!(sm::PMCSimulation;
     last_step = nothing,
-    walltime = nothing,
+    wall_time = nothing,
     reset_time = false,
     replica_strategy=nothing,
     post_step_strategy=nothing,
@@ -351,9 +352,9 @@ function CommonSolve.solve!(sm::PMCSimulation;
         report_metadata!(sm.report, "laststep", last_step)
         reset_flags = true
     end
-    if !isnothing(walltime)
+    if !isnothing(wall_time)
         state = sm.state
-        sm.state = @set state.simulation_plan.walltime = walltime
+        sm.state = @set state.simulation_plan.wall_time = wall_time
         reset_flags = true
     end
     if !isnothing(replica_strategy)
@@ -419,10 +420,10 @@ function CommonSolve.solve!(sm::PMCSimulation;
     name = get_metadata(sm.report, "display_name")
 
     @withprogress name = while !sm.aborted && !sm.success
-        if time() - starting_time > simulation_plan.walltime
+        if time() - starting_time > simulation_plan.wall_time
             sm.aborted = true
-            sm.message = "Walltime limit reached."
-            @warn "Walltime limit reached. Aborting simulation."
+            sm.message = "Wall time limit reached."
+            @warn "Wall time limit reached. Aborting simulation."
         else
             step!(sm)
         end

--- a/src/pmc_simulation.jl
+++ b/src/pmc_simulation.jl
@@ -80,7 +80,7 @@ function PMCSimulation(problem::ProjectorMonteCarloProblem; copy_vectors=true)
     @unpack algorithm, hamiltonian, start_at, style, threading, simulation_plan,
         replica_strategy, initial_shift_parameters,
         reporting_strategy, post_step_strategy,
-        maxlength, metadata, initiator, random_seed, spectral_strategy, minimum_size = problem
+        max_length, metadata, initiator, random_seed, spectral_strategy, minimum_size = problem
 
     reporting_strategy = refine_reporting_strategy(reporting_strategy)
 
@@ -137,7 +137,7 @@ function PMCSimulation(problem::ProjectorMonteCarloProblem; copy_vectors=true)
     # set up the initial state
     state = ReplicaState(
         spectral_states,
-        Ref(maxlength),
+        Ref(max_length),
         Ref(simulation_plan.starting_step),
         simulation_plan,
         reporting_strategy,

--- a/src/pmc_simulation.jl
+++ b/src/pmc_simulation.jl
@@ -6,6 +6,16 @@ Is returned by [`init(::ProjectorMonteCarloProblem)`](@ref) and solved with
 
 Obtain the results of a simulation `sm` as a DataFrame with `DataFrame(sm)`.
 
+## Fields
+- `problem::ProjectorMonteCarloProblem`: The problem that was solved
+- `state::Rimu.ReplicaState`: The current state of the simulation
+- `report::Rimu.Report`: The report of the simulation
+- `modified::Bool`: Whether the simulation has been modified
+- `aborted::Bool`: Whether the simulation has been aborted
+- `success::Bool`: Whether the simulation has been completed successfully
+- `message::String`: A message about the simulation status
+- `elapsed_time::Float64`: The time elapsed during the simulation
+
 See also [`state_vectors`](@ref),
 [`ProjectorMonteCarloProblem`](@ref), [`init`](@ref), [`solve!`](@ref).
 """

--- a/src/pmc_simulation.jl
+++ b/src/pmc_simulation.jl
@@ -124,23 +124,26 @@ function PMCSimulation(problem::ProjectorMonteCarloProblem; copy_vectors=true)
     # set up the spectral_states
     wm = working_memory(vectors[1, 1])
     spectral_states = ntuple(n_replicas) do i
+        replica_id = if n_replicas == 1
+            ""
+        else
+            "_$(i)"
+        end
         SpectralState(
             ntuple(n_spectral) do j
                 v = vectors[i, j]
                 sp = shift_parameters[i, j]
-                id = if n_replicas * n_spectral == 1
+                spectral_id = if n_spectral == 1
                     ""
-                elseif n_spectral == 1
-                    "_$(i)"
                 else
-                    "_s$(j)_$(i)" # j is the spectral state index, i is the replica index
-                end # we have to think about how to label the spectral states
+                    "_s$(j)" # j is the spectral state index, i is the replica index
+                end
                 SingleState(
                     hamiltonian, algorithm, v, zerovector(v),
                     wm isa PDWorkingMemory ? wm : working_memory(v), # reuse for PDVec
-                    sp, id
+                    sp, replica_id * spectral_id
                 )
-            end, spectral_strategy)
+            end, spectral_strategy, replica_id)
     end
     @assert spectral_states isa NTuple{n_replicas, <:SpectralState}
 

--- a/src/projector_monte_carlo_problem.jl
+++ b/src/projector_monte_carlo_problem.jl
@@ -159,15 +159,16 @@ function ProjectorMonteCarloProblem(
     starting_step = 0,
     last_step = 100,
     wall_time = Inf,
-    simulation_plan = SimulationPlan(starting_step, last_step, wall_time),
+    walltime = nothing, # deprecated
+    simulation_plan = nothing,
     replica_strategy = NoStats(n_replicas),
     targetwalkers = nothing, # deprecated
     target_walkers = 1_000,
     ζ = 0.08,
     ξ = ζ^2/4,
-    shift_strategy = DoubleLogUpdate(; target_walkers, ζ, ξ),
+    shift_strategy = nothing,
     time_step_strategy=ConstantTimeStep(),
-    algorithm=FCIQMC(; shift_strategy, time_step_strategy),
+    algorithm=nothing,
     initial_shift_parameters=nothing,
     reporting_strategy = ReportDFAndInfo(),
     post_step_strategy = (),
@@ -180,9 +181,25 @@ function ProjectorMonteCarloProblem(
     display_name = "PMCSimulation",
     random_seed = true
 )
+    if !isnothing(walltime)
+        @warn "The keyword argument `walltime` is deprecated. Use `wall_time` instead."
+        wall_time = walltime
+    end
+    if isnothing(simulation_plan)
+        simulation_plan = SimulationPlan(starting_step, last_step, wall_time)
+    end
+
     if !isnothing(targetwalkers)
         @warn "The keyword argument `targetwalkers` is deprecated. Use `target_walkers` instead."
         target_walkers = targetwalkers
+    end
+
+    if isnothing(shift_strategy)
+        shift_strategy = DoubleLogUpdate(; target_walkers, ζ, ξ)
+    end
+
+    if isnothing(algorithm)
+        algorithm = FCIQMC(; shift_strategy, time_step_strategy)
     end
 
     n_replicas = num_replicas(replica_strategy) # replica_strategy may override n_replicas

--- a/src/projector_monte_carlo_problem.jl
+++ b/src/projector_monte_carlo_problem.jl
@@ -96,9 +96,11 @@ julia> size(DataFrame(simulation))
   pairs or a `NamedTuple`, e.g. `metadata = ("key1" => "value1", "key2" => "value2")`.
   All metadata is converted to strings.
 - `random_seed = true`: Provide and store a seed for the random number generator. If set to
-    `true`, a random seed is generated. If set to number, this number is used as the seed.
-    The seed is used by `solve` such that `solve`ing the problem twice will yield identical
-    results. If set to `false`, no seed is used and results are not reproducible.
+    `true`, a new random seed is generated from `RandomDevice()`. If set to number, this
+    number is used as the seed. This seed is used by `solve` (and `init`) to re-seed the
+    default random number generator (consistently on each MPI rank) such that
+    `solve`ing the same `ProjectorMonteCarloProblem` twice will yield identical results. If
+    set to `false`, no seed is used and consecutive random numbers are used.
 - `minimum_size = 2*num_spectral_states(spectral_strategy)`: The minimum size of the basis
     used to construct starting vectors for simulations of spectral states, if `start_at`
     is not provided.

--- a/src/projector_monte_carlo_problem.jl
+++ b/src/projector_monte_carlo_problem.jl
@@ -7,21 +7,21 @@ See [`ProjectorMonteCarloProblem`](@ref), [`FCIQMC`](@ref).
 abstract type PMCAlgorithm end
 
 """
-    SimulationPlan(; starting_step = 1, last_step = 100, walltime = Inf)
+    SimulationPlan(; starting_step = 1, last_step = 100, wall_time = Inf)
 Defines the duration of the simulation. The simulation ends when the `last_step` is reached
-or the `walltime` is exceeded.
+or the `wall_time` is exceeded.
 
 See [`ProjectorMonteCarloProblem`](@ref), [`PMCSimulation`](@ref).
 """
 Base.@kwdef struct SimulationPlan
     starting_step::Int = 0
     last_step::Int = 100
-    walltime::Float64 = Inf
+    wall_time::Float64 = Inf
 end
 function Base.show(io::IO, plan::SimulationPlan)
     print(
         io, "SimulationPlan(starting_step=", plan.starting_step,
-        ", last_step=", plan.last_step, ", walltime=", plan.walltime, ")"
+        ", last_step=", plan.last_step, ", wall_time=", plan.wall_time, ")"
     )
 end
 
@@ -75,9 +75,9 @@ julia> size(DataFrame(simulation))
 
 # Further keyword arguments:
 - `starting_step = 1`: Starting step of the simulation.
-- `walltime = Inf`: Maximum time allowed for the simulation.
-- `simulation_plan = SimulationPlan(; starting_step, last_step, walltime)`: Defines the
-    duration of the simulation. Takes precedence over `last_step` and `walltime`.
+- `wall_time = Inf`: Maximum time allowed for the simulation.
+- `simulation_plan = SimulationPlan(; starting_step, last_step, wall_time)`: Defines the
+    duration of the simulation. Takes precedence over `last_step` and `wall_time`.
 - `ζ = 0.08`: Damping parameter for the shift update.
 - `ξ = ζ^2/4`: Forcing parameter for the shift update.
 - `shift_strategy = DoubleLogUpdate(; target_walkers, ζ, ξ)`: How to update the `shift`,
@@ -156,8 +156,8 @@ function ProjectorMonteCarloProblem(
     time_step = 0.01,
     starting_step = 0,
     last_step = 100,
-    walltime = Inf,
-    simulation_plan = SimulationPlan(starting_step, last_step, walltime),
+    wall_time = Inf,
+    simulation_plan = SimulationPlan(starting_step, last_step, wall_time),
     replica_strategy = NoStats(n_replicas),
     targetwalkers = nothing, # deprecated
     target_walkers = 1_000,

--- a/src/qmc_states.jl
+++ b/src/qmc_states.jl
@@ -150,6 +150,8 @@ struct StateVectors{V,R} <: AbstractMatrix{V}
 end
 Base.size(sv::StateVectors) = size(sv.state)
 Base.getindex(sv::StateVectors, i::Int, j::Int) = sv.state[i, j].v
+
+Base.show(io::IO, sv::StateVectors) = show(io, MIME("text/plain"), sv)
 function Base.show(io::IO, ::MIME"text/plain", sv::StateVectors)
     r = num_replicas(sv.state)
     s = num_spectral_states(sv.state)

--- a/src/qmc_states.jl
+++ b/src/qmc_states.jl
@@ -68,19 +68,6 @@ function state_vectors(state::SpectralState)
 end
 
 """
-    _n_walkers(v, shift_strategy)
-Returns an estimate of the expected number of walkers as an integer.
-"""
-function _n_walkers(v, shift_strategy)
-    n = if hasfield(typeof(shift_strategy), :target_walkers)
-        shift_strategy.target_walkers
-    else # e.g. for LogUpdate()
-        walkernumber(v)
-    end
-    return ceil(Int, max(real(n), imag(n)))
-end
-
-"""
     ReplicaState <: AbstractMatrix{SingleState}
 
 Holds information about multiple replicas of [`SpectralState`](@ref)s.

--- a/src/qmc_states.jl
+++ b/src/qmc_states.jl
@@ -100,7 +100,7 @@ struct ReplicaState{
     PS<:NTuple{<:Any,PostStepStrategy},
 } <: AbstractMatrix{SingleState}
     spectral_states::R
-    maxlength::Ref{Int}
+    max_length::Ref{Int}
     step::Ref{Int}
     simulation_plan::SimulationPlan
     reporting_strategy::RS
@@ -172,7 +172,7 @@ function report_default_metadata!(report::Report, state::ReplicaState)
     report_metadata!(report, "time_step", shift_parameters.time_step)
     report_metadata!(report, "step", state.step[])
     report_metadata!(report, "shift", shift_parameters.shift)
-    report_metadata!(report, "maxlength", state.maxlength[])
+    report_metadata!(report, "max_length", state.max_length[])
     report_metadata!(report, "post_step_strategy", state.post_step_strategy)
     report_metadata!(report, "v_summary", summary(s_state.v))
     report_metadata!(report, "v_type", typeof(s_state.v))

--- a/src/qmc_states.jl
+++ b/src/qmc_states.jl
@@ -39,17 +39,17 @@ end
 
 """
     SpectralState <: AbstractVector{SingleState}
-Holds one or several [`SingleState`](@ref)s representing the ground state and excited
+Holds one or several [`Rimu.SingleState`](@ref)s representing the ground state and excited
 states of a single replica.
 Indexing the `SpectralState` `state[i]` returns the `i`th `SingleState`.
 
 ## Fields
 - `single_states`: Tuple of `SingleState`s
 - `spectral_strategy`: Strategy for computing the spectral states
-- `id::String`: id is appended to column names
+- `id::String`: Identifies the replica
 
-See also [`SpectralStrategy`](@ref), [`ReplicaState`](@ref), [`SingleState`](@ref),
-[`PMCSimulation`](@ref).
+See also [`SpectralStrategy`](@ref), [`Rimu.ReplicaState`](@ref), [`Rimu.SingleState`](@ref),
+[`Rimu.PMCSimulation`](@ref).
 """
 struct SpectralState{
     N,
@@ -58,10 +58,7 @@ struct SpectralState{
 } <: AbstractVector{SingleState}
     single_states::NS # Tuple of SingleState
     spectral_strategy::SS # SpectralStrategy
-    id::String # id is appended to column names
-end
-function SpectralState(t::Tuple, ss::SpectralStrategy, id="")
-    return SpectralState(t, ss, id)
+    id::String # identifies the replica and is appended to row names
 end
 num_spectral_states(::SpectralState{N}) where {N} = N
 
@@ -73,6 +70,7 @@ function Base.show(io::IO, ::MIME"text/plain", s::SpectralState)
     ns = num_spectral_states(s)
     print(io, "$ns-element Rimu.SpectralState")
     print(io, " with ", ns, " spectral state(s) of type ", nameof(typeof(s[1])))
+    print(io, " and id \"", s.id, "\"")
     print(io, "\n    spectral_strategy: ", s.spectral_strategy)
     for (i, r) in enumerate(s.single_states)
         print(io, "\n      $i: ", r)
@@ -99,8 +97,8 @@ and `j`th spectral state.
 - `post_step_strategy`: Post-step strategy
 - `replica_strategy`: Replica strategy
 
-See also [`ReplicaStrategy`](@ref), [`SpectralState`](@ref), [`SingleState`](@ref),
-[`PMCSimulation`](@ref).
+See also [`ReplicaStrategy`](@ref), [`Rimu.SpectralState`](@ref), [`Rimu.SingleState`](@ref),
+[`Rimu.PMCSimulation`](@ref).
 """
 struct ReplicaState{
     N, # number of replicas

--- a/src/strategies_and_params/reportingstrategy.jl
+++ b/src/strategies_and_params/reportingstrategy.jl
@@ -175,22 +175,25 @@ end
 """
     ReportingStrategy
 
-Abstract type for strategies for reporting data in a DataFrame with [`report!()`](@ref).
+Abstract type for strategies for reporting data during a simulation of a
+[`ProjectorMonteCarloProblem`](@ref).
+
 
 # Implemented strategies:
 
 * [`ReportDFAndInfo`](@ref)
 * [`ReportToFile`](@ref)
 
-# Interface:
+# Extended help
+## Interface:
 
 A `ReportingStrategy` can define any of the following:
 
-* [`refine_reporting_strategy`](@ref)
-* [`report!`](@ref)
-* [`report_after_step!`](@ref)
-* [`finalize_report!`](@ref)
-* [`reporting_interval`](@ref)
+* [`Rimu.refine_reporting_strategy`](@ref)
+* [`Rimu.report!`](@ref)
+* [`Rimu.report_after_step!`](@ref)
+* [`Rimu.finalize_report!`](@ref)
+* [`Rimu.reporting_interval`](@ref)
 
 """
 abstract type ReportingStrategy end
@@ -208,9 +211,9 @@ refine_reporting_strategy(reporting_strategy::ReportingStrategy) = reporting_str
      report!(::ReportingStrategy, step, report::Report, nt, id="")
 
 Report `keys` and `values` to `report`, which will be converted to a `DataFrame` before
-[`ProjectorMonteCarloProblem`](@ref) exits. Alternatively, a `nt::NamedTuple` can be passed in place of `keys`
-and `values`. If `id` is specified, it is appended to all `keys`. This is used to
-differentiate between values reported by different replicas.
+[`ProjectorMonteCarloProblem`](@ref) exits. Alternatively, a `nt::NamedTuple` can be passed
+in place of `keys` and `values`. If `id` is specified, it is appended to all `keys`. This is
+used to differentiate between values reported by different replicas.
 
 To overload this function for a new `ReportingStrategy`, overload
 `report!(::ReportingStrategy, step, args...)` and apply the report by calling
@@ -224,8 +227,8 @@ end
 """
     report_after_step!(::ReportingStrategy, step, report, state) -> report
 
-This function is called at the very end of a step, after [`reporting_interval`](@ref) steps.
-It may modify the `report`.
+This function is called at the very end of a step, after [`Rimu.reporting_interval`](@ref)
+steps. It may modify the `report`.
 """
 function report_after_step!(::ReportingStrategy, _, report, args...)
     return report
@@ -261,10 +264,13 @@ end
 """
     ReportDFAndInfo(; reporting_interval=1, info_interval=100, io=stdout, writeinfo=false) <: ReportingStrategy
 
-The default [`ReportingStrategy`](@ref). Report every `reporting_interval`th step to a `DataFrame`
-and write info message to `io` every `info_interval`th reported step (unless `writeinfo == false`). The flag
-`writeinfo` is useful for controlling info messages in MPI codes, e.g. by setting
+The default [`ReportingStrategy`](@ref) for [`ProjectorMonteCarloProblem`](@ref). Report
+every `reporting_interval`th step to a `DataFrame` and write info message to `io` every
+`info_interval`th reported step (unless `writeinfo == false`). The flag `writeinfo` is
+useful for controlling info messages in MPI codes, e.g. by setting
 `writeinfo = `[`is_mpi_root()`](@ref Rimu.is_mpi_root).
+
+See also [`ProjectorMonteCarloProblem`](@ref), [`ReportToFile`](@ref).
 """
 @with_kw struct ReportDFAndInfo <: ReportingStrategy
     reporting_interval::Int = 1
@@ -288,9 +294,10 @@ end
 """
     ReportToFile(; kwargs...) <: ReportingStrategy
 
-[`ReportingStrategy`](@ref) that writes the report directly to a file in the
-[`Arrow`](https://arrow.apache.org/julia/dev/) format. Useful when dealing with long
-jobs or large numbers of replicas, when the report can incur a significant memory cost.
+[`ReportingStrategy`](@ref) for [`ProjectorMonteCarloProblem`](@ref) that writes the report
+directly to a file in the [`Arrow`](https://arrow.apache.org/julia/dev/) format. Useful when
+dealing with long jobs or large numbers of replicas, when the report can incur a significant
+memory cost.
 
 The arrow file can be read back in with [`load_df(filename)`](@ref) or
 `using Arrow; Arrow.Table(filename)`.
@@ -311,7 +318,8 @@ The arrow file can be read back in with [`load_df(filename)`](@ref) or
   messages printed out.
 * `compress = :zstd`: compression algorithm to use. Can be `:zstd`, `:lz4` or `nothing`.
 
-See also [`load_df`](@ref) and [`save_df`](@ref).
+See also [`load_df`](@ref), [`save_df`](@ref), [`ReportDFAndInfo`](@ref), and
+[`ProjectorMonteCarloProblem`](@ref).
 """
 mutable struct ReportToFile{C} <: ReportingStrategy
     filename::String

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -711,14 +711,17 @@ end
     d = DataFrame(sim)
     @test d.shift ≈ a.shift
     # integer walkernumber triggers IsStochasticInteger algorithm
-    Random.seed!(15)
-    sim = solve(ProjectorMonteCarloProblem(mh; start_at=DVec(pairs(ones(Int, dim)))))
+    sim = solve(
+        ProjectorMonteCarloProblem(mh; start_at=DVec(pairs(ones(Int, dim))), random_seed=18)
+    )
     @test StochasticStyle(only(state_vectors(sim))) == IsStochasticInteger()
     e = DataFrame(sim)
     @test ≈(e.shift[end], a.shift[end], atol=0.3)
     # wrap full matrix as MatrixHamiltonian
     fmh =  MatrixHamiltonian(Matrix(sparse_matrix))
-    sim = solve(ProjectorMonteCarloProblem(fmh; start_at=DVec(pairs(ones(dim)))))
+    sim = solve(
+        ProjectorMonteCarloProblem(fmh; start_at=DVec(pairs(ones(dim))), random_seed=15)
+    )
     @test StochasticStyle(only(state_vectors(sim))) == IsDeterministic()
     f = DataFrame(sim)
     @test f.shift ≈ a.shift

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -675,8 +675,6 @@ end
 end
 
 @testset "MatrixHamiltonian" begin
-    # using lomc! with an `AbstractMatrix` was removed in Rimu.jl v0.12.0
-
     # generate matrix
     ham = HubbardReal1D(BoseFS((1, 1, 1, 1)))
     dim = dimension(ham)
@@ -685,9 +683,9 @@ end
     sparse_matrix, basis = sparse(bsr), bsr.basis
     @test dim == length(basis)
 
-    # run lomc! in deterministic mode with Hamiltonian and DVec
+    # run ProjectorMonteCarloProblem in deterministic mode with Hamiltonian and DVec
     v = DVec(k=>1.0 for k in basis; style=IsDeterministic()) # corresponds to `ones(dim)`
-    a = lomc!(ham, v).df
+    a = solve(ProjectorMonteCarloProblem(ham; start_at=v)).df
 
     # MatrixHamiltonian
     @test_throws ArgumentError MatrixHamiltonian([1 2 3; 4 5 6])
@@ -706,17 +704,23 @@ end
     @test starting_address(mh) == 1
     @test dimension(mh) == dim
 
-    # lomc!
+    # ProjectorMonteCarloProblem with MatrixHamiltonian
     # float walkernumber triggers IsDeterministic algorithm
-    d = lomc!(mh, DVec(pairs(ones(dim)))).df
+    sim = solve(ProjectorMonteCarloProblem(mh; start_at=DVec(pairs(ones(dim)))))
+    @test StochasticStyle(only(state_vectors(sim))) == IsDeterministic()
+    d = DataFrame(sim)
     @test d.shift ≈ a.shift
     # integer walkernumber triggers IsStochasticInteger algorithm
     Random.seed!(15)
-    e = lomc!(mh, DVec(pairs(ones(Int,dim)))).df
+    sim = solve(ProjectorMonteCarloProblem(mh; start_at=DVec(pairs(ones(Int, dim)))))
+    @test StochasticStyle(only(state_vectors(sim))) == IsStochasticInteger()
+    e = DataFrame(sim)
     @test ≈(e.shift[end], a.shift[end], atol=0.3)
     # wrap full matrix as MatrixHamiltonian
     fmh =  MatrixHamiltonian(Matrix(sparse_matrix))
-    f = lomc!(fmh, DVec(pairs(ones(dim)))).df
+    sim = solve(ProjectorMonteCarloProblem(fmh; start_at=DVec(pairs(ones(dim)))))
+    @test StochasticStyle(only(state_vectors(sim))) == IsDeterministic()
+    f = DataFrame(sim)
     @test f.shift ≈ a.shift
 end
 

--- a/test/Interfaces.jl
+++ b/test/Interfaces.jl
@@ -44,7 +44,6 @@ end
            0 0 1 1 2;
            0 1 0 1 0]
     vector = ones(5)
-    @test_throws ArgumentError lomc!(ham, vector; laststep=10_000)
 
     # rephrase with MatrixHamiltonian
     mh = MatrixHamiltonian(ham)
@@ -54,13 +53,10 @@ end
     # solve with new API
     p = ProjectorMonteCarloProblem(mh; start_at=sv, last_step=10_000, post_step_strategy)
     sm = solve(p)
-    last_shift = DataFrame(sm).shift[end]
+    df = DataFrame(sm)
 
-    # solve with old API
-    df, _ = lomc!(mh, sv; laststep=10_000, post_step_strategy)
     eigs = eigen(ham)
 
-    @test eigs.values[1] ≈ last_shift rtol = 0.01
     @test df.shift[end] ≈ eigs.values[1] rtol=0.01
     @test df.hproj[end] / df.vproj[end] ≈ eigs.values[1] rtol=0.01
     @test normalize(state_vectors(sm)[1]) ≈ DVec(pairs(eigs.vectors[:, 1])) rtol = 0.01

--- a/test/StochasticStyles.jl
+++ b/test/StochasticStyles.jl
@@ -241,7 +241,8 @@ end
     add = BoseFS((0,0,0,10,0,0,0))
     H = HubbardMom1D(add)
     dv = DVec(add => 1.0, style=IsDeterministic())
-    lomc!(H, dv)
+    sim = solve(ProjectorMonteCarloProblem(H; start_at=dv))
+    dv = only(state_vectors(sim))
     normalize!(dv)
 
     for compression in (

--- a/test/doctests.jl
+++ b/test/doctests.jl
@@ -5,7 +5,7 @@ DocMeta.setdocmeta!(
     Rimu,
     :DocTestSetup,
     :(using Rimu; using Rimu.StatsTools; using DataFrames; using Random;
-      using LinearAlgebra);
+      using LinearAlgebra; using Suppressor);
     recursive=true
 )
 # Run with fix=true to fix docstrings

--- a/test/excited_states_tests.jl
+++ b/test/excited_states_tests.jl
@@ -13,9 +13,9 @@ using Test
     p = ProjectorMonteCarloProblem(ham; spectral_strategy, last_step, style)
     s = solve(p)
     df = DataFrame(s)
-    energy1 = shift_estimator(df, shift="shift_s1_1", skip=1000)
-    energy2 = shift_estimator(df, shift="shift_s2_1", skip=1000)
-    energy3 = shift_estimator(df, shift="shift_s3_1", skip=1000)
+    energy1 = shift_estimator(df, shift="shift_s1", skip=1000)
+    energy2 = shift_estimator(df, shift="shift_s2", skip=1000)
+    energy3 = shift_estimator(df, shift="shift_s3", skip=1000)
 
     @test energy1.mean ≈ vals[1]
     @test energy2.mean ≈ vals[2]
@@ -25,13 +25,13 @@ using Test
     p = ProjectorMonteCarloProblem(ham; spectral_strategy, last_step, style, n_replicas)
     s = solve(p)
     df = DataFrame(s)
-    energy1 = shift_estimator(df, shift="shift_s1_1", skip=1000)
-    energy2 = shift_estimator(df, shift="shift_s2_1", skip=1000)
-    energy3 = shift_estimator(df, shift="shift_s3_1", skip=1000)
-    energy4 = shift_estimator(df, shift="shift_s1_2", skip=1000)
-    energy5 = shift_estimator(df, shift="shift_s2_2", skip=1000)
-    energy6 = shift_estimator(df, shift="shift_s3_2", skip=1000)
-    
+    energy1 = shift_estimator(df, shift="shift_1_s1", skip=1000)
+    energy2 = shift_estimator(df, shift="shift_1_s2", skip=1000)
+    energy3 = shift_estimator(df, shift="shift_1_s3", skip=1000)
+    energy4 = shift_estimator(df, shift="shift_2_s1", skip=1000)
+    energy5 = shift_estimator(df, shift="shift_2_s2", skip=1000)
+    energy6 = shift_estimator(df, shift="shift_2_s3", skip=1000)
+
     @test energy1.mean ≈ vals[1]
     @test energy2.mean ≈ vals[2]
     @test energy3.mean ≈ vals[3]

--- a/test/lomc.jl
+++ b/test/lomc.jl
@@ -287,7 +287,7 @@ Random.seed!(1234)
         @test all(df.len_5[1:end-1] .≤ 10)
         @test all(df.len_6[1:end-1] .≤ 10)
 
-        state.maxlength[] += 1000
+        state.max_length[] += 1000
         df_cont = lomc!(state).df
         @test size(df_cont, 1) == 100 - size(df, 1)
     end

--- a/test/lomc.jl
+++ b/test/lomc.jl
@@ -53,7 +53,7 @@ Random.seed!(1234)
         address = BoseFS{5,2}((2,3))
         H = HubbardReal1D(address; u=0.1)
         dv = DVec(address => 1; style=IsStochasticInteger())
-        df, state = @test_logs (:warn, Regex("(Simulation)")) lomc!(H, dv; laststep=0, shift=23.1, dτ=0.002)
+        df, state = @test_logs (:warn, Regex("(Simulation)")) match_mode = :any lomc!(H, dv; laststep=0, shift=23.1, dτ=0.002)
         @test state.spectral_states[1].single_states[1].shift_parameters.time_step  == 0.002
         @test state.spectral_states[1].single_states[1].shift_parameters.shift == 23.1
         @test state.replica_strategy == NoStats{1}() # uses getfield method
@@ -91,7 +91,7 @@ Random.seed!(1234)
         walkers = lomc!(H, copy(dv); s_strat, laststep=1000).df.norm
         @test median(walkers) ≈ 1000 rtol=0.1
 
-        _, state = @test_logs (:warn, Regex("(Simulation)")) lomc!(H, copy(dv); targetwalkers=500, laststep=0)
+        _, state = @test_logs (:warn, Regex("(Simulation)")) match_mode = :any lomc!(H, copy(dv); targetwalkers=500, laststep=0)
         @test only(state).algorithm.shift_strategy.target_walkers == 500
     end
 

--- a/test/mpi_runtests.jl
+++ b/test/mpi_runtests.jl
@@ -171,7 +171,7 @@ end
                 Projector(proj_1=Norm2Projector()),
             )
             prob = ProjectorMonteCarloProblem(
-                H; start_at=dv, post_step_strategy, last_step=5000
+                H; start_at=dv, post_step_strategy, last_step=5000, random_seed=13
             )
             df = DataFrame(solve(prob))
 
@@ -194,7 +194,7 @@ end
             dv = PDVec(addr => 3; initiator_threshold=1)
             shift_strategy = DoubleLogUpdate(target_walkers=100)
             prob = ProjectorMonteCarloProblem(
-                H; start_at=dv, last_step=5000, shift_strategy
+                H; start_at=dv, last_step=5000, shift_strategy, random_seed=13
             )
             df = DataFrame(solve(prob))
 
@@ -214,7 +214,7 @@ end
                 # Diagonal
                 replica_strategy = AllOverlaps(2; operator=ntuple(DensityMatrixDiagonal, M))
                 prob = ProjectorMonteCarloProblem(
-                    H; start_at=dv, replica_strategy, last_step=10_000
+                    H; start_at=dv, replica_strategy, last_step=10_000, random_seed=13
                 )
                 df = DataFrame(solve(prob))
 
@@ -229,7 +229,7 @@ end
                 ops = ntuple(x -> G2MomCorrelator(x - cld(M, 2)), M)
                 replica_strategy = AllOverlaps(2; operator=ops)
                 prob = ProjectorMonteCarloProblem(
-                    H; start_at=dv, replica_strategy, last_step=10_000
+                    H; start_at=dv, replica_strategy, last_step=10_000, random_seed=13
                 )
                 df = DataFrame(solve(prob))
 

--- a/test/projector_monte_carlo_problem.jl
+++ b/test/projector_monte_carlo_problem.jl
@@ -22,7 +22,7 @@ using OrderedCollections: freeze
     @test sp.shift == diagonal_element(h, starting_address(h))
     @test sp.pnorm == walkernumber(only(state_vectors(simulation)))
     @test sp.pnorm isa Float64
-    @test p.maxlength == 2 * p.algorithm.shift_strategy.target_walkers + 100
+    @test p.max_length == 2 * p.algorithm.shift_strategy.target_walkers + 100
 
     ps = ProjectorMonteCarloProblem(h; initial_shift_parameters=sp, threading=false)
     @test ps.initial_shift_parameters === sp

--- a/test/projector_monte_carlo_problem.jl
+++ b/test/projector_monte_carlo_problem.jl
@@ -95,9 +95,14 @@ end
         @test sm.state[2].shift_parameters.shift ≡ 2.0
         @test state_vectors(sm.state)[1][BoseFS(1, 3)] == 10
         @test state_vectors(sm.state)[2][BoseFS(3, 1)] == 10
-        @test startswith(sprint(show, sm.state), "ReplicaState")
-        @test startswith(sprint(show, sm.state[1]), "SingleState")
-        @test startswith(sprint(show, sm.state.spectral_states), "(SpectralState")
+        @test startswith(sprint(show, sm.state), "2×1 Rimu.ReplicaState")
+        @test startswith(sprint(show, sm.state[1]), "Rimu.SingleState")
+        @test startswith(sprint(show, sm.state.spectral_states),
+            "(1-element Rimu.SpectralState"
+        )
+        @test startswith(sprint(show, sm.state.spectral_states[1]),
+            "1-element Rimu.SpectralState"
+        )
     end
 
     @testset "Default DVec" begin

--- a/test/projector_monte_carlo_problem.jl
+++ b/test/projector_monte_carlo_problem.jl
@@ -288,3 +288,13 @@ end
     @test size(sm.df, 1) == 100
     @test @suppress_err step!(sm) === sm # no effect, already finalized
 end
+
+@testset "deprecated keyword arguments" begin
+    h = HubbardReal1D(BoseFS(1, 3))
+    p = @suppress_err ProjectorMonteCarloProblem(
+        h; shift=1.0, targetwalkers=100, maxlength=200, walltime=23
+    )
+    @test p.algorithm.shift_strategy.target_walkers == 100
+    @test p.max_length == 200
+    @test p.simulation_plan.wall_time == 23
+end

--- a/test/projector_monte_carlo_problem.jl
+++ b/test/projector_monte_carlo_problem.jl
@@ -95,6 +95,10 @@ end
         @test sm.state[2].shift_parameters.shift ≡ 2.0
         @test state_vectors(sm.state)[1][BoseFS(1, 3)] == 10
         @test state_vectors(sm.state)[2][BoseFS(3, 1)] == 10
+        @test startswith(sprint(show, sm.state), "ReplicaState")
+        @test startswith(sprint(show, sm.state[1]), "SingleState")
+        @test startswith(sprint(show, sm.state.spectral_states), "(SpectralState")
+
     end
 
     @testset "random seeds" begin

--- a/test/projector_monte_carlo_problem.jl
+++ b/test/projector_monte_carlo_problem.jl
@@ -98,8 +98,24 @@ end
         @test startswith(sprint(show, sm.state), "ReplicaState")
         @test startswith(sprint(show, sm.state[1]), "SingleState")
         @test startswith(sprint(show, sm.state.spectral_states), "(SpectralState")
-
     end
+
+    @testset "Default DVec" begin
+        address = BoseFS(2, 3)
+        H = HubbardReal1D(address; u=20)
+        sm = init(ProjectorMonteCarloProblem(H; threading=false))
+        @test only(state_vectors(sm)) isa DVec
+        @test StochasticStyle(only(state_vectors(sm))) isa IsDynamicSemistochastic
+
+        sm = init(ProjectorMonteCarloProblem(H; threading=true))
+        @test only(state_vectors(sm)) isa PDVec
+        @test StochasticStyle(only(state_vectors(sm))) isa IsDynamicSemistochastic
+
+        sm = init(ProjectorMonteCarloProblem(H; threading=false, initiator=true))
+        @test only(state_vectors(sm)) isa InitiatorDVec
+        @test StochasticStyle(only(state_vectors(sm))) isa IsDynamicSemistochastic
+    end
+
 
     @testset "random seeds" begin
         p = ProjectorMonteCarloProblem(h) # generates random_seed

--- a/test/projector_monte_carlo_problem.jl
+++ b/test/projector_monte_carlo_problem.jl
@@ -1,5 +1,5 @@
 using Rimu
-using Test
+using Test, Suppressor
 import Random
 
 using Rimu: is_finalized

--- a/test/projector_monte_carlo_problem.jl
+++ b/test/projector_monte_carlo_problem.jl
@@ -103,6 +103,7 @@ end
         @test startswith(sprint(show, sm.state.spectral_states[1]),
             "1-element Rimu.SpectralState"
         )
+        @test startswith(sprint(show, state_vectors(sm)), "2×1 Rimu.StateVectors")
     end
 
     @testset "Default DVec" begin

--- a/test/projector_monte_carlo_problem.jl
+++ b/test/projector_monte_carlo_problem.jl
@@ -181,14 +181,14 @@ using Rimu: num_replicas, num_spectral_states
     @test sm.success == true == parse(Bool, (Rimu.get_metadata(sm.report, "success")))
 
     # time out
-    p = ProjectorMonteCarloProblem(h; last_step=500, walltime=1e-3)
+    p = ProjectorMonteCarloProblem(h; last_step=500, wall_time=1e-3)
     sm = init(p)
-    @test_logs (:warn, Regex("(Walltime)")) solve!(sm)
+    @test_logs (:warn, Regex("(Wall time)")) solve!(sm)
     @test sm.success == false
     @test sm.aborted == true
-    @test sm.message == "Walltime limit reached."
+    @test sm.message == "Wall time limit reached."
 
-    sm2 = solve!(sm; walltime=1.0)
+    sm2 = solve!(sm; wall_time=1.0)
     @test sm2 === sm
     @test sm.success == true
     @test sm.state.step[] == 500 == size(sm.df)[1]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,9 +42,9 @@ end
     include("projector_monte_carlo_problem.jl")
 end
 
-@safetestset "lomc!" begin
-    include("lomc.jl")
-end
+# @safetestset "lomc!" begin
+#     include("lomc.jl")
+# end
 
 @safetestset "RimuIO" begin
     include("RimuIO.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -60,9 +60,9 @@ end
     include("projector_monte_carlo_problem.jl")
 end
 
-# @safetestset "lomc!" begin
-#     include("lomc.jl")
-# end
+@suppress_err @safetestset "lomc!" begin
+    include("lomc.jl")
+end
 
 @safetestset "RimuIO" begin
     include("RimuIO.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,6 +14,24 @@ using ExplicitImports: check_no_implicit_imports
 
 @test Rimu.PACKAGE_VERSION == VersionNumber(TOML.parsefile(pkgdir(Rimu, "Project.toml"))["version"])
 
+@safetestset "ExplicitImports" begin
+    using Rimu
+    using ExplicitImports
+    # Check that no implicit imports are used in the Rimu module.
+    # See https://ericphanson.github.io/ExplicitImports.jl/stable/
+    @test check_no_implicit_imports(Rimu; skip=(Rimu, Base, Core, VectorInterface)) === nothing
+    # If this test fails, make your import statements explicit.
+    # For example, replace `using Foo` with `using Foo: bar, baz`.
+end
+
+@safetestset "doctests" begin
+    include("doctests.jl")
+end
+
+@safetestset "excited states" begin
+    include("excited_states_tests.jl")
+end
+
 @safetestset "Interfaces" begin
     include("Interfaces.jl")
 end
@@ -118,24 +136,6 @@ end
         @info "No progress bar" sl
     end
     @test default_logger() isa Logging.ConsoleLogger
-end
-
-@safetestset "doctests" begin
-    include("doctests.jl")
-end
-
-@safetestset "ExplicitImports" begin
-    using Rimu
-    using ExplicitImports
-    # Check that no implicit imports are used in the Rimu module.
-    # See https://ericphanson.github.io/ExplicitImports.jl/stable/
-    @test check_no_implicit_imports(Rimu; skip=(Rimu, Base, Core, VectorInterface)) === nothing
-    # If this test fails, make your import statements explicit.
-    # For example, replace `using Foo` with `using Foo: bar, baz`.
-end
-
-@safetestset "excited states" begin
-    include("excited_states_tests.jl")
 end
 
 # Note: Running Rimu with several MPI ranks is tested seperately on GitHub CI and not here.


### PR DESCRIPTION
# Apply snake_case to keyword arguments

## Breaking changes
- IDs for replicas and spectral states are swapped: replica ids defining the row in the matrix of `state_vectors` now are appended first and spectral ids second. If there is only a single replica, or a single spectral state, the respective ids are ommitted.

## Deprecations 
- in keyword arguments to `ProjectorMonteCarloProblem`
  - `maxlength` deprecated, replaced by `max_length`
  - `walltime` deprecated, replaced by `walltime`
- `lomc!` now prints a deprecation warning

## Internal changes
- fix random seeding of tests
- minor docstring changes
- remove `lomc!` from most tests
