### PR TITLE
Import CompressionStrategy interface explicitly

### DIFF
--- a/src/StochasticStyles/StochasticStyles.jl
+++ b/src/StochasticStyles/StochasticStyles.jl
@@ -29,7 +29,7 @@ using ..Rimu: MultiScalar
 using ..Interfaces
 import ..Interfaces:
     deposit!, diagonal_element, offdiagonals, random_offdiagonal, default_style,
-    apply_column!, step_stats, compress!, localpart
+    apply_column!, step_stats, compress!, localpart, CompressionStrategy
 export
     StochasticStyle, IsStochasticInteger, IsDeterministic, IsStochasticWithThreshold,
     IsDynamicSemistochastic, StyleUnknown, Exact, WithReplacement, DynamicSemistochastic,


### PR DESCRIPTION
According to the merged PR JuliaLang/julia#57311, all types should be imported explicitly. Otherwise, starting from Julia version 1.12.0, the compiler will generate a warning message during the precompilation process, which has been observed in the recent CI test on julia nightly. This PR should fix the problem. 