### PR TITLE
Fix type instability in exact spawning

### DIFF
--- a/src/BitStringAddresses/BitStringAddresses.jl
+++ b/src/BitStringAddresses/BitStringAddresses.jl
@@ -4,7 +4,7 @@ Module with types and methods pertaining to bitstring addresses.
 ```
 module BitStringAddresses
 
-using LinearAlgebra: LinearAlgebra, I, dot
+using LinearAlgebra: LinearAlgebra, I, dot, ⋅
 using Parameters: Parameters, @unpack
 using Setfield: Setfield, @set, @set!, setindex
 using SparseArrays: SparseArrays, SparseVector, nonzeros, rowvals, spzeros

--- a/src/ExactDiagonalization/ExactDiagonalization.jl
+++ b/src/ExactDiagonalization/ExactDiagonalization.jl
@@ -19,7 +19,7 @@ provided by external packages.
 """
 module ExactDiagonalization
 
-using LinearAlgebra: LinearAlgebra, eigen!, issymmetric, ishermitian, Matrix, dot
+using LinearAlgebra: LinearAlgebra, eigen!, issymmetric, ishermitian, Matrix, dot, ⋅
 using LinearMaps: LinearMaps, LinearMap
 using SparseArrays: SparseArrays, nnz, nzrange, sparse
 using CommonSolve: CommonSolve, solve, init

--- a/src/Rimu.jl
+++ b/src/Rimu.jl
@@ -3,7 +3,7 @@ module Rimu
 using Arrow: Arrow
 using DataFrames: DataFrames, DataFrame, metadata
 using DataStructures: DataStructures
-using LinearAlgebra: LinearAlgebra, dot, isdiag, eigvecs, norm
+using LinearAlgebra: LinearAlgebra, dot, isdiag, eigvecs, norm, ⋅
 using OrderedCollections: OrderedCollections, LittleDict, freeze
 using Parameters: Parameters, @pack!, @unpack, @with_kw
 using ProgressLogging: ProgressLogging, @logprogress, @withprogress

--- a/src/StochasticStyles/spawning.jl
+++ b/src/StochasticStyles/spawning.jl
@@ -167,9 +167,10 @@ See [`SpawningStrategy`](@ref).
 @inline function spawn!(s::Exact, w, column, val, boost=1)
     T = valtype(w)
     attempts = 0
-    spawns = sum(offdiagonals(column); init=real(zero(T))) do (new_add, mat_elem)
+    spawns = real(zero(T))
+    for (new_add, mat_elem) in offdiagonals(column)
         attempts += 1
-        abs(projected_deposit!(
+        spawns += abs(projected_deposit!(
             w, new_add, val * mat_elem, starting_address(column) => val, s.threshold
         ))
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,7 +19,9 @@ using ExplicitImports: check_no_implicit_imports
     using ExplicitImports
     # Check that no implicit imports are used in the Rimu module.
     # See https://ericphanson.github.io/ExplicitImports.jl/stable/
-    @test check_no_implicit_imports(Rimu; skip=(Rimu, Base, Core, VectorInterface)) === nothing
+    @test check_no_implicit_imports(
+        Rimu; skip=(Rimu, Base, Core, VectorInterface), ignore=(:/,)
+    ) === nothing
     # If this test fails, make your import statements explicit.
     # For example, replace `using Foo` with `using Foo: bar, baz`.
 end


### PR DESCRIPTION
Fix type instability coming from editing a local variable from an anonymous function.