### PR TITLE
Allow any operator in BasisSetRep

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -53,4 +53,4 @@ jobs:
         with:
           github-token: ${{ secrets.github_token }}
           path-to-lcov: ./lcov.info
-        if: ${{ matrix.julia-version == '1' }}
+        if: ${{ (matrix.julia-version == '1') && (matrix.os == 'ubuntu-latest') }}

--- a/src/ExactDiagonalization/ExactDiagonalization.jl
+++ b/src/ExactDiagonalization/ExactDiagonalization.jl
@@ -29,7 +29,7 @@ using StaticArrays: setindex
 
 using Rimu: Rimu, DictVectors, Hamiltonians, Interfaces, BitStringAddresses, replace_keys,
     clean_and_warn_if_others_present
-using ..Interfaces: AbstractDVec, AbstractHamiltonian, AdjointUnknown,
+using ..Interfaces: AbstractDVec, AbstractHamiltonian, AbstractOperator, AdjointUnknown,
     diagonal_element, offdiagonals, starting_address, LOStructure, IsHermitian
 using ..BitStringAddresses: AbstractFockAddress, BoseFS, FermiFS, CompositeFS, near_uniform
 using ..DictVectors: FrozenDVec, PDVec, DVec

--- a/src/ExactDiagonalization/basis_set_representation.jl
+++ b/src/ExactDiagonalization/basis_set_representation.jl
@@ -7,7 +7,7 @@
 
 Eagerly construct the basis set representation of the operator `hamiltonian` with all
 addresses reachable from `addr`. Instead of a single address, a vector of `addresses` can be
-passed. The second argument is mandatory when the operator is not an `AbstractHamiltonian`.
+passed. The second argument is mandatory when the operator is not an [`AbstractHamiltonian`](@ref).
 
 An `ArgumentError` is thrown if `dimension(hamiltonian) > sizelim` in order to prevent
 memory overflow. Set `sizelim = Inf` in order to disable this behaviour.
@@ -75,7 +75,7 @@ DVec{BoseFS{1, 3, BitString{3, 1, UInt8}},Float64} with 3 entries, style = IsDet
 Has methods for [`dimension`](@ref), [`sparse`](@ref), [`Matrix`](@ref),
 [`starting_address`](@ref).
 
-Part of the [`AbstractHamiltonian`](@ref) interface. See also [`build_basis`](@ref).
+Part of the [`AbstractHamiltonian`](@ref) interface. See also [`build_basis`](@ref), [`AbstractOperator`](@ref).
 """
 struct BasisSetRepresentation{A,SM,H}
     sparse_matrix::SM

--- a/src/ExactDiagonalization/basis_set_representation.jl
+++ b/src/ExactDiagonalization/basis_set_representation.jl
@@ -1,6 +1,6 @@
 """
     BasisSetRepresentation(
-        hamiltonian::AbstractHamiltonian, addr=starting_address(hamiltonian);
+        hamiltonian::AbstractOperator, addr=starting_address(hamiltonian);
         sizelim=10^7, cutoff, filter, max_depth, minimum_size, sort=false, kwargs...
     )
     BasisSetRepresentation(hamiltonian::AbstractHamiltonian, addresses::AbstractVector; kwargs...)
@@ -84,9 +84,11 @@ struct BasisSetRepresentation{A,SM,H}
 end
 
 function BasisSetRepresentation(
-    hamiltonian::AbstractHamiltonian, addr_or_vec=starting_address(hamiltonian);
-    kwargs...
+    hamiltonian::AbstractHamiltonian; kwargs...
 )
+    return BasisSetRepresentation(hamiltonian, starting_address(hamiltonian); kwargs...)
+end
+function BasisSetRepresentation(hamiltonian::AbstractOperator, addr_or_vec; kwargs...)
     # In the default case we pass `AdjointUnknown()` in order to skip the
     # symmetrisation of the sparse matrix
     return _bsr_ensure_symmetry(AdjointUnknown(), hamiltonian, addr_or_vec; kwargs...)
@@ -113,7 +115,7 @@ end
 
 # default, does not enforce symmetries
 function _bsr_ensure_symmetry(
-    ::LOStructure, hamiltonian::AbstractHamiltonian, addr_or_vec;
+    ::LOStructure, hamiltonian::AbstractOperator, addr_or_vec;
     test_approx_symmetry=true, kwargs...
 )
     single_addr = addr_or_vec isa Union{AbstractArray,Tuple} ? addr_or_vec[1] : addr_or_vec
@@ -124,7 +126,7 @@ end
 
 # build the BasisSetRepresentation while enforcing hermitian symmetry
 function _bsr_ensure_symmetry(
-    ::IsHermitian, hamiltonian::AbstractHamiltonian, addr_or_vec;
+    ::IsHermitian, hamiltonian::AbstractOperator, addr_or_vec;
     test_approx_symmetry=true, kwargs...
 )
     single_addr = addr_or_vec isa Union{AbstractArray,Tuple} ? addr_or_vec[1] : addr_or_vec
@@ -289,7 +291,7 @@ Return a sparse matrix representation of `hamiltonian` or `bsr`. `kwargs` are pa
 
 See [`BasisSetRepresentation`](@ref).
 """
-function SparseArrays.sparse(hamiltonian::AbstractHamiltonian, args...; kwargs...)
+function SparseArrays.sparse(hamiltonian::AbstractOperator, args...; kwargs...)
     return sparse(BasisSetRepresentation(hamiltonian, args...; kwargs...))
 end
 SparseArrays.sparse(bsr::BasisSetRepresentation) = bsr.sparse_matrix
@@ -306,7 +308,7 @@ Return a dense matrix representation of `hamiltonian` or `bsr`. `kwargs` are pas
 
 See [`BasisSetRepresentation`](@ref).
 """
-function Base.Matrix(hamiltonian::AbstractHamiltonian, args...; sizelim=1e4, kwargs...)
+function Base.Matrix(hamiltonian::AbstractOperator, args...; sizelim=1e4, kwargs...)
     return Matrix(BasisSetRepresentation(hamiltonian, args...; sizelim, kwargs...))
 end
 Base.Matrix(bsr::BasisSetRepresentation) = Matrix(bsr.sparse_matrix)

--- a/src/ExactDiagonalization/basis_set_representation.jl
+++ b/src/ExactDiagonalization/basis_set_representation.jl
@@ -3,11 +3,11 @@
         hamiltonian::AbstractOperator, addr=starting_address(hamiltonian);
         sizelim=10^7, cutoff, filter, max_depth, minimum_size, sort=false, kwargs...
     )
-    BasisSetRepresentation(hamiltonian::AbstractHamiltonian, addresses::AbstractVector; kwargs...)
+    BasisSetRepresentation(hamiltonian::AbstractOperator, addresses::AbstractVector; kwargs...)
 
 Eagerly construct the basis set representation of the operator `hamiltonian` with all
 addresses reachable from `addr`. Instead of a single address, a vector of `addresses` can be
-passed.
+passed. The second argument is mandatory when the operator is not an `AbstractHamiltonian`.
 
 An `ArgumentError` is thrown if `dimension(hamiltonian) > sizelim` in order to prevent
 memory overflow. Set `sizelim = Inf` in order to disable this behaviour.

--- a/test/ExactDiagonalization.jl
+++ b/test/ExactDiagonalization.jl
@@ -25,6 +25,14 @@ using Suppressor
         @test isdiag(ham) == (LOStructure(ham) ≡ IsDiagonal())
         @test ishermitian(ham) == (LOStructure(ham) ≡ IsHermitian())
         @test issymmetric(ham) == (ishermitian(ham) && isreal(ham))
+
+        # Test for non-Hamiltonian
+        g2 = G2RealCorrelator(1)
+        bsr_g2 = BasisSetRepresentation(g2, bsr.basis)
+        @test isdiag(bsr_g2.sparse_matrix)
+
+        bsr_g2 = BasisSetRepresentation(g2, bsr.basis[1])
+        @test size(bsr_g2.sparse_matrix) == (1, 1)
     end
 
     @testset "filtering" begin


### PR DESCRIPTION
Previously, it was limited to `AbstractHamiltonian`s.