### PR TITLE
Fix check for starting vectors with a complex Hamiltonian

### DIFF
--- a/src/projector_monte_carlo_problem.jl
+++ b/src/projector_monte_carlo_problem.jl
@@ -262,7 +262,7 @@ function ProjectorMonteCarloProblem(
     if eltype(hamiltonian) <: Complex
         if (start_at isa AbstractDVec && valtype(start_at) <: Real ||
             start_at isa Union{AbstractMatrix, AbstractVector} &&
-            eltype(start_at) <: AbsractDVec && valtype(eltype(start_at)) <: Real)
+            eltype(start_at) <: AbstractDVec && valtype(eltype(start_at)) <: Real)
             throw(ArgumentError(
                 "The starting vector(s) provided are not compatible with a complex Hamiltonian."
             ))

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -1628,10 +1628,13 @@ end
     @test adjoint(h) == h
     h2 = ExtendedHubbardReal1D(OccupationNumberFS(3, 0, 1); u=6 + 3im, t=0)
     # diagonal and non-Hermitian
-    @test LOStructure(h) isa IsDiagonal
     @test LOStructure(h2) isa AdjointKnown
     @test h2'.u == conj(h2.u)
     @test diagonal_element(h2, OccupationNumberFS(3,0,1)) == 21 + 9im
+    start_at = DVec(OccupationNumberFS(3,0,1) => 1)
+    @test_throws ArgumentError ProjectorMonteCarloProblem(h2; start_at)
+    start_at = [DVec(OccupationNumberFS(3,0,1) => 1) DVec(OccupationNumberFS(3,0,1) => 1)]
+    @test_throws ArgumentError ProjectorMonteCarloProblem(h2; start_at, n_spectral=2)
     h3 = HubbardReal1D(BoseFS(1,1,1),u=1.0im)
     @test h3'.u == -1.0im
     @test diagonal_element(h3, BoseFS(2,1,0)) == 1.0im

--- a/test/projector_monte_carlo_problem.jl
+++ b/test/projector_monte_carlo_problem.jl
@@ -180,6 +180,10 @@ end
         @test sm.state[1].shift_parameters.shift isa Real
         @test sm.state[1].shift_parameters.pnorm isa Real
         @test_throws ArgumentError ProjectorMonteCarloProblem(h; start_at=DVec(BoseFS(1,3)=>1.0))
+        start_at = [DVec(BoseFS(1, 3) => 1.0im)]
+        p = ProjectorMonteCarloProblem(h; start_at)
+        sm = init(p)
+        @test only(state_vectors(sm)) == start_at[1]
     end
 end
 


### PR DESCRIPTION
This fixes a typo I made in `ProjectorMonteCarloProblem`, where the starting vectors are checked to see if they will work with a complex Hamiltonian.