### PR TITLE
Allow passing `time_step` to StatsTools functions

### DIFF
--- a/src/StatsTools/growth_witness.jl
+++ b/src/StatsTools/growth_witness.jl
@@ -51,7 +51,7 @@ function growth_witness(
     shift=:shift, norm=:norm, time_step=nothing, kwargs...
 )
     df = DataFrame(sim)
-    time_step = determine_constant_time_step(df)
+    time_step = isnothing(time_step) ? determine_constant_time_step(df) : time_step
 
     shift_vec = getproperty(df, Symbol(shift))
     norm_vec = getproperty(df, Symbol(norm))

--- a/src/StatsTools/reweighting.jl
+++ b/src/StatsTools/reweighting.jl
@@ -219,6 +219,7 @@ Returns a `NamedTuple` with the fields
 * `threading = Threads.nthreads() > 1`: if `false` a progress meter is displayed
 * `shift_name = :shift` name of column in `df` with shift data
 * `norm_name = :norm` name of column in `df` with walkernumber data
+* `time_step = determine_constant_time_step(df)` the time step
 * `warn = true` whether to log warning messages when blocking fails or denominators are
   small
 
@@ -242,8 +243,8 @@ function growth_estimator_analysis(
     threading=Threads.nthreads() > 1,
     shift_name=:shift,
     norm_name=:norm,
-    warn=true,
     time_step=nothing,
+    warn=true,
     kwargs...
 )
     df = DataFrame(sim)
@@ -389,6 +390,7 @@ Returns a `NamedTuple` with the fields
 * `shift_name = :shift` name of column in `df` with shift data
 * `hproj_name = :hproj` name of column in `df` with operator overlap data
 * `vproj_name = :vproj` name of column in `df` with projector overlap data
+* `time_step = determine_constant_time_step(df)` the time step
 * `warn = true` whether to log warning messages when blocking fails or denominators are small
 
 ## Example


### PR DESCRIPTION
Allows passing `time_step` to all functions that internally use `determine_constant_time_step`.