### PR TITLE
Feature/saner dynamicsemistochastic parameters

### DIFF
--- a/src/StochasticStyles/spawning.jl
+++ b/src/StochasticStyles/spawning.jl
@@ -364,9 +364,8 @@ end
 @inline function spawn!(s::DynamicSemistochastic, w, offdiags::AbstractVector, add, val, boost)
     # assumes that s.strat.threshold is defined
     # special-case substrategies that don't fit the pattern?
-    thresh = min(s.abs_threshold, length(offdiags))
-    amount = boost * abs(val) * s.rel_threshold
-    if amount ≥ thresh
+    amount = boost * abs(val)
+    if amount ≥ length(offdiags) * s.rel_threshold || amount > s.abs_threshold
         # Exact multiplication.
         attempts, spawns = spawn!(Exact(s.strat.threshold), w, offdiags, add, val)
         return (1, 0, attempts, spawns)

--- a/src/StochasticStyles/spawning.jl
+++ b/src/StochasticStyles/spawning.jl
@@ -370,7 +370,7 @@ end
     # assumes that s.strat.threshold is defined
     # special-case substrategies that don't fit the pattern?
     amount = boost * abs(val)
-    if amount ≥ length(offdiags) * s.rel_threshold || amount > s.abs_threshold
+    if amount ≥ num_offdiagonals(column) * s.rel_threshold || amount > s.abs_threshold
         # Exact multiplication.
         attempts, spawns = spawn!(Exact(s.strat.threshold), w, column, val)
         return (1, 0, attempts, spawns)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,7 +19,9 @@ using ExplicitImports: check_no_implicit_imports
     using ExplicitImports
     # Check that no implicit imports are used in the Rimu module.
     # See https://ericphanson.github.io/ExplicitImports.jl/stable/
-    @test check_no_implicit_imports(Rimu; skip=(Rimu, Base, Core, VectorInterface)) === nothing
+    @test check_no_implicit_imports(
+        Rimu; skip=(Rimu, Base, Core, LinearAlgebra, VectorInterface)
+    ) === nothing
     # If this test fails, make your import statements explicit.
     # For example, replace `using Foo` with `using Foo: bar, baz`.
 end


### PR DESCRIPTION
* Changes the dynamic semistochastic relative threshold condition from `amount * t_rel > num_offdiagonals` to `amount > num_offdiagonals * t_rel`. This makes smaller thresholds produce more exact steps. I find this makes sense as smaller thresholds take the algorithm closer to deterministic FCIQMC.
* Makes the inequality with absolute thresholds strict. Then when setting `abs_threshold` to 1, any walker number strictly larger than 1 will cause an exact spawn.
