### PR TITLE
Fix interface tests

### DIFF
--- a/src/InterfaceTests.jl
+++ b/src/InterfaceTests.jl
@@ -136,6 +136,8 @@ function test_operator_interface(op, addr; test_iterable_offdiagonals=true, test
             if test_iterable_offdiagonals
                 @testset "offdiagonals" begin
                     offdiags = offdiagonals(column)
+                    @test num_offdiagonals(column) isa Union{Int,BigInt}
+                    @test num_offdiagonals(column) >= length(collect(offdiags))
                     if num_offdiagonals(column) > 0
                         @test iterate(offdiags)[1] isa Union{Tuple{typeof(addr),eltype(op)},Pair{typeof(addr),eltype(op)}}
                     end

--- a/src/InterfaceTests.jl
+++ b/src/InterfaceTests.jl
@@ -92,7 +92,6 @@ to be defined. If `test_iterable_offdiagonals` is `true`, tests are performed th
 
 - `diagonal_element(column)` returns a value of the same type as the `eltype` of the operator
 - `offdiagonals` iterates `address => value` pairs of consistent type (only if `test_iterable_offdiagonals==true`)
-- `num_offdiagonals` returns the correct number of offdiagonals
 - `random_offdiagonal` returns a tuple with the correct types (only if `test_random_offdiagonal==true`)
 - `mul!` and `dot` work as expected
 - `dimension` returns a consistent value
@@ -137,9 +136,6 @@ function test_operator_interface(op, addr; test_iterable_offdiagonals=true, test
             if test_iterable_offdiagonals
                 @testset "offdiagonals" begin
                     offdiags = offdiagonals(column)
-                    if hasmethod(num_offdiagonals, (typeof(op), typeof(addr)))
-                        @test num_offdiagonals(column) == num_offdiagonals(op, addr)
-                    end
                     if num_offdiagonals(column) > 0
                         @test iterate(offdiags)[1] isa Union{Tuple{typeof(addr),eltype(op)},Pair{typeof(addr),eltype(op)}}
                     end

--- a/src/Interfaces/hamiltonians.jl
+++ b/src/Interfaces/hamiltonians.jl
@@ -103,7 +103,7 @@ Alternatively, if the generation of matrix elements is more complicated:
 - [`allows_address_type(op, type)`](@ref)
 - [`operator_column(op, address)`](@ref)
 - [`diagonal_element(column)`](@ref)
-- [`num_offdiagonals(column)`](@ref) (this can be an estimate)
+- [`num_offdiagonals(column)`](@ref) (this can be an upper bound)
 - [`offdiagonals(column)`](@ref)
 - [`random_offdiagonal(column)`](@ref)
 
@@ -180,7 +180,7 @@ Alternatively, if the generation of matrix elements is more complicated:
 * [`starting_address(::AbstractHamiltonian)`](@ref)
 * [`operator_column(op, address)`](@ref)
 * [`diagonal_element(column)`](@ref)
-* [`num_offdiagonals(column)`](@ref) (this can be an estimate)
+* [`num_offdiagonals(column)`](@ref) (this can be an upper bound)
 * [`offdiagonals(column)`](@ref)
 * [`random_offdiagonal(column)`](@ref)
 
@@ -263,7 +263,7 @@ diagonal_element(m::AbstractMatrix, i) = m[i, i]
     num_offdiagonals(ham, address) # (deprecated)
 
 Compute the number of number of reachable configurations from address `address`,
-where `column = operator_column(ham, address)`. If necessary, this may be an estimate.
+where `column = operator_column(ham, address)`. If necessary, this may be an upper bound.
 
 # Example
 
@@ -456,7 +456,7 @@ A `column` can be accessed with the following functions:
 * [`starting_address(column)`](@ref) - returns `address`,
 * [`diagonal_element(column)`](@ref) - returns the diagonal element ``⟨α|Ĥ|α⟩`` of `address`
   in `operator`,
-* [`num_offdiagonals(column)`](@ref) - returns an estimate of the number of
+* [`num_offdiagonals(column)`](@ref) - returns an upper bound on the number of
   off-diagonal elements in the `column`,
 * [`offdiagonals(column)`](@ref) - returns an object representing the off-diagonal
   elements of the `column`,


### PR DESCRIPTION
The interface tests were incorrect for new `AbstractOperatorColumn`s, since `num_offdiagonals(op, address)` has a method to check `LOStructure(op)`.