### PR TITLE
Bugfix: momentum_cutoff in FrohlichPolaron

### DIFF
--- a/src/Hamiltonians/FroehlichPolaron.jl
+++ b/src/Hamiltonians/FroehlichPolaron.jl
@@ -85,7 +85,7 @@ function FroehlichPolaron(
     ks = SVector{M,typeof(v)}(kr)
 
     if !isnothing(momentum_cutoff)
-        momentum_cutoff = typeof(v)(momentum_cutoff)ß
+        momentum_cutoff = typeof(v)(momentum_cutoff)
         momentum = dot(ks,onr(addr))
         if abs(momentum) > momentum_cutoff
             throw(ArgumentError("Starting address has momentum $momentum which cannot exceed momentum_cutoff $momentum_cutoff"))

--- a/src/Hamiltonians/FroehlichPolaron.jl
+++ b/src/Hamiltonians/FroehlichPolaron.jl
@@ -82,10 +82,10 @@ function FroehlichPolaron(
         start = -π + step
     end
     kr = (M/l)*range(start; step = step, length = M)
-    ks = SVector{M}(kr)
+    ks = SVector{M,typeof(v)}(kr)
 
     if !isnothing(momentum_cutoff)
-        momentum_cutoff = typeof(v)(momentum_cutoff)
+        momentum_cutoff = typeof(v)(momentum_cutoff)ß
         momentum = dot(ks,onr(addr))
         if abs(momentum) > momentum_cutoff
             throw(ArgumentError("Starting address has momentum $momentum which cannot exceed momentum_cutoff $momentum_cutoff"))

--- a/src/Hamiltonians/FroehlichPolaron.jl
+++ b/src/Hamiltonians/FroehlichPolaron.jl
@@ -87,7 +87,7 @@ function FroehlichPolaron(
     if !isnothing(momentum_cutoff)
         momentum_cutoff = typeof(v)(momentum_cutoff)
         momentum = dot(ks,onr(addr))
-        if momentum > momentum_cutoff
+        if abs(momentum) > momentum_cutoff
             throw(ArgumentError("Starting address has momentum $momentum which cannot exceed momentum_cutoff $momentum_cutoff"))
         end
     end
@@ -137,7 +137,7 @@ function get_offdiagonal(h::FroehlichPolaron{T,M,<:Any,T}, addr::OccupationNumbe
     naddress, value = _froehlich_offdiag(h, addr, chosen)
 
     new_p_tot = dot(h.ks, onr(naddress))
-    if (M/h.l) * new_p_tot > h.momentum_cutoff # check if momentum of new address exceeds momentum_cutoff
+    if abs(new_p_tot) > h.momentum_cutoff # check if momentum of new address exceeds momentum_cutoff
         return addr, 0.0
     else
         return naddress, - h.v * value

--- a/src/Hamiltonians/FroehlichPolaron.jl
+++ b/src/Hamiltonians/FroehlichPolaron.jl
@@ -140,7 +140,7 @@ function get_offdiagonal(h::FroehlichPolaron{T,M,<:Any,T}, addr::OccupationNumbe
     if abs(new_p_tot) > h.momentum_cutoff # check if momentum of new address exceeds momentum_cutoff
         return addr, 0.0
     else
-        return naddress, - h.v * value
+        return naddress, value
     end
 end
 

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -1116,6 +1116,7 @@ end
     addr2 = OccupationNumberFS(1,2,3)
     @test_throws ArgumentError FroehlichPolaron(addr2; mode_cutoff=1.0)
     @test_throws ArgumentError FroehlichPolaron(addr2; momentum_cutoff=10.0)
+    @test_throws ArgumentError FroehlichPolaron(OccupationNumberFS(3,2,1); momentum_cutoff=10.0)
 
     addr3 = OccupationNumberFS(1,2,3,4)
     f2 = FroehlichPolaron(addr2)
@@ -1154,6 +1155,16 @@ end
     addr4 = OccupationNumberFS(1,2,1)
     f4 = FroehlichPolaron(addr4; momentum_cutoff=10.0)
     @test get_offdiagonal(f4, addr2, 3)[2] == 0.0
+
+    m = 5; l = 6
+    addr5 = OccupationNumberFS{5}()
+    mom_unit = 2π/l
+    momentum_cutoff = 1.5 * mom_unit
+    f5 = FroehlichPolaron(addr5; l, mode_cutoff=1, momentum_cutoff)
+    basis5 = build_basis(f5)
+    mom_vec = map(o -> dot(o, f5.ks), onr.(basis5))
+    @test all(abs.(mom_vec) .≤ momentum_cutoff) == true
+    @test length(basis5) == 20
 end
 
 """

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -1165,6 +1165,11 @@ end
     mom_vec = map(o -> dot(o, f5.ks), onr.(basis5))
     @test all(abs.(mom_vec) .≤ momentum_cutoff) == true
     @test length(basis5) == 20
+
+    # with and without momentum cutoff
+    f6 = FroehlichPolaron(addr5; v=10, mode_cutoff=1)
+    f7 = FroehlichPolaron(addr5; v=10, mode_cutoff=1, momentum_cutoff=100)
+    @test get_offdiagonal(f6, addr5, 1) == get_offdiagonal(f7, addr5, 1)
 end
 
 """


### PR DESCRIPTION
## Bug fixes
- In `FroehlichPolaron` the keyword argument `momentum_cutoff` was not applied to negative momentum values and calculated incorrectly for off-diagonal matrix elements; also the off diagonal matrix elements were incorrect only when the momentum_cutoff was used. 