### PR TITLE
Operator traits for iterable offdiagonals and random offdiagonal

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Rimu"
 uuid = "c53c40cc-bd84-11e9-2cf4-a9fde2b9386e"
 authors = ["Joachim Brand <j.brand@massey.ac.nz>"]
-version = "0.14.1"
+version = "0.14.2"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -43,7 +43,7 @@ for fn in EXAMPLES_FILES
 end
 
 makedocs(;
-    modules=[Rimu,Rimu.RimuIO,Rimu.InterfaceTests],
+    modules=[Rimu,Rimu.RimuIO,Rimu.InterfaceTests,Rimu.BitStringAddresses],
     format=Documenter.HTML(
         prettyurls = false,
         size_threshold=700_000, # 700 kB

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -43,7 +43,9 @@ for fn in EXAMPLES_FILES
 end
 
 makedocs(;
-    modules=[Rimu,Rimu.RimuIO,Rimu.InterfaceTests,Rimu.BitStringAddresses],
+    modules=[
+        Rimu, Rimu.RimuIO, Rimu.InterfaceTests, Rimu.BitStringAddresses, Rimu.Interfaces
+    ],
     format=Documenter.HTML(
         prettyurls = false,
         size_threshold=700_000, # 700 kB

--- a/docs/src/addresses.md
+++ b/docs/src/addresses.md
@@ -24,6 +24,9 @@ straightforward to implement efficient Hamiltonians. Examples are:
 
 ```@docs
 Rimu.Interfaces.AbstractFockAddress
+Rimu.Interfaces.num_particles
+Rimu.Interfaces.num_modes
+Rimu.Interfaces.num_components
 ```
 
 ```@autodocs

--- a/docs/src/addresses.md
+++ b/docs/src/addresses.md
@@ -28,7 +28,7 @@ Rimu.Interfaces.AbstractFockAddress
 
 ```@autodocs
 Modules = [BitStringAddresses]
-Pages = ["fockaddress.jl","bosefs.jl","fermifs.jl","multicomponent.jl","occupationnumberfs.jl"]
+Pages = ["BitStringAddresses.jl","fockaddress.jl","bosefs.jl","fermifs.jl","multicomponent.jl","occupationnumberfs.jl"]
 Private = false
 ```
 

--- a/docs/src/addresses.md
+++ b/docs/src/addresses.md
@@ -22,6 +22,10 @@ straightforward to implement efficient Hamiltonians. Examples are:
 
 ### Fock address API
 
+```@docs
+Rimu.Interfaces.AbstractFockAddress
+```
+
 ```@autodocs
 Modules = [BitStringAddresses]
 Pages = ["fockaddress.jl","bosefs.jl","fermifs.jl","multicomponent.jl","occupationnumberfs.jl"]

--- a/docs/src/custom_hamiltonians.md
+++ b/docs/src/custom_hamiltonians.md
@@ -33,6 +33,7 @@ AbstractHamiltonian
 starting_address
 operator_column
 AbstractOperatorColumn
+column_operator
 diagonal_element
 offdiagonals
 random_offdiagonal

--- a/docs/src/custom_hamiltonians.md
+++ b/docs/src/custom_hamiltonians.md
@@ -34,18 +34,20 @@ starting_address
 operator_column
 AbstractOperatorColumn
 diagonal_element
-num_offdiagonals
 offdiagonals
+random_offdiagonal
+num_offdiagonals
 get_offdiagonal
 ```
 
 The following functions come with default implementations, but may be customized.
 
 ```@docs
-random_offdiagonal
 Hamiltonians.LOStructure
 dimension
 has_adjoint
+has_iterable_offdiagonals
+has_random_offdiagonal
 allows_address_type
 Base.eltype
 VectorInterface.scalartype

--- a/docs/src/custom_hamiltonians.md
+++ b/docs/src/custom_hamiltonians.md
@@ -33,7 +33,7 @@ AbstractHamiltonian
 starting_address
 operator_column
 AbstractOperatorColumn
-column_operator
+parent_operator
 diagonal_element
 offdiagonals
 random_offdiagonal

--- a/src/BitStringAddresses/BitStringAddresses.jl
+++ b/src/BitStringAddresses/BitStringAddresses.jl
@@ -12,14 +12,14 @@ using StaticArrays: StaticArrays, @MVector, FieldVector, MVector, SA, SVector
 
 using Base.Cartesian
 
-using ..Interfaces: AbstractFockAddress
+using ..Interfaces: Interfaces, AbstractFockAddress, num_particles, num_modes,
+    num_components
 
 export SingleComponentFockAddress, BoseFS, FermiFS
 export CompositeFS, FermiFS2C, time_reverse
 export OccupationNumberFS
 export BoseFSIndex, FermiFSIndex
 export BitString, SortedParticleList
-export num_particles, num_modes, num_components
 export find_occupied_mode, find_mode, occupied_modes, is_occupied, num_occupied_modes
 export excitation, near_uniform, OccupiedModeMap, OccupiedPairsMap
 export onr, occupation_number_representation

--- a/src/BitStringAddresses/BitStringAddresses.jl
+++ b/src/BitStringAddresses/BitStringAddresses.jl
@@ -12,7 +12,9 @@ using StaticArrays: StaticArrays, @MVector, FieldVector, MVector, SA, SVector
 
 using Base.Cartesian
 
-export AbstractFockAddress, SingleComponentFockAddress, BoseFS, FermiFS
+using ..Interfaces: AbstractFockAddress
+
+export SingleComponentFockAddress, BoseFS, FermiFS
 export CompositeFS, FermiFS2C, time_reverse
 export OccupationNumberFS
 export BoseFSIndex, FermiFSIndex

--- a/src/BitStringAddresses/BitStringAddresses.jl
+++ b/src/BitStringAddresses/BitStringAddresses.jl
@@ -1,7 +1,7 @@
-```
+"""
     BitStringAddresses
 Module with types and methods pertaining to bitstring addresses.
-```
+"""
 module BitStringAddresses
 
 using LinearAlgebra: LinearAlgebra, I, dot, ⋅

--- a/src/BitStringAddresses/BitStringAddresses.jl
+++ b/src/BitStringAddresses/BitStringAddresses.jl
@@ -12,7 +12,7 @@ using StaticArrays: StaticArrays, @MVector, FieldVector, MVector, SA, SVector
 
 using Base.Cartesian
 
-export AbstractFockAddress, SingleComponentFockAddress, BoseFS, BoseFS2C, FermiFS
+export AbstractFockAddress, SingleComponentFockAddress, BoseFS, FermiFS
 export CompositeFS, FermiFS2C, time_reverse
 export OccupationNumberFS
 export BoseFSIndex, FermiFSIndex

--- a/src/BitStringAddresses/fockaddress.jl
+++ b/src/BitStringAddresses/fockaddress.jl
@@ -1,30 +1,5 @@
-# AbstractFockAddress is defined in Interfaces.jl, so we can use it here.
-
-"""
-    num_particles(::Type{<:AbstractFockAddress})
-    num_particles(::AbstractFockAddress)
-
-Number of particles represented by address.
-"""
-num_particles(a::AbstractFockAddress) = num_particles(typeof(a))
-num_particles(::Type{<:AbstractFockAddress{N}}) where {N} = N
-
-"""
-    num_modes(::Type{<:AbstractFockAddress})
-    num_modes(::AbstractFockAddress)
-
-Number of modes represented by address.
-"""
-num_modes(a::AbstractFockAddress) = num_modes(typeof(a))
-num_modes(::Type{<:AbstractFockAddress{<:Any,M}}) where {M} = M
-
-"""
-    num_components(::Type{<:AbstractFockAddress})
-    num_components(::AbstractFockAddress)
-
-Number of components in address.
-"""
-num_components(b::AbstractFockAddress) = num_components(typeof(b))
+# AbstractFockAddress is defined in Interfaces/abstractfockaddress.jl, so we can use it here.
+# So are num_particles, num_modes, num_components.
 
 """
     SingleComponentFockAddress{N,M} <: AbstractFockAddress{N,M}
@@ -47,7 +22,7 @@ See also [`CompositeFS`](@ref), [`AbstractFockAddress`](@ref).
 """
 abstract type SingleComponentFockAddress{N,M} <: AbstractFockAddress{N,M} end
 
-num_components(::Type{<:SingleComponentFockAddress}) = 1
+Interfaces.num_components(::Type{<:SingleComponentFockAddress}) = 1
 
 """
     occupation_number_representation(fs::SingleComponentFockAddress)

--- a/src/BitStringAddresses/fockaddress.jl
+++ b/src/BitStringAddresses/fockaddress.jl
@@ -1,15 +1,4 @@
-"""
-    AbstractFockAddress{N,M}
-
-Abstract type representing a Fock state with `N` particles and `M` modes.
-
-See also [`SingleComponentFockAddress`](@ref), [`CompositeFS`](@ref), [`BoseFS`](@ref),
-[`FermiFS`](@ref).
-"""
-abstract type AbstractFockAddress{N,M} end
-
-# `AbstractFockAddress`es can be reconstructed from their printout.
-Base.typeinfo_implicit(::Type{<:AbstractFockAddress}) = true
+# AbstractFockAddress is defined in Interfaces.jl, so we can use it here.
 
 """
     num_particles(::Type{<:AbstractFockAddress})

--- a/src/BitStringAddresses/multicomponent.jl
+++ b/src/BitStringAddresses/multicomponent.jl
@@ -28,7 +28,7 @@ function CompositeFS(adds::Vararg{SingleComponentFockAddress})
     return CompositeFS{length(adds),N,M1,typeof(adds)}(adds)
 end
 
-num_components(::Type{<:CompositeFS{C}}) where {C} = C
+Interfaces.num_components(::Type{<:CompositeFS{C}}) where {C} = C
 Base.hash(c::CompositeFS, u::UInt) = hash(c.components, u)
 
 function print_address(io::IO, c::CompositeFS{C}; compact=false) where {C}

--- a/src/BitStringAddresses/occupationnumberfs.jl
+++ b/src/BitStringAddresses/occupationnumberfs.jl
@@ -123,7 +123,7 @@ end
 Base.:(==)(a::OccupationNumberFS, b::OccupationNumberFS) = a.onr == b.onr
 Base.hash(ofs::OccupationNumberFS, h::UInt) = hash(ofs.onr, h)
 
-num_particles(ofs::OccupationNumberFS) = sum(Int, onr(ofs))
+Interfaces.num_particles(ofs::OccupationNumberFS) = sum(Int, onr(ofs))
 # `num_modes` does not have to be defined here, because it is defined for the abstract type
 
 """

--- a/src/BitStringAddresses/sortedparticlelist.jl
+++ b/src/BitStringAddresses/sortedparticlelist.jl
@@ -80,8 +80,8 @@ function Base.isless(ss1::SortedParticleList, ss2::SortedParticleList)
     return isless(ss1.storage, ss2.storage)
 end
 
-num_particles(::Type{<:SortedParticleList{N}}) where {N} = N
-num_modes(::Type{<:SortedParticleList{<:Any,M}}) where {M} = M
+Interfaces.num_particles(::Type{<:SortedParticleList{N}}) where {N} = N
+Interfaces.num_modes(::Type{<:SortedParticleList{<:Any,M}}) where {M} = M
 
 ###
 ### General functions

--- a/src/DictVectors/abstractdvec.jl
+++ b/src/DictVectors/abstractdvec.jl
@@ -5,7 +5,11 @@
 function Base.show(io::IO, dvec::AbstractDVec)
     summary(io, dvec)
     limit, _ = displaysize()
-    for (i, p) in enumerate(pairs(localpart(dvec)))
+    # sort if length(dvec) is small to make doctests reproducible
+    pldvec = length(dvec) < 20 ? sort!(collect(pairs(localpart(dvec)))) :
+        pairs(localpart(dvec))
+
+    for (i, p) in enumerate(pldvec)
         if length(dvec) > i > limit - 4
             print(io, "\n  ⋮   => ⋮")
             break

--- a/src/DictVectors/abstractdvec.jl
+++ b/src/DictVectors/abstractdvec.jl
@@ -316,8 +316,8 @@ end
 function Interfaces.dot_from_right(target, op, source::AbstractDVec)
     T = typeof(zero(valtype(target)) * zero(valtype(source)) * zero(eltype(op)))
 
-    result = sum(pairs(source); init=zero(T)) do (k, v)
-        dot(target, op * k) * v
+    result = sum(pairs(source); init=zero(T)) do (address, value)
+        dot(target, operator_column(op, address)) * value
     end
     return result::T
 end

--- a/src/DictVectors/abstractdvec.jl
+++ b/src/DictVectors/abstractdvec.jl
@@ -317,12 +317,7 @@ function Interfaces.dot_from_right(target, op, source::AbstractDVec)
     T = typeof(zero(valtype(target)) * zero(valtype(source)) * zero(eltype(op)))
 
     result = sum(pairs(source); init=zero(T)) do (k, v)
-        column = operator_column(op, k)
-        res = conj(target[k]) * diagonal_element(column) * v
-        for (k_off, v_off) in offdiagonals(column)
-            res += conj(target[k_off]) * v_off * v
-        end
-        res
+        dot(target, op * k) * v
     end
     return result::T
 end

--- a/src/ExactDiagonalization/basis_set_representation.jl
+++ b/src/ExactDiagonalization/basis_set_representation.jl
@@ -68,9 +68,9 @@ julia> ev = eigvecs(Matrix(bsr))[:,1]; ev = ev .* sign(ev[1]) # ground state eig
 
 julia> dv = DVec(zip(bsr.basis, ev)) # ground state as DVec
 DVec{BoseFS{1, 3, BitString{3, 1, UInt8}},Float64} with 3 entries, style = IsDeterministic{Float64}()
-  fs"|0 0 1⟩" => 0.57735
-  fs"|0 1 0⟩" => 0.57735
   fs"|1 0 0⟩" => 0.57735
+  fs"|0 1 0⟩" => 0.57735
+  fs"|0 0 1⟩" => 0.57735
 ```
 Has methods for [`dimension`](@ref), [`sparse`](@ref), [`Matrix`](@ref),
 [`starting_address`](@ref).

--- a/src/Hamiltonians/HOCartesianContactInteractions.jl
+++ b/src/Hamiltonians/HOCartesianContactInteractions.jl
@@ -245,7 +245,7 @@ function starting_address(h::HOCartesianContactInteractions)
 end
 
 LOStructure(::Type{<:HOCartesianContactInteractions}) = IsHermitian()
-RandomOffdiagonalTrait(::Type{<:HOCartesianContactInteractions}) = NoRandomOffdiagonal()
+has_random_offdiagonal(::Type{<:HOCartesianContactInteractions}) = false
 
 ### DIAGONAL ELEMENTS ###
 function energy_transfer_diagonal(h::HOCartesianContactInteractions{D}, omm::BoseOccupiedModeMap) where {D}

--- a/src/Hamiltonians/HOCartesianContactInteractions.jl
+++ b/src/Hamiltonians/HOCartesianContactInteractions.jl
@@ -245,7 +245,7 @@ function starting_address(h::HOCartesianContactInteractions)
 end
 
 LOStructure(::Type{<:HOCartesianContactInteractions}) = IsHermitian()
-
+RandomOffdiagonalTrait(::Type{<:HOCartesianContactInteractions}) = NoRandomOffdiagonal()
 
 ### DIAGONAL ELEMENTS ###
 function energy_transfer_diagonal(h::HOCartesianContactInteractions{D}, omm::BoseOccupiedModeMap) where {D}

--- a/src/Hamiltonians/Hamiltonians.jl
+++ b/src/Hamiltonians/Hamiltonians.jl
@@ -66,7 +66,7 @@ using ..Interfaces
 using ..Interfaces: sum_mutating!
 import ..Interfaces: diagonal_element, num_offdiagonals, get_offdiagonal, starting_address,
     offdiagonals, random_offdiagonal, LOStructure, allows_address_type, operator_column,
-    RandomOffdiagonalTrait, IterableOffdiagonalsTrait
+    has_random_offdiagonal, has_iterable_offdiagonals
 
 export dimension, rayleigh_quotient, momentum
 

--- a/src/Hamiltonians/Hamiltonians.jl
+++ b/src/Hamiltonians/Hamiltonians.jl
@@ -65,7 +65,8 @@ using ..BitStringAddresses
 using ..Interfaces
 using ..Interfaces: sum_mutating!
 import ..Interfaces: diagonal_element, num_offdiagonals, get_offdiagonal, starting_address,
-    offdiagonals, random_offdiagonal, LOStructure, allows_address_type, operator_column
+    offdiagonals, random_offdiagonal, LOStructure, allows_address_type, operator_column,
+    RandomOffdiagonalTrait, IterableOffdiagonalsTrait
 
 export dimension, rayleigh_quotient, momentum
 

--- a/src/Hamiltonians/Hamiltonians.jl
+++ b/src/Hamiltonians/Hamiltonians.jl
@@ -66,7 +66,7 @@ using ..Interfaces
 using ..Interfaces: sum_mutating!
 import ..Interfaces: diagonal_element, num_offdiagonals, get_offdiagonal, starting_address,
     offdiagonals, random_offdiagonal, LOStructure, allows_address_type, operator_column,
-    has_random_offdiagonal, has_iterable_offdiagonals, column_operator
+    has_random_offdiagonal, has_iterable_offdiagonals, parent_operator
 
 export dimension, rayleigh_quotient, momentum
 

--- a/src/Hamiltonians/Hamiltonians.jl
+++ b/src/Hamiltonians/Hamiltonians.jl
@@ -66,7 +66,7 @@ using ..Interfaces
 using ..Interfaces: sum_mutating!
 import ..Interfaces: diagonal_element, num_offdiagonals, get_offdiagonal, starting_address,
     offdiagonals, random_offdiagonal, LOStructure, allows_address_type, operator_column,
-    has_random_offdiagonal, has_iterable_offdiagonals
+    has_random_offdiagonal, has_iterable_offdiagonals, column_operator
 
 export dimension, rayleigh_quotient, momentum
 

--- a/src/Hamiltonians/MatrixHamiltonian.jl
+++ b/src/Hamiltonians/MatrixHamiltonian.jl
@@ -1,7 +1,7 @@
 """
     MatrixHamiltonian(
         mat::AbstractMatrix{T};
-        starting_address::Int = starting_address(mat)
+        starting_address::Int = findmin(real.(diag(mat)))[2]
     ) <: AbstractHamiltonian{T}
 Wrap an abstract matrix `mat` as an [`AbstractHamiltonian`](@ref) object.
 Works with stochastic methods of [`ProjectorMonteCarloProblem()`](@ref) and [`DVec`](@ref).
@@ -17,7 +17,7 @@ end
 
 function MatrixHamiltonian(
     m::AM;
-    starting_address=starting_address(m)
+    starting_address = findmin(real.(diag(m)))[2]
 ) where AM <:AbstractMatrix
     Base.require_one_based_indexing(m)
     s = size(m)

--- a/src/Hamiltonians/reduced_density_matrix.jl
+++ b/src/Hamiltonians/reduced_density_matrix.jl
@@ -168,8 +168,8 @@ ReducedDensityMatrix{Float32}(2)
 
 julia> dvec_f = PDVec(FermiFS(1,1,0,0) => 0.5, FermiFS(0,1,1,0) => 0.5)
 2-element PDVec: style = IsDeterministic{Float64}()
-  fs"|⋅↑↑⋅⟩" => 0.5
   fs"|↑↑⋅⋅⟩" => 0.5
+  fs"|⋅↑↑⋅⟩" => 0.5
 
 julia> dot(dvec_f, Op2, dvec_f)
 6×6 Hermitian{Float32, Matrix{Float32}}:

--- a/src/InterfaceTests.jl
+++ b/src/InterfaceTests.jl
@@ -15,8 +15,8 @@ using Test: Test, @test, @testset, @test_throws
 using Rimu: Rimu, DVec, Interfaces, LOStructure, IsHermitian, IsDiagonal, AdjointKnown,
     Hamiltonians, num_offdiagonals, allows_address_type, offdiagonals, random_offdiagonal,
     diagonal_element, dimension, dot_from_right, IsDeterministic, starting_address, PDVec,
-    sparse, scale!, scalartype, operator_column, AbstractOperatorColumn
-using Rimu.Interfaces: has_random_offdiagonal, has_iterable_offdiagonals
+    sparse, scale!, scalartype, operator_column, AbstractOperatorColumn,
+    has_random_offdiagonal, has_iterable_offdiagonals, column_operator
 using Rimu.Hamiltonians: AbstractHamiltonian, AbstractOperator, AbstractObservable,
     AbstractOffdiagonals
 using LinearAlgebra: dot, mul!, isdiag, ishermitian
@@ -137,8 +137,9 @@ function test_operator_interface(op, addr;
         column = operator_column(op, addr)
         @test column isa AbstractOperatorColumn
         @testset "Operator interface: $(nameof(typeof(op)))" begin
-            @testset "starting_address(column)" begin
+            @testset "starting_address(column) and column_operator" begin
                 @test starting_address(column) == addr
+                @test column_operator(column) == op
             end
             @testset "diagonal_element" begin
                 @test diagonal_element(column) isa eltype(op)

--- a/src/InterfaceTests.jl
+++ b/src/InterfaceTests.jl
@@ -16,6 +16,8 @@ using Rimu: Rimu, DVec, Interfaces, LOStructure, IsHermitian, IsDiagonal, Adjoin
     Hamiltonians, num_offdiagonals, allows_address_type, offdiagonals, random_offdiagonal,
     diagonal_element, dimension, dot_from_right, IsDeterministic, starting_address, PDVec,
     sparse, scale!, scalartype, operator_column, AbstractOperatorColumn
+using Rimu.Interfaces: IterableOffdiagonalsTrait, HasIterableOffdiagonals,
+    RandomOffdiagonalTrait, HasRandomOffdiagonal
 using Rimu.Hamiltonians: AbstractHamiltonian, AbstractOperator, AbstractObservable,
     AbstractOffdiagonals
 using LinearAlgebra: dot, mul!, isdiag, ishermitian
@@ -76,12 +78,23 @@ function test_observable_interface(obs, addr)
 end
 
 """
-    test_operator_interface(op, addr; test_iterable_offdiagonals=true, test_random_offdiagonal=true)
+    test_operator_interface(op, addr; kwargs...)
 
 This function tests compliance with the [`AbstractOperator`](@ref) interface for an operator
 `op` at address `addr` (typically
 [`<: AbstractFockAddress`](@ref Rimu.BitStringAddresses.AbstractFockAddress)) by
 checking that all required methods are defined.
+
+## Keyword arguments
+- `test_iterable_offdiagonals::Bool`: If `true`, tests that the `offdiagonals(column)` is
+    iterable.
+- `test_random_offdiagonal::Bool`: If `true`, tests that the `random_offdiagonal(column)` is
+    defined.
+
+By default the keyword arguments are set according the [`IterableOffdiagonalsTrait`](@ref)
+and [`RandomOffdiagonalTrait`](@ref) of the operator type. If the operator does not
+support iterable offdiagonals or random offdiagonals, the tests that require these
+features are skipped.
 
 The following properties are tested:
 - `operator_column(op, addr)` returns a `column` object that is subtype to [`AbstractOperatorColumn`](@ref)
@@ -113,7 +126,10 @@ Operator interface: SuperfluidCorrelator |    9      9  0.0s
 See also [`AbstractOperator`](@ref), [`test_observable_interface`](@ref),
 [`test_hamiltonian_interface`](@ref).
 """
-function test_operator_interface(op, addr; test_iterable_offdiagonals=true, test_random_offdiagonal=true)
+function test_operator_interface(op, addr;
+    test_iterable_offdiagonals = IterableOffdiagonalsTrait(typeof(op)) isa HasIterableOffdiagonals,
+    test_random_offdiagonal = RandomOffdiagonalTrait(typeof(op)) isa HasRandomOffdiagonal
+)
     test_observable_interface(op, addr)
     @testset "`AbstractOperator` interface test: $(nameof(typeof(op)))" begin
 
@@ -170,9 +186,17 @@ end
 The main purpose of this test function is to check that all required methods of the
 [`AbstractHamiltonian`](@ref) interface are defined and work as expected.
 
-Set `test_iterable_offdiagonals=false` to skip tests that require [`offdiagonals(column)`](@ref)
-to be iterable. Set `test_random_offdiagonal=false` to skip tests that require
-[`random_offdiagonal(column)`](@ref) to be defined.
+
+## Keyword arguments
+- `test_iterable_offdiagonals::Bool`: If `true`, tests that the `offdiagonals(column)` is
+    iterable.
+- `test_random_offdiagonal::Bool`: If `true`, tests that the `random_offdiagonal(column)` is
+    defined.
+
+By default the keyword arguments are set according the [`IterableOffdiagonalsTrait`](@ref)
+and [`RandomOffdiagonalTrait`](@ref) of the operator type. If the operator does not
+support iterable offdiagonals or random offdiagonals, the tests that require these
+features are skipped.
 
 This function also tests the following properties of the Hamiltonian:
 - `dimension(h) ≥ dimension(h, addr)`
@@ -202,7 +226,10 @@ Hamiltonians-only tests with HubbardRealSpace |    6      6  0.0s
 
 See also [`test_operator_interface`](@ref), [`test_observable_interface`](@ref).
 """
-function test_hamiltonian_interface(h, addr=starting_address(h); test_iterable_offdiagonals=true, test_random_offdiagonal=true)
+function test_hamiltonian_interface(h, addr=starting_address(h);
+    test_iterable_offdiagonals = IterableOffdiagonalsTrait(typeof(h)) isa HasIterableOffdiagonals,
+    test_random_offdiagonal = RandomOffdiagonalTrait(typeof(h)) isa HasRandomOffdiagonal
+)
     test_operator_interface(h, addr; test_iterable_offdiagonals, test_random_offdiagonal)
     @testset "`AbstractHamiltonian` interface test: $(nameof(typeof(h)))" begin
 

--- a/src/InterfaceTests.jl
+++ b/src/InterfaceTests.jl
@@ -16,7 +16,7 @@ using Rimu: Rimu, DVec, Interfaces, LOStructure, IsHermitian, IsDiagonal, Adjoin
     Hamiltonians, num_offdiagonals, allows_address_type, offdiagonals, random_offdiagonal,
     diagonal_element, dimension, dot_from_right, IsDeterministic, starting_address, PDVec,
     sparse, scale!, scalartype, operator_column, AbstractOperatorColumn,
-    has_random_offdiagonal, has_iterable_offdiagonals, column_operator
+    has_random_offdiagonal, has_iterable_offdiagonals, parent_operator
 using Rimu.Hamiltonians: AbstractHamiltonian, AbstractOperator, AbstractObservable,
     AbstractOffdiagonals
 using LinearAlgebra: dot, mul!, isdiag, ishermitian
@@ -137,9 +137,9 @@ function test_operator_interface(op, addr;
         column = operator_column(op, addr)
         @test column isa AbstractOperatorColumn
         @testset "Operator interface: $(nameof(typeof(op)))" begin
-            @testset "starting_address(column) and column_operator" begin
+            @testset "starting_address(column) and parent_operator" begin
                 @test starting_address(column) == addr
-                @test column_operator(column) == op
+                @test parent_operator(column) == op
             end
             @testset "diagonal_element" begin
                 @test diagonal_element(column) isa eltype(op)

--- a/src/InterfaceTests.jl
+++ b/src/InterfaceTests.jl
@@ -16,8 +16,7 @@ using Rimu: Rimu, DVec, Interfaces, LOStructure, IsHermitian, IsDiagonal, Adjoin
     Hamiltonians, num_offdiagonals, allows_address_type, offdiagonals, random_offdiagonal,
     diagonal_element, dimension, dot_from_right, IsDeterministic, starting_address, PDVec,
     sparse, scale!, scalartype, operator_column, AbstractOperatorColumn
-using Rimu.Interfaces: IterableOffdiagonalsTrait, HasIterableOffdiagonals,
-    RandomOffdiagonalTrait, HasRandomOffdiagonal
+using Rimu.Interfaces: has_random_offdiagonal, has_iterable_offdiagonals
 using Rimu.Hamiltonians: AbstractHamiltonian, AbstractOperator, AbstractObservable,
     AbstractOffdiagonals
 using LinearAlgebra: dot, mul!, isdiag, ishermitian
@@ -86,26 +85,25 @@ This function tests compliance with the [`AbstractOperator`](@ref) interface for
 checking that all required methods are defined.
 
 ## Keyword arguments
-- `test_iterable_offdiagonals::Bool`: If `true`, tests that the `offdiagonals(column)` is
-    iterable.
-- `test_random_offdiagonal::Bool`: If `true`, tests that the `random_offdiagonal(column)` is
-    defined.
-
-By default the keyword arguments are set according the [`IterableOffdiagonalsTrait`](@ref)
-and [`RandomOffdiagonalTrait`](@ref) of the operator type. If the operator does not
-support iterable offdiagonals or random offdiagonals, the tests that require these
-features are skipped.
+- `test_iterable_offdiagonals = has_iterable_offdiagonals(typeof(op))`: If `true`, tests
+  that the `offdiagonals(column)` is iterable.
+- `test_random_offdiagonal = has_random_offdiagonal(typeof(op))`: If `true`, tests that the
+  `random_offdiagonal(column)` is defined.
 
 The following properties are tested:
-- `operator_column(op, addr)` returns a `column` object that is subtype to [`AbstractOperatorColumn`](@ref)
+- `operator_column(op, addr)` returns a `column` object that is subtype to
+  [`AbstractOperatorColumn`](@ref)
 
-If `test_random_offdiagonal` is `true`, tests are performed that require `random_offdiagonal(column)`
-to be defined. If `test_iterable_offdiagonals` is `true`, tests are performed that require
-`offdiagonals(column)` to be iterable.
+If `test_random_offdiagonal` is `true`, tests are performed that require
+`random_offdiagonal(column)` to be defined. If `test_iterable_offdiagonals` is `true`, tests
+are performed that require `offdiagonals(column)` to be iterable.
 
-- `diagonal_element(column)` returns a value of the same type as the `eltype` of the operator
-- `offdiagonals` iterates `address => value` pairs of consistent type (only if `test_iterable_offdiagonals==true`)
-- `random_offdiagonal` returns a tuple with the correct types (only if `test_random_offdiagonal==true`)
+- `diagonal_element(column)` returns a value of the same type as the `eltype` of the
+  operator
+- `offdiagonals` iterates `address => value` pairs of consistent type (only if
+  `test_iterable_offdiagonals==true`)
+- `random_offdiagonal` returns a tuple with the correct types (only if
+  `test_random_offdiagonal == true`)
 - `mul!` and `dot` work as expected
 - `dimension` returns a consistent value
 - the [`AbstractObservable`](@ref) interface is tested
@@ -127,8 +125,8 @@ See also [`AbstractOperator`](@ref), [`test_observable_interface`](@ref),
 [`test_hamiltonian_interface`](@ref).
 """
 function test_operator_interface(op, addr;
-    test_iterable_offdiagonals = IterableOffdiagonalsTrait(typeof(op)) isa HasIterableOffdiagonals,
-    test_random_offdiagonal = RandomOffdiagonalTrait(typeof(op)) isa HasRandomOffdiagonal
+    test_iterable_offdiagonals = has_iterable_offdiagonals(typeof(op)),
+    test_random_offdiagonal = has_random_offdiagonal(typeof(op))
 )
     test_observable_interface(op, addr)
     @testset "`AbstractOperator` interface test: $(nameof(typeof(op)))" begin
@@ -155,15 +153,21 @@ function test_operator_interface(op, addr;
                     @test num_offdiagonals(column) isa Union{Int,BigInt}
                     @test num_offdiagonals(column) >= length(collect(offdiags))
                     if num_offdiagonals(column) > 0
-                        @test iterate(offdiags)[1] isa Union{Tuple{typeof(addr),eltype(op)},Pair{typeof(addr),eltype(op)}}
+                        @test iterate(offdiags)[1] isa Union{Tuple{typeof(addr),eltype(op)},
+                            Pair{typeof(addr),eltype(op)}
+                        }
                     end
-                    @test eltype(offdiags) <: Union{Tuple{typeof(addr),eltype(op)},Pair{typeof(addr),eltype(op)}}
+                    @test eltype(offdiags) <: Union{Tuple{typeof(addr),eltype(op)},
+                        Pair{typeof(addr),eltype(op)}
+                    }
                 end
             end
             if test_random_offdiagonal
                 @testset "random_offdiagonal" begin
                     if num_offdiagonals(column) > 0
-                        @test random_offdiagonal(column) isa Tuple{typeof(addr),<:Real,eltype(op)}
+                        @test random_offdiagonal(column) isa Tuple{typeof(addr),<:Real,
+                            eltype(op)
+                        }
                     end
                 end
             end
@@ -181,22 +185,17 @@ function test_operator_interface(op, addr;
 end
 
 """
-    test_hamiltonian_interface(h, addr=starting_address(h); test_iterable_offdiagonals=true, test_random_offdiagonal=true)
+    test_hamiltonian_interface(h, addr=starting_address(h); kwargs...)
 
 The main purpose of this test function is to check that all required methods of the
 [`AbstractHamiltonian`](@ref) interface are defined and work as expected.
 
 
 ## Keyword arguments
-- `test_iterable_offdiagonals::Bool`: If `true`, tests that the `offdiagonals(column)` is
-    iterable.
-- `test_random_offdiagonal::Bool`: If `true`, tests that the `random_offdiagonal(column)` is
-    defined.
-
-By default the keyword arguments are set according the [`IterableOffdiagonalsTrait`](@ref)
-and [`RandomOffdiagonalTrait`](@ref) of the operator type. If the operator does not
-support iterable offdiagonals or random offdiagonals, the tests that require these
-features are skipped.
+- `test_iterable_offdiagonals = has_iterable_offdiagonals(typeof(h))`: If `true`, tests that
+  the `offdiagonals(column)` is iterable.
+- `test_random_offdiagonal = has_random_offdiagonal(typeof(h))`: If `true`, tests that the
+  `random_offdiagonal(column)` is defined.
 
 This function also tests the following properties of the Hamiltonian:
 - `dimension(h) ≥ dimension(h, addr)`
@@ -227,8 +226,8 @@ Hamiltonians-only tests with HubbardRealSpace |    6      6  0.0s
 See also [`test_operator_interface`](@ref), [`test_observable_interface`](@ref).
 """
 function test_hamiltonian_interface(h, addr=starting_address(h);
-    test_iterable_offdiagonals = IterableOffdiagonalsTrait(typeof(h)) isa HasIterableOffdiagonals,
-    test_random_offdiagonal = RandomOffdiagonalTrait(typeof(h)) isa HasRandomOffdiagonal
+    test_iterable_offdiagonals = has_iterable_offdiagonals(typeof(h)),
+    test_random_offdiagonal = has_random_offdiagonal(typeof(h))
 )
     test_operator_interface(h, addr; test_iterable_offdiagonals, test_random_offdiagonal)
     @testset "`AbstractHamiltonian` interface test: $(nameof(typeof(h)))" begin

--- a/src/Interfaces/Interfaces.jl
+++ b/src/Interfaces/Interfaces.jl
@@ -8,6 +8,8 @@ behaviours of `Rimu`.
 Follow the links for the definitions of the interfaces!
 * [`AbstractHamiltonian`](@ref) for defining [`Hamiltonians`](@ref Main.Hamiltonians)
 * [`AbstractOperator`](@ref) for defining observable operators
+* [`AbstractObservable`](@ref) for defining observables
+* [`AbstractOperatorColumn`](@ref) for defining operator columns
 * [`AbstractDVec`](@ref) for defining data structures for `Rimu` as in [
     `DictVectors`](@ref Main.DictVectors)
 * [`StochasticStyle`](@ref) for controlling the stochastic algorithms used by
@@ -21,6 +23,7 @@ Follow the links for the definitions of the interfaces!
 ## Interface functions for[`AbstractHamiltonian`](@ref)s:
 * [`starting_address`](@ref)
 * [`operator_column`](@ref)
+* [`column_operator`](@ref)
 * [`diagonal_element`](@ref)
 * [`random_offdiagonal`](@ref)
 * [`offdiagonals`](@ref).
@@ -69,11 +72,11 @@ export
     AbstractHamiltonian, diagonal_element, num_offdiagonals, get_offdiagonal, offdiagonals,
     random_offdiagonal, starting_address, allows_address_type,
     LOStructure, IsDiagonal, IsHermitian, AdjointKnown, AdjointUnknown, has_adjoint,
-    AbstractOperator, AbstractObservable, operator_column, OffdiagonalsOperatorColumn, AbstractOperatorColumn
+    AbstractOperator, AbstractObservable, operator_column, OffdiagonalsOperatorColumn,
+    AbstractOperatorColumn, column_operator,
+    has_random_offdiagonal, has_iterable_offdiagonals
 export
     num_replicas, num_spectral_states, num_overlaps
-export
-    has_iterable_offdiagonals, has_random_offdiagonal
 
 """
     AbstractFockAddress{N,M}

--- a/src/Interfaces/Interfaces.jl
+++ b/src/Interfaces/Interfaces.jl
@@ -13,8 +13,7 @@ Follow the links for the definitions of the interfaces!
 * [`StochasticStyle`](@ref) for controlling the stochastic algorithms used by
     [`ProjectorMonteCarloProblem`](@ref Main.ProjectorMonteCarloProblem) as implemented in
     [`StochasticStyles`](@ref Main.StochasticStyles)
-* [`AbstractFockAddress`](@ref) for defining Fock states, see also
-    [`BitStringAddresses`](@ref Main.BitStringAddresses).
+* [`AbstractFockAddress`](@ref) for defining Fock states.
 
 # Additional exports
 

--- a/src/Interfaces/Interfaces.jl
+++ b/src/Interfaces/Interfaces.jl
@@ -65,8 +65,7 @@ export
 export
     num_replicas, num_spectral_states, num_overlaps
 export
-    IterableOffdiagonalsTrait, NoIterableOffdiagonals, HasIterableOffdiagonals,
-    RandomOffdiagonalTrait, NoRandomOffdiagonal, HasRandomOffdiagonal
+    has_iterable_offdiagonals, has_random_offdiagonal
 
 include("stochasticstyles.jl")
 include("dictvectors.jl")

--- a/src/Interfaces/Interfaces.jl
+++ b/src/Interfaces/Interfaces.jl
@@ -64,6 +64,8 @@ export
     AbstractOperator, AbstractObservable, operator_column, OffdiagonalsOperatorColumn, AbstractOperatorColumn
 export
     num_replicas, num_spectral_states, num_overlaps
+export
+    IterableOffdiagonalsTrait, NoIterableOffdiagonals, HasIterableOffdiagonals
 
 include("stochasticstyles.jl")
 include("dictvectors.jl")

--- a/src/Interfaces/Interfaces.jl
+++ b/src/Interfaces/Interfaces.jl
@@ -51,6 +51,11 @@ Follow the links for the definitions of the interfaces!
 * [`num_replicas`](@ref)
 * [`num_spectral_states`](@ref)
 * [`num_overlaps`](@ref)
+
+## Functions for working with [`AbstractFockAddress`](@ref)s:
+* [`num_particles`](@ref)
+* [`num_modes`](@ref)
+* [`num_components`](@ref)
 """
 module Interfaces
 
@@ -61,7 +66,7 @@ using DataFrames: DataFrame, metadata
 import OrderedCollections: freeze
 
 export
-    AbstractFockAddress
+    AbstractFockAddress, num_particles, num_modes, num_components
 export
     StochasticStyle, default_style, StyleUnknown, apply_column!, step_stats,
     CompressionStrategy, NoCompression, compress!
@@ -78,20 +83,7 @@ export
 export
     num_replicas, num_spectral_states, num_overlaps
 
-"""
-    AbstractFockAddress{N,M}
-
-Abstract type representing a Fock state with `N` particles and `M` modes.
-
-See also [`SingleComponentFockAddress`](@ref Main.SingleComponentFockAddress),
-[`CompositeFS`](@ref Main.CompositeFS), [`BoseFS`](@ref Main.BoseFS),
-[`FermiFS`](@ref Main.FermiFS).
-"""
-abstract type AbstractFockAddress{N,M} end
-
-# `AbstractFockAddress`es can be reconstructed from their printout.
-Base.typeinfo_implicit(::Type{<:AbstractFockAddress}) = true
-
+include("abstractfockaddress.jl")
 include("stochasticstyles.jl")
 include("dictvectors.jl")
 include("hamiltonians.jl")

--- a/src/Interfaces/Interfaces.jl
+++ b/src/Interfaces/Interfaces.jl
@@ -13,7 +13,8 @@ Follow the links for the definitions of the interfaces!
 * [`StochasticStyle`](@ref) for controlling the stochastic algorithms used by
     [`ProjectorMonteCarloProblem`](@ref Main.ProjectorMonteCarloProblem) as implemented in
     [`StochasticStyles`](@ref Main.StochasticStyles)
-* [`AbstractFockAddress`](@ref) for defining Fock states.
+* [`AbstractFockAddress`](@ref) for defining Fock states, see also
+    [`BitStringAddresses`](@ref Main.BitStringAddresses).
 
 # Additional exports
 

--- a/src/Interfaces/Interfaces.jl
+++ b/src/Interfaces/Interfaces.jl
@@ -65,7 +65,8 @@ export
 export
     num_replicas, num_spectral_states, num_overlaps
 export
-    IterableOffdiagonalsTrait, NoIterableOffdiagonals, HasIterableOffdiagonals
+    IterableOffdiagonalsTrait, NoIterableOffdiagonals, HasIterableOffdiagonals,
+    RandomOffdiagonalTrait, NoRandomOffdiagonal, HasRandomOffdiagonal
 
 include("stochasticstyles.jl")
 include("dictvectors.jl")

--- a/src/Interfaces/Interfaces.jl
+++ b/src/Interfaces/Interfaces.jl
@@ -23,7 +23,7 @@ Follow the links for the definitions of the interfaces!
 ## Interface functions for[`AbstractHamiltonian`](@ref)s:
 * [`starting_address`](@ref)
 * [`operator_column`](@ref)
-* [`column_operator`](@ref)
+* [`parent_operator`](@ref)
 * [`diagonal_element`](@ref)
 * [`random_offdiagonal`](@ref)
 * [`offdiagonals`](@ref).
@@ -78,7 +78,7 @@ export
     random_offdiagonal, starting_address, allows_address_type,
     LOStructure, IsDiagonal, IsHermitian, AdjointKnown, AdjointUnknown, has_adjoint,
     AbstractOperator, AbstractObservable, operator_column, OffdiagonalsOperatorColumn,
-    AbstractOperatorColumn, column_operator,
+    AbstractOperatorColumn, parent_operator,
     has_random_offdiagonal, has_iterable_offdiagonals
 export
     num_replicas, num_spectral_states, num_overlaps

--- a/src/Interfaces/Interfaces.jl
+++ b/src/Interfaces/Interfaces.jl
@@ -1,29 +1,35 @@
 """
     module Interfaces
 
-This module contains interfaces that can be used to extend and modify the algorithms and behaviours of `Rimu`.
+This module contains interfaces that can be used to extend and modify the algorithms and
+behaviours of `Rimu`.
 
 # Interfaces
 Follow the links for the definitions of the interfaces!
 * [`AbstractHamiltonian`](@ref) for defining [`Hamiltonians`](@ref Main.Hamiltonians)
 * [`AbstractOperator`](@ref) for defining observable operators
-* [`AbstractDVec`](@ref) for defining data structures for `Rimu` as in [`DictVectors`](@ref Main.DictVectors)
+* [`AbstractDVec`](@ref) for defining data structures for `Rimu` as in [
+    `DictVectors`](@ref Main.DictVectors)
 * [`StochasticStyle`](@ref) for controlling the stochastic algorithms used by
-  [`ProjectorMonteCarloProblem`](@ref Main.ProjectorMonteCarloProblem) as implemented in
-  [`StochasticStyles`](@ref Main.StochasticStyles)
+    [`ProjectorMonteCarloProblem`](@ref Main.ProjectorMonteCarloProblem) as implemented in
+    [`StochasticStyles`](@ref Main.StochasticStyles)
+* [`AbstractFockAddress`](@ref) for defining Fock states, see also
+    [`BitStringAddresses`](@ref Main.BitStringAddresses).
 
 # Additional exports
 
 ## Interface functions for[`AbstractHamiltonian`](@ref)s:
+* [`starting_address`](@ref)
 * [`operator_column`](@ref)
 * [`diagonal_element`](@ref)
+* [`random_offdiagonal`](@ref)
+* [`offdiagonals`](@ref).
 * [`num_offdiagonals`](@ref)
 * [`get_offdiagonal`](@ref)
-* [`offdiagonals`](@ref).
-* [`random_offdiagonal`](@ref)
-* [`starting_address`](@ref)
 * [`LOStructure`](@ref)
 * [`allows_address_type`](@ref)
+* [`has_random_offdiagonal`](@ref)
+* [`has_iterable_offdiagonals`](@ref)
 
 ## working with  [`AbstractDVec`](@ref)s and [`StochasticStyle`](@ref)
 * [`deposit!`](@ref)

--- a/src/Interfaces/Interfaces.jl
+++ b/src/Interfaces/Interfaces.jl
@@ -52,6 +52,8 @@ using DataFrames: DataFrame, metadata
 import OrderedCollections: freeze
 
 export
+    AbstractFockAddress
+export
     StochasticStyle, default_style, StyleUnknown, apply_column!, step_stats,
     CompressionStrategy, NoCompression, compress!
 export
@@ -66,6 +68,20 @@ export
     num_replicas, num_spectral_states, num_overlaps
 export
     has_iterable_offdiagonals, has_random_offdiagonal
+
+"""
+    AbstractFockAddress{N,M}
+
+Abstract type representing a Fock state with `N` particles and `M` modes.
+
+See also [`SingleComponentFockAddress`](@ref Main.SingleComponentFockAddress),
+[`CompositeFS`](@ref Main.CompositeFS), [`BoseFS`](@ref Main.BoseFS),
+[`FermiFS`](@ref Main.FermiFS).
+"""
+abstract type AbstractFockAddress{N,M} end
+
+# `AbstractFockAddress`es can be reconstructed from their printout.
+Base.typeinfo_implicit(::Type{<:AbstractFockAddress}) = true
 
 include("stochasticstyles.jl")
 include("dictvectors.jl")

--- a/src/Interfaces/abstractfockaddress.jl
+++ b/src/Interfaces/abstractfockaddress.jl
@@ -1,0 +1,40 @@
+"""
+    AbstractFockAddress{N,M}
+
+Abstract type representing a Fock state with `N` particles and `M` modes.
+
+See also [`SingleComponentFockAddress`](@ref Main.SingleComponentFockAddress),
+[`CompositeFS`](@ref Main.CompositeFS), [`BoseFS`](@ref Main.BoseFS),
+[`FermiFS`](@ref Main.FermiFS), [`num_particles`](@ref num_particles),
+[`num_modes`](@ref num_modes), [`num_components`](@ref num_components).
+"""
+abstract type AbstractFockAddress{N,M} end
+
+# `AbstractFockAddress`es can be reconstructed from their printout.
+Base.typeinfo_implicit(::Type{<:AbstractFockAddress}) = true
+
+"""
+    num_particles(::Type{<:AbstractFockAddress})
+    num_particles(::AbstractFockAddress)
+
+Number of particles represented by address.
+"""
+num_particles(a::AbstractFockAddress) = num_particles(typeof(a))
+num_particles(::Type{<:AbstractFockAddress{N}}) where {N} = N
+
+"""
+    num_modes(::Type{<:AbstractFockAddress})
+    num_modes(::AbstractFockAddress)
+
+Number of modes represented by address.
+"""
+num_modes(a::AbstractFockAddress) = num_modes(typeof(a))
+num_modes(::Type{<:AbstractFockAddress{<:Any,M}}) where {M} = M
+
+"""
+    num_components(::Type{<:AbstractFockAddress})
+    num_components(::AbstractFockAddress)
+
+Number of components in address.
+"""
+num_components(b::AbstractFockAddress) = num_components(typeof(b))

--- a/src/Interfaces/hamiltonians.jl
+++ b/src/Interfaces/hamiltonians.jl
@@ -525,7 +525,24 @@ Part of the [`AbstractHamiltonian`](@ref) interface.
 """
 abstract type IterableOffdiagonalsTrait end
 
+"""
+    NoIterableOffdiagonals() <: IterableOffdiagonalsTrait
+`NoIterableOffdiagonals` is a trait that indicates that the operator's columns do not have
+iterable `offdiagonals`. This means that the `offdiagonals(column)` function returns an
+error when called on the operator's column.
+
+See also [`IterableOffdiagonalsTrait`](@ref Main.Interfaces.IterableOffdiagonalsTrait).
+"""
 struct NoIterableOffdiagonals <: IterableOffdiagonalsTrait end
+
+"""
+    HasIterableOffdiagonals() <: IterableOffdiagonalsTrait
+`HasIterableOffdiagonals` is a trait that indicates that the operator's columns have
+iterable `offdiagonals`. This means that the `offdiagonals(column)` function returns an
+iterable object when called on the operator's column.
+
+See also [`IterableOffdiagonalsTrait`](@ref Main.Interfaces.IterableOffdiagonalsTrait).
+"""
 struct HasIterableOffdiagonals <: IterableOffdiagonalsTrait end
 
 IterableOffdiagonalsTrait(::Type{<:AbstractObservable}) = HasIterableOffdiagonals()

--- a/src/Interfaces/hamiltonians.jl
+++ b/src/Interfaces/hamiltonians.jl
@@ -540,7 +540,7 @@ function LinearAlgebra.dot(column::AbstractOperatorColumn, a)
 end
 
 """
-    dot(dv::AbstractDVec, column::AbstractOperatorColumn)
+    dot(dv, column::AbstractOperatorColumn)
 
 Compute the dot product of the vector `dv` with the operator `column`.
 
@@ -548,8 +548,8 @@ See also [`operator_column`](@ref), [`AbstractOperatorColumn`](@ref),
 and [`AbstractDVec`](@ref).
 """
 function LinearAlgebra.dot(
-    dv::AbstractDVec{A}, column::AbstractOperatorColumn{A}
-) where {A} # `A` is the (compatible) address type
+    dv, column::AbstractOperatorColumn
+)
     res = conj(dv[starting_address(column)]) * diagonal_element(column)
     for (newaddress, matrixelement) in offdiagonals(column)
         res += conj(dv[newaddress]) * matrixelement

--- a/src/Interfaces/hamiltonians.jl
+++ b/src/Interfaces/hamiltonians.jl
@@ -181,10 +181,15 @@ Mandatory methods to implement:
 
 * [`starting_address(op::AbstractHamiltonian)`](@ref)
 * [`operator_column(op, address)`](@ref) returns an [`AbstractOperatorColumn`](@ref)
-* [`diagonal_element(column)`](@ref)
-* [`num_offdiagonals(column)`](@ref) (this can be an upper bound)
-* [`offdiagonals(column)`](@ref) returns an iterator
-* [`random_offdiagonal(column)`](@ref)
+
+[`AbstractOperatorColumn`](@ref) has its own interface methods:
+* [`column_operator(column)`](@ref) returns the operator of the column
+* [`diagonal_element(column)`](@ref) returns the diagonal element of the column
+* [`num_offdiagonals(column)`](@ref) (this can be an upper bound) returns the number of
+    off-diagonal elements in the column
+* [`offdiagonals(column)`](@ref) returns an object representing the off-diagonal elements
+    of the column
+* [`random_offdiagonal(column)`](@ref) returns a random off-diagonal element in the column
 
 Optional additional methods to implement:
 
@@ -387,13 +392,47 @@ has_adjoint(::LOStructure) = true
 """
     AbstractOperatorColumn{A,T,O}
 
-Abstract type for operator columns returned by [`operator_column`](@ref).
-The type parameters represent the address type (`A`), the eltype (`T`), and the
-type of the operator (`O`).
+Abstract type for operator columns returned by [`operator_column(operator, address)`](@ref)
+or `operator * address`. The type parameters represent the address type (`A`), the eltype
+(`T`), and the type of the operator (`O`).
+
+In quantum notation, the column represents the object
+```math
+    Ĥ|α⟩ = ∑ᵦ|β⟩⟨β|Ĥ|α⟩,
+```
+where ``α`` is the  `address` and ``β`` represents all reachable addresses with nonzero
+matrix element ``⟨β|Ĥ|α⟩`` of the `operator` ``Ĥ``.
+
+# Interface
+
+The default constructor for `AbstractOperatorColumn` is
+`operator_column(operator, address)`. The interface for `AbstractOperatorColumn` is defined
+by the following functions:
+
+* [`column_operator(c::AbstractOperatorColumn)`](@ref) - returns the `operator`,
+* [`starting_address(c::AbstractOperatorColumn)`](@ref) - returns the starting `address`,
+* [`diagonal_element(c::AbstractOperatorColumn)`](@ref) - returns the diagonal element of
+    the column `c`, `⟨α|Ĥ|α⟩`, where ``α`` is the starting address,
+* [`num_offdiagonals(c::AbstractOperatorColumn)`](@ref) - returns an upper bound on the
+    number of off-diagonal elements in the column `c`,
+* [`offdiagonals(c::AbstractOperatorColumn)`](@ref) - returns an object representing the
+    off-diagonal elements of the column `c`,
+* [`random_offdiagonal(c::AbstractOperatorColumn)`](@ref) - returns a random off-diagonal
+    element in the column `c`.
+
+Methods for these functions need to be implemented for a new type of
+[`AbstractOperator`](@ref).
 
 Part of the  [`AbstractHamiltonian`](@ref) and  [`AbstractOperator`](@ref) interface.
+See also [`operator_column`](@ref).
 """
 abstract type AbstractOperatorColumn{A,T,O} end
+
+function Base.show(io::IO, c::AbstractOperatorColumn{A,T,O}) where {A,T,O}
+    io = IOContext(io, :compact => true)
+    show(io, column_operator(c))
+    print(io, " * ", starting_address(c))
+end
 
 """
     OffdiagonalsOperatorColumn <: AbstractOperatorColumn
@@ -410,11 +449,15 @@ struct OffdiagonalsOperatorColumn{A,T,O<:Union{AbstractOperator{T},AbstractMatri
     diagonal::T
 end
 
-function Base.show(io::IO, c::OffdiagonalsOperatorColumn{A,T,O}) where {A,T,O}
-    io = IOContext(io, :compact => true)
-    print(io, "OffdiagonalsOperatorColumn{", nameof(A), "{…}, ", T, ", ", nameof(O),
-        "{…}}(", starting_address(c), ", …)")
-end
+"""
+    column_operator(c::AbstractOperatorColumn)
+Return the operator of the column `c`.  This is the operator that was used to
+construct the column with [`operator_column`](@ref).
+
+Part of the [`AbstractHamiltonian`](@ref) and [`AbstractOperator`](@ref) interface.
+See also [`AbstractOperatorColumn`](@ref) and [`operator_column`](@ref).
+"""
+column_operator(c::OffdiagonalsOperatorColumn) = c.operator
 
 """
     operator_column(operator::AbstractOperator, address) -> column <: AbstractOperatorColumn
@@ -428,41 +471,25 @@ notation, the `column` represents the object
 where ``α`` is the  `address` and ``β`` represents all reachable addresses with nonzero
 matrix element ``⟨β|Ĥ|α⟩`` of the `operator` ``Ĥ``.
 
-A `column` can be accessed with the following functions:
-
-* [`starting_address(column)`](@ref) - returns `address`,
-* [`diagonal_element(column)`](@ref) - returns the diagonal element ``⟨α|Ĥ|α⟩`` of `address`
-  in `operator`,
-* [`num_offdiagonals(column)`](@ref) - returns an upper bound on the number of
-  off-diagonal elements in the `column`,
-* [`offdiagonals(column)`](@ref) - returns an object representing the off-diagonal
-  elements of the `column`,
-* [`random_offdiagonal(column)`](@ref) - returns a random off-diagonal element in the
-  `column`.
-
-Methods for these functions need to be implemented for a new type of
-[`AbstractOperator`](@ref). Implementing [`random_offdiagonal(column)`](@ref) is optional
-if [`offdiagonals(column)`](@ref) returns an `AbstractVector`.
+For more information and the definition of an interface see
+[`AbstractOperatorColumn`](@ref).
 
 # Example
 ```jldoctest
 julia> address = BoseFS(1,2,3);
 
-julia> H = HubbardRealSpace(address);
+julia> H = HubbardReal1D(address; u=6.0);
 
-julia> column = operator_column(H, address)
-OffdiagonalsOperatorColumn{BoseFS{…}, Float64, HubbardRealSpace{…}}(fs"|1 2 3⟩", …)
+julia> column = H * address
+HubbardReal1D(fs"|1 2 3⟩"; u=6.0, t=1.0) * fs"|1 2 3⟩"
 
-julia> H * address == column
+julia> operator_column(H, address) == column
 true
-
-julia> num_offdiagonals(column)
-6
 
 julia> diagonal_element(column) == address * column
 true
 
-julia> fs"|1 3 2⟩" * column
+julia> fs"|1 3 2⟩" * column # an off-diagonal matrix element
 -3.0
 ```
 

--- a/src/Interfaces/hamiltonians.jl
+++ b/src/Interfaces/hamiltonians.jl
@@ -547,3 +547,54 @@ struct HasIterableOffdiagonals <: IterableOffdiagonalsTrait end
 
 IterableOffdiagonalsTrait(::Type{<:AbstractObservable}) = HasIterableOffdiagonals()
 # default trait for observables
+
+"""
+    RandomOffdiagonalTrait(operatortype::Type) -> RandomOffdiagonalTrait
+Return a trait that indicates whether the operator's columns have a
+[`random_offdiagonal`](@ref) method implemented. One of the following values will be
+returned:
+
+- [`NoRandomOffdiagonal()`](@ref): no `random_offdiagonal` method is implemented.
+- [`HasRandomOffdiagonal()`](@ref): `random_offdiagonal(column)` is implemented.
+
+## Example
+```jldoctest
+julia> using Rimu.Interfaces
+
+julia> h = HubbardReal1D(BoseFS(1,2,3));
+
+julia> RandomOffdiagonalTrait(typeof(h)) isa HasRandomOffdiagonal
+true
+```
+
+When extending the interface, implement a method for
+`RandomOffdiagonalTrait(::Type{<:MyNewOperator})`.
+
+Part of the [`AbstractHamiltonian`](@ref) interface.
+"""
+abstract type RandomOffdiagonalTrait end
+
+"""
+    NoRandomOffdiagonal() <: RandomOffdiagonalTrait
+`NoRandomOffdiagonal` is a trait that indicates that the operator's columns do not have a
+`random_offdiagonal` method implemented. This means that the
+[`random_offdiagonal(column)`](@ref) function returns an error when called on the
+operator's column.
+
+See also [`RandomOffdiagonalTrait`](@ref Main.Interfaces.RandomOffdiagonalTrait).
+"""
+struct NoRandomOffdiagonal <: RandomOffdiagonalTrait end
+
+"""
+    HasRandomOffdiagonal() <: RandomOffdiagonalTrait
+`HasRandomOffdiagonal` is a trait that indicates that the operator's columns have a
+`random_offdiagonal` method implemented. This means that the
+[`random_offdiagonal(column)`](@ref) function returns a random off-diagonal element when
+called on the operator's column.
+
+See also [`RandomOffdiagonalTrait`](@ref Main.Interfaces.RandomOffdiagonalTrait).
+"""
+struct HasRandomOffdiagonal <: RandomOffdiagonalTrait end
+
+RandomOffdiagonalTrait(::Type{<:AbstractObservable}) = HasRandomOffdiagonal()
+# default trait for observables

--- a/src/Interfaces/hamiltonians.jl
+++ b/src/Interfaces/hamiltonians.jl
@@ -270,7 +270,7 @@ julia> diagonal_element(column)
 Part of the [`AbstractHamiltonian`](@ref) interface. See also
 [`AbstractOperatorColumn`](@ref) and [`operator_column`](@ref).
 """
-diagonal_element(m::AbstractMatrix, i) = m[i, i]
+diagonal_element
 
 """
     num_offdiagonals(column::AbstractOperatorColumn)
@@ -292,7 +292,7 @@ julia> num_offdiagonals(column)
 Part of the [`AbstractHamiltonian`](@ref) interface. See also
 [`AbstractOperatorColumn`](@ref) and [`operator_column`](@ref).
 """
-num_offdiagonals(m::AbstractMatrix, i) = length(offdiagonals(m, i))
+num_offdiagonals
 
 """
     newadd, me = get_offdiagonal(ham, address, chosen) # (deprecated)
@@ -313,15 +313,13 @@ julia> get_offdiagonal(H, addr, 3)
 ```
 Part of the [`AbstractHamiltonian`](@ref) interface.
 """
-get_offdiagonal(m::AbstractMatrix, i, n) = offdiagonals(m, i)[n]
+get_offdiagonal(m, i, n) = offdiagonals(m, i)[n]
 
 """
     starting_address(h::AbstractHamiltonian)
     starting_address(column::AbstractOperatorColumn)
 
-Return the starting address for the Hamiltonian `h`, or for the `column`. When
-called on an `AbstractMatrix`, `starting_address` returns the index of the diagonal
-element with the smallest real part.
+Return the starting address for the Hamiltonian `h`, or for the `column`.
 
 # Example
 
@@ -336,7 +334,7 @@ true
 Part of the [`AbstractHamiltonian`](@ref) interface. See also
 [`AbstractOperatorColumn`](@ref).
 """
-starting_address(m::AbstractMatrix) = findmin(real.(diag(m)))[2]
+starting_address
 
 @doc """
     LOStructure(op::AbstractHamiltonian)
@@ -368,7 +366,6 @@ struct AdjointUnknown <: LOStructure end
 # defaults
 LOStructure(op) = LOStructure(typeof(op))
 LOStructure(::Type) = AdjointUnknown()
-LOStructure(::AbstractMatrix) = AdjointKnown()
 
 # diagonal matrices have zero offdiagonal elements
 function num_offdiagonals(h::H, addr) where {H<:AbstractOperator}
@@ -442,7 +439,7 @@ Default column, using the deprecated interface with [`offdiagonals(op, address)`
 
 See also [`operator_column`](@ref).
 """
-struct OffdiagonalsOperatorColumn{A,T,O<:Union{AbstractOperator{T},AbstractMatrix{T}},OD} <: AbstractOperatorColumn{A,T,O}
+struct OffdiagonalsOperatorColumn{A,T,O<:AbstractOperator{T},OD} <: AbstractOperatorColumn{A,T,O}
     operator::O
     address::A
     ods::OD
@@ -504,6 +501,8 @@ Part of the [`AbstractHamiltonian`](@ref) interface. See also
 """
 operator_column(o, a) = OffdiagonalsOperatorColumn(o, a, offdiagonals(o,a),
     eltype(o)(diagonal_element(o,a)))
+
+@doc (@doc operator_column) Base.:*
 function Base.:*(o::AbstractObservable, a::A) where {A<:Union{AbstractFockAddress,Integer}}
     return operator_column(o, a)
 end
@@ -518,16 +517,22 @@ offdiagonals(c::OffdiagonalsOperatorColumn) = c.ods
 
 Return the matrix element of the operator column `column` at `address`.
 
+!!! warning
+    This method is provided for convenience only. It is not efficient and should not be
+    used in performance-critical code. Use [`diagonal_element`](@ref) and
+    [`offdiagonals`](@ref) instead to access the diagonal and off-diagonal
+    elements of the operator column.
+
 See also [`operator_column`](@ref), [`AbstractOperatorColumn`](@ref).
 """
 function Base.getindex(
-    column::AbstractOperatorColumn{A,T}, a::A
-) where {A,T} # `A` is the (compatible) address type, `T` is the eltype
-    if a == starting_address(column)
+    column::AbstractOperatorColumn{A,T}, address::A
+) where {A,T}
+    if address == starting_address(column)
         return diagonal_element(column)::T
     else
         for (newaddress, matrixelement) in offdiagonals(column)
-            if newaddress == a
+            if newaddress == address
                 return matrixelement::T
             end
         end
@@ -583,12 +588,6 @@ julia> h = offdiagonals(H * address)
 Part of the [`AbstractHamiltonian`](@ref) interface. See also
 [`AbstractOperatorColumn`](@ref) and [`operator_column`](@ref).
 """
-function offdiagonals(m::AbstractMatrix, i)
-    pairs = collect(zip(axes(m, 1), view(m, :, i)))
-    return filter!(pairs) do ((k, v))
-        k ≠ i && v ≠ 0
-    end
-end
 function offdiagonals(::AbstractOperatorColumn{A,T,O}) where {A,T,O}
     if has_iterable_offdiagonals(O)
         error("offdiagonals not implemented for operator type $O " *

--- a/src/Interfaces/hamiltonians.jl
+++ b/src/Interfaces/hamiltonians.jl
@@ -100,7 +100,7 @@ Mandatory methods to implement:
 - [`diagonal_element(column)`](@ref)
 - [`num_offdiagonals(column)`](@ref) (this can be an upper bound)
 - [`offdiagonals(column)`](@ref) required for deterministic operations, see
-    [`has_iterable_offdiagonals(::Type{typeof(op)})`](@ref) below
+    [`has_iterable_offdiagonals(::Type{typeof(op)})`](@ref has_iterable_offdiagonals) below
 
 Optional additional methods to implement:
 - [`VectorInterface.scalartype(op)`](@ref): defaults to `eltype(eltype(op))`

--- a/src/Interfaces/hamiltonians.jl
+++ b/src/Interfaces/hamiltonians.jl
@@ -463,7 +463,7 @@ column_operator(c::OffdiagonalsOperatorColumn) = c.operator
     operator_column(operator::AbstractOperator, address) -> column <: AbstractOperatorColumn
     *(o::AbstractOperator, a::AbstractFockAddress) -> column
 
-Return an object representing the column of `operator` given by `address`. In quantum
+Return a (lazy) object representing the column of `operator` given by `address`. In quantum
 notation, the `column` represents the object
 ```math
     Ĥ|α⟩ = ∑ᵦ|β⟩⟨β|Ĥ|α⟩,
@@ -476,21 +476,24 @@ For more information and the definition of an interface see
 
 # Example
 ```jldoctest
-julia> address = BoseFS(1,2,3);
+julia> address = BoseFS(0,1,0);
 
 julia> H = HubbardReal1D(address; u=6.0);
 
-julia> column = H * address
-HubbardReal1D(fs"|1 2 3⟩"; u=6.0, t=1.0) * fs"|1 2 3⟩"
+julia> column = H * address # construct column with `*` operator
+HubbardReal1D(fs"|0 1 0⟩"; u=6.0, t=1.0) * fs"|0 1 0⟩"
 
 julia> operator_column(H, address) == column
 true
 
-julia> diagonal_element(column) == dot(address, column)
+julia> diagonal_element(column) == dot(address, column) # access elements with `dot()`
 true
 
-julia> fs"|1 3 2⟩" ⋅ column # an off-diagonal matrix element
--3.0
+julia> DVec(column) # materialise as a `DVec`
+DVec{BoseFS{1, 3, BitString{3, 1, UInt8}},Float64} with 3 entries, style = IsDeterministic{Float64}()
+  fs"|1 0 0⟩" => -1.0
+  fs"|0 1 0⟩" => 0.0
+  fs"|0 0 1⟩" => -1.0
 ```
 
 Part of the [`AbstractHamiltonian`](@ref) interface. See also
@@ -595,6 +598,25 @@ function offdiagonals(::AbstractOperatorColumn{A,T,O}) where {A,T,O}
         throw(ArgumentError("offdiagonals not supported for operator type $O"))
     end
 end
+
+# Iteration interface for AbstractOperatorColumn
+function Base.iterate(col::AbstractOperatorColumn)
+    return starting_address(col) => diagonal_element(col), nothing
+end
+function Base.iterate(col::AbstractOperatorColumn, state)
+    result = if state === nothing
+        iterate(offdiagonals(col))
+    else
+        iterate(offdiagonals(col), state)
+    end
+    if result === nothing
+        return nothing
+    end
+    (address, value), newstate = result
+    return address => value, newstate
+end
+Base.IteratorSize(::AbstractOperatorColumn) = Base.SizeUnknown()
+Base.eltype(::AbstractOperatorColumn{A,T}) where {A,T} = Pair{A,T}
 
 """
     random_offdiagonal(column::AbstractOperatorColumn)

--- a/src/Interfaces/hamiltonians.jl
+++ b/src/Interfaces/hamiltonians.jl
@@ -410,6 +410,12 @@ struct OffdiagonalsOperatorColumn{A,T,O<:Union{AbstractOperator{T},AbstractMatri
     diagonal::T
 end
 
+function Base.show(io::IO, c::OffdiagonalsOperatorColumn{A,T,O}) where {A,T,O}
+    io = IOContext(io, :compact => true)
+    print(io, "OffdiagonalsOperatorColumn{", nameof(A), "{…}, ", T, ", ", nameof(O),
+        "{…}}(", starting_address(c), ", …)")
+end
+
 """
     operator_column(operator::AbstractOperator, address) -> column <: AbstractOperatorColumn
     *(o::AbstractOperator, a::AbstractFockAddress) -> column

--- a/src/Interfaces/hamiltonians.jl
+++ b/src/Interfaces/hamiltonians.jl
@@ -27,8 +27,8 @@ Basic interface methods to implement:
 Optional additional methods to implement:
 - [`VectorInterface.scalartype(op)`](@ref): defaults to `eltype(eltype(op))`
 - [`LOStructure(::Type{typeof(op)})`](@ref LOStructure): defaults to `AdjointUnknown`
-- [`RandomOffdiagonalTrait(op)`](@ref): defaults to `NoRandomOffdiagonal()`
-- [`IterableOffdiagonalsTrait(op)`](@ref): defaults to `NoIterableOffdiagonals()`
+- [`has_random_offdiagonal(::Type{typeof(op)})`](@ref): defaults to `false`
+- [`has_iterable_offdiagonals(::Type{typeof(op)})`](@ref): defaults to `false`
 
 See also [`AbstractOperator`](@ref), [`AbstractHamiltonian`](@ref), [`Interfaces`](@ref).
 """
@@ -98,16 +98,16 @@ Mandatory methods to implement:
 - [`diagonal_element(column)`](@ref)
 - [`num_offdiagonals(column)`](@ref) (this can be an upper bound)
 - [`offdiagonals(column)`](@ref) required for deterministic operations, see
-    [`IterableOffdiagonalsTrait(op)`](@ref) below
+    [`has_iterable_offdiagonals(::Type{typeof(op)})`](@ref) below
 
 Optional additional methods to implement:
 - [`VectorInterface.scalartype(op)`](@ref): defaults to `eltype(eltype(op))`
 - [`LOStructure(::Type{typeof(op)})`](@ref LOStructure): defaults to `AdjointUnknown`
 - [`dimension(op, addr)`](@ref Main.Hamiltonians.dimension): defaults to dimension of
   address space
-- [`IterableOffdiagonalsTrait(op)`](@ref): defaults to `HasIterableOffdiagonals()`
-- [`RandomOffdiagonalTrait(op)`](@ref): defaults to `NoRandomOffdiagonal()`. If this set to
-  `HasRandomOffdiagonal()`, the method [`random_offdiagonal(column)`](@ref) needs to be
+- [`has_iterable_offdiagonals(::Type{typeof(op)})`](@ref): defaults to `true`
+- [`has_random_offdiagonal(::Type{typeof(op)})`](@ref): defaults to `false`. If this set to
+  `true`, the method [`random_offdiagonal(column)`](@ref) needs to be
   implemented.
 
 ## Alternative Interface (deprecated)
@@ -176,7 +176,7 @@ For available implementations see [`Hamiltonians`](@ref Main.Hamiltonians).
 
 Mandatory methods to implement:
 
-* [`starting_address(::AbstractHamiltonian)`](@ref)
+* [`starting_address(op::AbstractHamiltonian)`](@ref)
 * [`operator_column(op, address)`](@ref) returns an `AbstractOperatorColumn`
 * [`diagonal_element(column)`](@ref)
 * [`num_offdiagonals(column)`](@ref) (this can be an upper bound)
@@ -185,9 +185,9 @@ Mandatory methods to implement:
 
 Optional additional methods to implement:
 
-* [`LOStructure(::Type{typeof(lo)})`](@ref LOStructure): defaults to `AdjointUnknown`
-* [`RandomOffdiagonalTrait(op)`](@ref): defaults to `HasRandomOffdiagonal()`.
-* [`IterableOffdiagonalsTrait(op)`](@ref): defaults to `HasIterableOffdiagonals()`.
+* [`LOStructure(::Type{typeof(op)})`](@ref LOStructure): defaults to `AdjointUnknown`
+* [`has_random_offdiagonal(::Type{typeof(op)})`](@ref): defaults to `true`.
+* [`has_iterable_offdiagonals(::Type{typeof(op)})`](@ref): defaults to `true`.
 * [`dimension(::AbstractHamiltonian, addr)`](@ref Main.Hamiltonians.dimension): defaults to
   dimension of address space
 * [`allows_address_type(h::AbstractHamiltonian, type)`](@ref): defaults to
@@ -199,7 +199,7 @@ Optional additional methods to implement:
 * [`starting_address(::AbstractHamiltonian)`](@ref)
 * [`diagonal_element(op, address)`](@ref)
 * [`num_offdiagonals(op, address)`](@ref) and
-* [`get_offdiagonal(op, address, chosen)`](@ref) or [`offdiagonals`](@ref)
+* [`get_offdiagonal(op, address, chosen)`](@ref) or [`offdiagonals(op, address)`](@ref)
 
 Provides the following functions and methods:
 
@@ -496,9 +496,9 @@ by `ham`. Alternatively, pass as argument a column `operator_column(ham, address
 Part of the [`AbstractHamiltonian`](@ref) interface.
 """
 function random_offdiagonal(::AbstractOperatorColumn{A,T,O}) where {A,T,O}
-    if RandomOffdiagonalTrait(O) isa HasRandomOffdiagonal
+    if has_random_offdiagonal(O)
         error("random_offdiagonal not implemented for operator type $O " *
-                         "even though RandomOffdiagonalTrait($O) isa HasRandomOffdiagonal")
+                         "even though has_random_offdiagonal($O) == true")
     else
         throw(ArgumentError("random_offdiagonal not supported for operator type $O"))
     end
@@ -517,13 +517,10 @@ function random_offdiagonal(ham, address)
 end
 
 """
-    IterableOffdiagonalsTrait(operatortype::Type) -> IterableOffdiagonalsTrait
+    has_iterable_offdiagonals(operatortype::Type)::Bool
 
-Return a trait that indicates whether the operator's columns have iterable
-[`offdiagonals`](@ref). One of the following values will be returned:
-- [`NoIterableOffdiagonals()`](@ref): no iterable `offdiagonals` are available.
-- [`HasIterableOffdiagonals()`](@ref): `offdiagonals(column)` returns an iterable
-  object.
+Return `true` if the operator's columns have iterable
+[`offdiagonals`](@ref).
 
 ## Example
 ```jldoctest
@@ -531,49 +528,26 @@ julia> using Rimu.Interfaces
 
 julia> h = HubbardReal1D(BoseFS(1,2,3));
 
-julia> IterableOffdiagonalsTrait(typeof(h)) isa HasIterableOffdiagonals
+julia> has_iterable_offdiagonals(typeof(h))
 true
 ```
 
 When extending the interface, implement a method for
-`IterableOffdiagonalsTrait(::Type{<:MyNewOperator})`.
+`has_iterable_offdiagonals(::Type{<:MyNewOperator})`.
 
 Part of the [`AbstractHamiltonian`](@ref) interface.
 """
-abstract type IterableOffdiagonalsTrait end
-
-"""
-    NoIterableOffdiagonals() <: IterableOffdiagonalsTrait
-`NoIterableOffdiagonals` is a trait that indicates that the operator's columns do not have
-iterable `offdiagonals`. This means that the `offdiagonals(column)` function returns an
-error when called on the operator's column.
-
-See also [`IterableOffdiagonalsTrait`](@ref Main.Interfaces.IterableOffdiagonalsTrait).
-"""
-struct NoIterableOffdiagonals <: IterableOffdiagonalsTrait end
-
-"""
-    HasIterableOffdiagonals() <: IterableOffdiagonalsTrait
-`HasIterableOffdiagonals` is a trait that indicates that the operator's columns have
-iterable `offdiagonals`. This means that the `offdiagonals(column)` function returns an
-iterable object when called on the operator's column.
-
-See also [`IterableOffdiagonalsTrait`](@ref Main.Interfaces.IterableOffdiagonalsTrait).
-"""
-struct HasIterableOffdiagonals <: IterableOffdiagonalsTrait end
+has_iterable_offdiagonals(op::AbstractObservable) = has_iterable_offdiagonals(type(op))
 
 # default traits for operators and observables
-IterableOffdiagonalsTrait(::Type{<:AbstractOperator}) = HasIterableOffdiagonals()
-IterableOffdiagonalsTrait(::Type{<:AbstractObservable}) = NoIterableOffdiagonals()
+has_iterable_offdiagonals(::Type{<:AbstractOperator}) = true
+has_iterable_offdiagonals(::Type{<:AbstractObservable}) = false
 
 """
-    RandomOffdiagonalTrait(operatortype::Type) -> RandomOffdiagonalTrait
-Return a trait that indicates whether the operator's columns have a
-[`random_offdiagonal`](@ref) method implemented. One of the following values will be
-returned:
+    has_random_offdiagonal(operatortype::Type)::Bool
 
-- [`NoRandomOffdiagonal()`](@ref): no `random_offdiagonal` method is implemented.
-- [`HasRandomOffdiagonal()`](@ref): `random_offdiagonal(column)` is implemented.
+Return `true` if the operator's columns have a
+[`random_offdiagonal`](@ref) method implemented.
 
 ## Example
 ```jldoctest
@@ -581,39 +555,17 @@ julia> using Rimu.Interfaces
 
 julia> h = HubbardReal1D(BoseFS(1,2,3));
 
-julia> RandomOffdiagonalTrait(typeof(h)) isa HasRandomOffdiagonal
+julia> has_random_offdiagonal(typeof(h))
 true
 ```
 
 When extending the interface, implement a method for
-`RandomOffdiagonalTrait(::Type{<:MyNewOperator})`.
+`Rimu.Interfaces.has_random_offdiagonal(::Type{<:MyNewOperator})`.
 
 Part of the [`AbstractHamiltonian`](@ref) interface.
 """
-abstract type RandomOffdiagonalTrait end
-
-"""
-    NoRandomOffdiagonal() <: RandomOffdiagonalTrait
-`NoRandomOffdiagonal` is a trait that indicates that the operator's columns do not have a
-`random_offdiagonal` method implemented. This means that the
-[`random_offdiagonal(column)`](@ref) function returns an error when called on the
-operator's column.
-
-See also [`RandomOffdiagonalTrait`](@ref Main.Interfaces.RandomOffdiagonalTrait).
-"""
-struct NoRandomOffdiagonal <: RandomOffdiagonalTrait end
-
-"""
-    HasRandomOffdiagonal() <: RandomOffdiagonalTrait
-`HasRandomOffdiagonal` is a trait that indicates that the operator's columns have a
-`random_offdiagonal` method implemented. This means that the
-[`random_offdiagonal(column)`](@ref) function returns a random off-diagonal element when
-called on the operator's column.
-
-See also [`RandomOffdiagonalTrait`](@ref Main.Interfaces.RandomOffdiagonalTrait).
-"""
-struct HasRandomOffdiagonal <: RandomOffdiagonalTrait end
+has_random_offdiagonal(op::AbstractObservable) = has_random_offdiagonal(type(op))
 
 # default traits for operators and observables
-RandomOffdiagonalTrait(::Type{<:AbstractHamiltonian}) = HasRandomOffdiagonal()
-RandomOffdiagonalTrait(::Type{<:AbstractObservable}) = NoRandomOffdiagonal()
+has_random_offdiagonal(::Type{<:AbstractHamiltonian}) = true
+has_random_offdiagonal(::Type{<:AbstractObservable}) = false

--- a/src/Interfaces/hamiltonians.jl
+++ b/src/Interfaces/hamiltonians.jl
@@ -486,10 +486,10 @@ HubbardReal1D(fs"|1 2 3⟩"; u=6.0, t=1.0) * fs"|1 2 3⟩"
 julia> operator_column(H, address) == column
 true
 
-julia> diagonal_element(column) == address * column
+julia> diagonal_element(column) == dot(address, column)
 true
 
-julia> fs"|1 3 2⟩" * column # an off-diagonal matrix element
+julia> fs"|1 3 2⟩" ⋅ column # an off-diagonal matrix element
 -3.0
 ```
 
@@ -500,14 +500,26 @@ Part of the [`AbstractHamiltonian`](@ref) interface. See also
 """
 operator_column(o, a) = OffdiagonalsOperatorColumn(o, a, offdiagonals(o,a),
     eltype(o)(diagonal_element(o,a)))
-Base.:*(o::AbstractOperator, a::AbstractFockAddress) = operator_column(o, a)
+function Base.:*(o::AbstractObservable, a::A) where {A<:Union{AbstractFockAddress,Integer}}
+    return operator_column(o, a)
+end
 
 starting_address(c::OffdiagonalsOperatorColumn) = c.address
 diagonal_element(c::OffdiagonalsOperatorColumn) = c.diagonal
 num_offdiagonals(c::OffdiagonalsOperatorColumn) = num_offdiagonals(c.operator, c.address)
 offdiagonals(c::OffdiagonalsOperatorColumn) = c.ods
 
-function Base.:*(a::A, column::AbstractOperatorColumn{A,T}) where {A<:AbstractFockAddress,T}
+"""
+    dot(a::AbstractFockAddress, column::AbstractOperatorColumn)
+
+Compute the matrix element of the operator `column` at address `a`.
+
+See also [`operator_column`](@ref), [`AbstractOperatorColumn`](@ref),
+[`AbstractFockAddress`](@ref).
+"""
+function LinearAlgebra.dot(
+    a::A, column::AbstractOperatorColumn{A,T}
+) where {A,T} # `A` is the (compatible) address type, `T` is the eltype
     if a == starting_address(column)
         return diagonal_element(column)::T
     else
@@ -518,6 +530,28 @@ function Base.:*(a::A, column::AbstractOperatorColumn{A,T}) where {A<:AbstractFo
         end
     end
     return zero(T)
+end
+
+function LinearAlgebra.dot(column::AbstractOperatorColumn, a)
+    return adjoint(LinearAlgebra.dot(a, column))
+end
+
+"""
+    dot(dv::AbstractDVec, column::AbstractOperatorColumn)
+
+Compute the dot product of the vector `dv` with the operator `column`.
+
+See also [`operator_column`](@ref), [`AbstractOperatorColumn`](@ref),
+and [`AbstractDVec`](@ref).
+"""
+function LinearAlgebra.dot(
+    dv::AbstractDVec{A}, column::AbstractOperatorColumn{A}
+) where {A} # `A` is the (compatible) address type
+    res = conj(dv[starting_address(column)]) * diagonal_element(column)
+    for (newaddress, matrixelement) in offdiagonals(column)
+        res += conj(dv[newaddress]) * matrixelement
+    end
+    return res
 end
 
 """

--- a/src/Interfaces/hamiltonians.jl
+++ b/src/Interfaces/hamiltonians.jl
@@ -492,22 +492,21 @@ function Base.:*(a::AbstractFockAddress, column::AbstractOperatorColumn{<:Any,T}
 end
 
 """
-    offdiagonals(column)
+    offdiagonals(column::AbstractOperatorColumn)
     offdiagonals(h::AbstractHamiltonian, address) # (deprecated)
 
 Return an iterator over nonzero off-diagonal matrix elements of `h` in the same column as
-`address`. Will iterate over pairs `(newaddress, matrixelement)` or `newaddress => matrixelement`.
+`address`. Will iterate over pairs `(newaddress, matrixelement)` or
+`newaddress => matrixelement`.
 
 # Example
 
 ```jldoctest
 julia> address = BoseFS(3,2,1);
 
-
 julia> H = HubbardReal1D(address);
 
-
-julia> h = offdiagonals(H, address)
+julia> h = offdiagonals(H * address)
 6-element Rimu.Hamiltonians.Offdiagonals{BoseFS{6, 3, BitString{8, 1, UInt8}}, Float64, HubbardReal1D{Float64, BoseFS{6, 3, BitString{8, 1, UInt8}}, 1.0, 1.0}}:
  (fs"|2 3 1⟩", -3.0)
  (fs"|2 2 2⟩", -2.449489742783178)
@@ -516,11 +515,8 @@ julia> h = offdiagonals(H, address)
  (fs"|4 2 0⟩", -2.0)
  (fs"|3 3 0⟩", -1.7320508075688772)
 ```
-Part of the [`AbstractHamiltonian`](@ref) interface.
-
-See also [`Offdiagonals`](@ref Main.Hamiltonians.Offdiagonals),
-[`AbstractOffdiagonals`](@ref Main.Hamiltonians.AbstractOffdiagonals).
-
+Part of the [`AbstractHamiltonian`](@ref) interface. See also
+[`AbstractOperatorColumn`](@ref) and [`operator_column`](@ref).
 """
 function offdiagonals(m::AbstractMatrix, i)
     pairs = collect(zip(axes(m, 1), view(m, :, i)))
@@ -538,15 +534,17 @@ function offdiagonals(::AbstractOperatorColumn{A,T,O}) where {A,T,O}
 end
 
 """
-    random_offdiagonal(column)
+    random_offdiagonal(column::AbstractOperatorColumn)
     random_offdiagonal(ham::AbstractHamiltonian, address) # deprecated
     -> newaddress, probability, matrixelement
 
 Generate a single random excitation, i.e. choose from one of the accessible off-diagonal
-elements in the column corresponding to `address` in the Hamiltonian matrix represented
-by `ham`. Alternatively, pass as argument a column `operator_column(ham, address)`.
+elements in the column `ham * address`.
+The result is a tuple of the new address `newaddress`, the probability of this excitation
+`probability`, and the matrix element `matrixelement` of the excitation.
 
-Part of the [`AbstractHamiltonian`](@ref) interface.
+Part of the [`AbstractHamiltonian`](@ref) interface. See also
+[`AbstractOperatorColumn`](@ref) and [`operator_column`](@ref).
 """
 function random_offdiagonal(::AbstractOperatorColumn{A,T,O}) where {A,T,O}
     if has_random_offdiagonal(O)
@@ -588,7 +586,8 @@ true
 When extending the interface, implement a method for
 `has_iterable_offdiagonals(::Type{<:MyNewOperator})`.
 
-Part of the [`AbstractHamiltonian`](@ref) interface.
+Part of the [`AbstractHamiltonian`](@ref) interface. See also
+[`AbstractOperatorColumn`](@ref) and [`operator_column`](@ref).
 """
 has_iterable_offdiagonals(op::AbstractObservable) = has_iterable_offdiagonals(typeof(op))
 has_iterable_offdiagonals(::AbstractOperatorColumn{A,T,O}) where {A,T,O} =
@@ -617,7 +616,8 @@ true
 When extending the interface, implement a method for
 `Rimu.Interfaces.has_random_offdiagonal(::Type{<:MyNewOperator})`.
 
-Part of the [`AbstractHamiltonian`](@ref) interface.
+Part of the [`AbstractHamiltonian`](@ref) interface. See also
+[`AbstractOperatorColumn`](@ref) and [`operator_column`](@ref).
 """
 has_random_offdiagonal(op::AbstractObservable) = has_random_offdiagonal(typeof(op))
 has_random_offdiagonal(::AbstractOperatorColumn{A,T,O}) where {A,T,O} =

--- a/src/Interfaces/hamiltonians.jl
+++ b/src/Interfaces/hamiltonians.jl
@@ -183,7 +183,7 @@ Mandatory methods to implement:
 * [`operator_column(op, address)`](@ref) returns an [`AbstractOperatorColumn`](@ref)
 
 [`AbstractOperatorColumn`](@ref) has its own interface methods:
-* [`column_operator(column)`](@ref) returns the operator of the column
+* [`parent_operator(column)`](@ref) returns the operator of the column
 * [`diagonal_element(column)`](@ref) returns the diagonal element of the column
 * [`num_offdiagonals(column)`](@ref) (this can be an upper bound) returns the number of
     off-diagonal elements in the column
@@ -406,7 +406,7 @@ The default constructor for `AbstractOperatorColumn` is
 `operator_column(operator, address)`. The interface for `AbstractOperatorColumn` is defined
 by the following functions:
 
-* [`column_operator(c::AbstractOperatorColumn)`](@ref) - returns the `operator`,
+* [`parent_operator(c::AbstractOperatorColumn)`](@ref) - returns the `operator`,
 * [`starting_address(c::AbstractOperatorColumn)`](@ref) - returns the starting `address`,
 * [`diagonal_element(c::AbstractOperatorColumn)`](@ref) - returns the diagonal element of
     the column `c`, ``⟨α|Ĥ|α⟩``, where ``α`` is the starting address,
@@ -427,7 +427,7 @@ abstract type AbstractOperatorColumn{A,T,O} end
 
 function Base.show(io::IO, c::AbstractOperatorColumn{A,T,O}) where {A,T,O}
     io = IOContext(io, :compact => true)
-    show(io, column_operator(c))
+    show(io, parent_operator(c))
     print(io, " * ", starting_address(c))
 end
 
@@ -447,14 +447,14 @@ struct OffdiagonalsOperatorColumn{A,T,O<:AbstractOperator{T},OD} <: AbstractOper
 end
 
 """
-    column_operator(c::AbstractOperatorColumn)
+    parent_operator(c::AbstractOperatorColumn)
 Return the operator of the column `c`.  This is the operator that was used to
 construct the column with [`operator_column`](@ref).
 
 Part of the [`AbstractHamiltonian`](@ref) and [`AbstractOperator`](@ref) interface.
 See also [`AbstractOperatorColumn`](@ref) and [`operator_column`](@ref).
 """
-column_operator(c::OffdiagonalsOperatorColumn) = c.operator
+parent_operator(c::OffdiagonalsOperatorColumn) = c.operator
 
 """
     operator_column(operator::AbstractOperator, address) -> column <: AbstractOperatorColumn
@@ -495,7 +495,7 @@ DVec{BoseFS{1, 3, BitString{3, 1, UInt8}},Float64} with 3 entries, style = IsDet
 ```
 
 Part of the [`AbstractHamiltonian`](@ref) interface. See also
-[`AbstractOperatorColumn`](@ref), [`column_operator`](@ref), [`starting_address`](@ref),
+[`AbstractOperatorColumn`](@ref), [`parent_operator`](@ref), [`starting_address`](@ref),
 [`diagonal_element`](@ref), [`offdiagonals`](@ref), [`num_offdiagonals`](@ref),
 [`random_offdiagonal`](@ref).
 """

--- a/src/Interfaces/hamiltonians.jl
+++ b/src/Interfaces/hamiltonians.jl
@@ -27,6 +27,8 @@ Basic interface methods to implement:
 Optional additional methods to implement:
 - [`VectorInterface.scalartype(op)`](@ref): defaults to `eltype(eltype(op))`
 - [`LOStructure(::Type{typeof(op)})`](@ref LOStructure): defaults to `AdjointUnknown`
+- [`RandomOffdiagonalTrait(op)`](@ref): defaults to `NoRandomOffdiagonal()`
+- [`IterableOffdiagonalsTrait(op)`](@ref): defaults to `NoIterableOffdiagonals()`
 
 See also [`AbstractOperator`](@ref), [`AbstractHamiltonian`](@ref), [`Interfaces`](@ref).
 """
@@ -76,7 +78,7 @@ as observable operators in a [`ReplicaStrategy`](@ref Rimu.ReplicaStrategy), e.g
 defining correlation functions. In contrast to [`AbstractHamiltonian`](@ref)s,
 `AbstractOperator`s do not need to have a [`starting_address`](@ref). Moreover, the
 `eltype` of an `AbstractOperator` can be a vector value whereas
-[`AbstractHamiltonian`](@ref)s requre a scalar `eltype`.
+[`AbstractHamiltonian`](@ref)s require a scalar `eltype`.
 
     AbstractHamiltonian{T} <: AbstractOperator{T} <: AbstractObservable{T}
 
@@ -90,28 +92,33 @@ implement a Hamiltonian for use in [`ProjectorMonteCarloProblem`](@ref) or
 
 # Interface
 
-There are two options for which methods need to be implemented.
-
-If the number of non-zero matrix elements that can be reached from any address is known,
-and they can be separately generated:
-- [`allows_address_type(op, type)`](@ref)
-- [`diagonal_element(op, address)`](@ref)
-- [`num_offdiagonals(op, address)`](@ref) and
-- [`get_offdiagonal(op, address, chosen)`](@ref) or [`offdiagonals`](@ref)
-
-Alternatively, if the generation of matrix elements is more complicated:
+Mandatory methods to implement:
 - [`allows_address_type(op, type)`](@ref)
 - [`operator_column(op, address)`](@ref)
 - [`diagonal_element(column)`](@ref)
 - [`num_offdiagonals(column)`](@ref) (this can be an upper bound)
-- [`offdiagonals(column)`](@ref)
-- [`random_offdiagonal(column)`](@ref)
+- [`offdiagonals(column)`](@ref) required for deterministic operations, see
+    [`IterableOffdiagonalsTrait(op)`](@ref) below
 
 Optional additional methods to implement:
 - [`VectorInterface.scalartype(op)`](@ref): defaults to `eltype(eltype(op))`
 - [`LOStructure(::Type{typeof(op)})`](@ref LOStructure): defaults to `AdjointUnknown`
 - [`dimension(op, addr)`](@ref Main.Hamiltonians.dimension): defaults to dimension of
   address space
+- [`IterableOffdiagonalsTrait(op)`](@ref): defaults to `HasIterableOffdiagonals()`
+- [`RandomOffdiagonalTrait(op)`](@ref): defaults to `NoRandomOffdiagonal()`. If this set to
+  `HasRandomOffdiagonal()`, the method [`random_offdiagonal(column)`](@ref) needs to be
+  implemented.
+
+## Alternative Interface (deprecated)
+
+If the number of non-zero matrix elements that can be reached from any address is known,
+and they can be separately generated:
+- [`allows_address_type(op, type)`](@ref)
+- [`diagonal_element(op, address)`](@ref)
+- [`num_offdiagonals(op, address)`](@ref) and
+- [`get_offdiagonal(op, address, chosen)`](@ref) or [`offdiagonals`](@ref) returning an
+    `AbstractVector` object.
 
 In order to calculate observables efficiently, it may make sense to implement custom methods
 for [`Interfaces.dot_from_right(x, op, y)`](@ref) and [`LinearAlgebra.mul!(y, op, x)`](@ref).
@@ -167,31 +174,32 @@ For available implementations see [`Hamiltonians`](@ref Main.Hamiltonians).
 
 # Interface
 
-There are two options for which methods need to be implemented.
+Mandatory methods to implement:
 
-If the number of non-zero matrix elements that can be reached from any address is known,
-and they can be separately generated:
 * [`starting_address(::AbstractHamiltonian)`](@ref)
-* [`diagonal_element(op, address)`](@ref)
-* [`num_offdiagonals(op, address)`](@ref) and
-* [`get_offdiagonal(op, address, chosen)`](@ref) or [`offdiagonals`](@ref)
-
-Alternatively, if the generation of matrix elements is more complicated:
-* [`starting_address(::AbstractHamiltonian)`](@ref)
-* [`operator_column(op, address)`](@ref)
+* [`operator_column(op, address)`](@ref) returns an `AbstractOperatorColumn`
 * [`diagonal_element(column)`](@ref)
 * [`num_offdiagonals(column)`](@ref) (this can be an upper bound)
-* [`offdiagonals(column)`](@ref)
+* [`offdiagonals(column)`](@ref) returns an iterator
 * [`random_offdiagonal(column)`](@ref)
 
 Optional additional methods to implement:
 
 * [`LOStructure(::Type{typeof(lo)})`](@ref LOStructure): defaults to `AdjointUnknown`
+* [`RandomOffdiagonalTrait(op)`](@ref): defaults to `HasRandomOffdiagonal()`.
+* [`IterableOffdiagonalsTrait(op)`](@ref): defaults to `HasIterableOffdiagonals()`.
 * [`dimension(::AbstractHamiltonian, addr)`](@ref Main.Hamiltonians.dimension): defaults to
   dimension of address space
 * [`allows_address_type(h::AbstractHamiltonian, type)`](@ref): defaults to
   `type :< typeof(starting_address(h))`
 * [`momentum(::AbstractHamiltonian)`](@ref Main.Hamiltonians.momentum): no default
+
+## Alternative Interface (deprecated)
+
+* [`starting_address(::AbstractHamiltonian)`](@ref)
+* [`diagonal_element(op, address)`](@ref)
+* [`num_offdiagonals(op, address)`](@ref) and
+* [`get_offdiagonal(op, address, chosen)`](@ref) or [`offdiagonals`](@ref)
 
 Provides the following functions and methods:
 
@@ -554,8 +562,9 @@ See also [`IterableOffdiagonalsTrait`](@ref Main.Interfaces.IterableOffdiagonals
 """
 struct HasIterableOffdiagonals <: IterableOffdiagonalsTrait end
 
-IterableOffdiagonalsTrait(::Type{<:AbstractObservable}) = HasIterableOffdiagonals()
-# default trait for observables
+# default traits for operators and observables
+IterableOffdiagonalsTrait(::Type{<:AbstractOperator}) = HasIterableOffdiagonals()
+IterableOffdiagonalsTrait(::Type{<:AbstractObservable}) = NoIterableOffdiagonals()
 
 """
     RandomOffdiagonalTrait(operatortype::Type) -> RandomOffdiagonalTrait
@@ -605,5 +614,6 @@ See also [`RandomOffdiagonalTrait`](@ref Main.Interfaces.RandomOffdiagonalTrait)
 """
 struct HasRandomOffdiagonal <: RandomOffdiagonalTrait end
 
-RandomOffdiagonalTrait(::Type{<:AbstractObservable}) = HasRandomOffdiagonal()
-# default trait for observables
+# default traits for operators and observables
+RandomOffdiagonalTrait(::Type{<:AbstractHamiltonian}) = HasRandomOffdiagonal()
+RandomOffdiagonalTrait(::Type{<:AbstractObservable}) = NoRandomOffdiagonal()

--- a/src/Interfaces/hamiltonians.jl
+++ b/src/Interfaces/hamiltonians.jl
@@ -471,7 +471,7 @@ Part of the [`AbstractHamiltonian`](@ref) interface. See also [`AbstractOperator
 """
 operator_column(o, a) = OffdiagonalsOperatorColumn(o, a, offdiagonals(o,a), eltype(o)(diagonal_element(o,a)))
 
-starting_address(c::AbstractOperatorColumn) = c.address
+starting_address(c::OffdiagonalsOperatorColumn) = c.address
 diagonal_element(c::OffdiagonalsOperatorColumn) = c.diagonal
 num_offdiagonals(c::OffdiagonalsOperatorColumn) = num_offdiagonals(c.operator, c.address)
 offdiagonals(c::OffdiagonalsOperatorColumn) = c.ods
@@ -487,7 +487,16 @@ by `ham`. Alternatively, pass as argument a column `operator_column(ham, address
 
 Part of the [`AbstractHamiltonian`](@ref) interface.
 """
-function random_offdiagonal(column::AbstractOperatorColumn)
+function random_offdiagonal(::AbstractOperatorColumn{A,T,O}) where {A,T,O}
+    if RandomOffdiagonalTrait(O) isa HasRandomOffdiagonal
+        error("random_offdiagonal not implemented for operator type $O " *
+                         "even though RandomOffdiagonalTrait($O) isa HasRandomOffdiagonal")
+    else
+        throw(ArgumentError("random_offdiagonal not supported for operator type $O"))
+    end
+end
+
+function random_offdiagonal(column::OffdiagonalsOperatorColumn)
     offdiags = offdiagonals(column)
     nl = length(offdiags) # check how many sites we could reach
     chosen = rand(1:nl) # choose one of them

--- a/src/Interfaces/hamiltonians.jl
+++ b/src/Interfaces/hamiltonians.jl
@@ -412,7 +412,7 @@ end
 
 """
     operator_column(operator::AbstractOperator, address) -> column <: AbstractOperatorColumn
-    *(o::AbstractOperator, a::AbstractFockAddress)
+    *(o::AbstractOperator, a::AbstractFockAddress) -> column
 
 Return an object representing the column of `operator` given by `address`. In quantum
 notation, the `column` represents the object
@@ -434,11 +434,33 @@ A `column` can be accessed with the following functions:
 * [`random_offdiagonal(column)`](@ref) - returns a random off-diagonal element in the
   `column`.
 
-Methods for these functions need to be implemented for a new type of `AbstractOperator`.
-Implementing [`random_offdiagonal(column)`](@ref) is optional if `offdiagonals(column)`
-returns an `AbstractVector`.
+Methods for these functions need to be implemented for a new type of
+[`AbstractOperator`](@ref). Implementing [`random_offdiagonal(column)`](@ref) is optional
+if [`offdiagonals(column)`](@ref) returns an `AbstractVector`.
 
-Part of the [`AbstractHamiltonian`](@ref) interface. See also [`AbstractOperatorColumn`](@ref).
+# Example
+```jldoctest
+julia> address = BoseFS(1,2,3);
+
+julia> H = HubbardRealSpace(address);
+
+julia> column = operator_column(H, address);
+
+julia> H * address == column
+true
+
+julia> num_offdiagonals(column)
+6
+
+julia> diagonal_element(column) == address * column
+true
+
+julia> fs"|1 3 2⟩" * column
+-3.0
+```
+
+Part of the [`AbstractHamiltonian`](@ref) interface. See also
+[`AbstractOperatorColumn`](@ref).
 """
 operator_column(o, a) = OffdiagonalsOperatorColumn(o, a, offdiagonals(o,a),
     eltype(o)(diagonal_element(o,a)))
@@ -448,6 +470,19 @@ starting_address(c::OffdiagonalsOperatorColumn) = c.address
 diagonal_element(c::OffdiagonalsOperatorColumn) = c.diagonal
 num_offdiagonals(c::OffdiagonalsOperatorColumn) = num_offdiagonals(c.operator, c.address)
 offdiagonals(c::OffdiagonalsOperatorColumn) = c.ods
+
+function Base.:*(a::AbstractFockAddress, column::AbstractOperatorColumn{<:Any,T}) where {T}
+    if a == starting_address(column)
+        return diagonal_element(column)::T
+    else
+        for (newaddress, matrixelement) in offdiagonals(column)
+            if newaddress == a
+                return matrixelement::T
+            end
+        end
+    end
+    return zero(T)
+end
 
 """
     offdiagonals(column)

--- a/src/Interfaces/hamiltonians.jl
+++ b/src/Interfaces/hamiltonians.jl
@@ -180,7 +180,7 @@ For available implementations see [`Hamiltonians`](@ref Main.Hamiltonians).
 Mandatory methods to implement:
 
 * [`starting_address(op::AbstractHamiltonian)`](@ref)
-* [`operator_column(op, address)`](@ref) returns an `AbstractOperatorColumn`
+* [`operator_column(op, address)`](@ref) returns an [`AbstractOperatorColumn`](@ref)
 * [`diagonal_element(column)`](@ref)
 * [`num_offdiagonals(column)`](@ref) (this can be an upper bound)
 * [`offdiagonals(column)`](@ref) returns an iterator
@@ -208,25 +208,22 @@ Optional additional methods to implement:
 
 Provides the following functions and methods:
 
-* [`offdiagonals`](@ref): iterator over reachable off-diagonal matrix elements
-* [`random_offdiagonal`](@ref): function to generate random off-diagonal matrix element
+* [`ProjectorMonteCarloProblem(H)`](@ref Main.ProjectorMonteCarloProblem):
+  use this Hamiltonian for FCIQMC
+* [`ExactDiagonalizationProblem(H)`](@ref Main.ExactDiagonalizationProblem):
+  use this Hamiltonian for exact diagonalization
 * `*(H, v)`: deterministic matrix-vector multiply (allocating)
 * `H(v)`: equivalent to `H * v`.
 * `mul!(w, H, v)`: mutating matrix-vector multiply.
 * [`dot(x, H, v)`](@ref Main.Hamiltonians.dot): compute `x⋅(H*v)` minimizing allocations.
 * `H[address1, address2]`: indexing with `getindex()` - mostly for testing purposes (slow!)
 * [`BasisSetRepresentation`](@ref Main.ExactDiagonalization.BasisSetRepresentation):
-  construct a basis set repesentation
+  construct a basis set representation
 * [`sparse`](@ref Main.ExactDiagonalization.sparse), [`Matrix`](@ref): construct a (sparse)
   matrix representation
 
-Alternatively to the above, [`offdiagonals`](@ref) can be implemented instead of
-[`get_offdiagonal`](@ref). Sometimes this can be done efficiently. In this case
-[`num_offdiagonals`](@ref) should provide an upper bound on the number of elements obtained
-when iterating [`offdiagonals`](@ref).
-
 See also [`Hamiltonians`](@ref Main.Hamiltonians), [`Interfaces`](@ref),
-[`AbstractOperator`](@ref), [`AbstractObservable`](@ref).
+[`AbstractOperatorColumn`](@ref), [`AbstractOperator`](@ref), [`AbstractObservable`](@ref).
 """
 abstract type AbstractHamiltonian{T} <: AbstractOperator{T} end
 
@@ -249,7 +246,7 @@ function allows_address_type(op, address)
 end
 
 """
-    diagonal_element(column)
+    diagonal_element(column::AbstractOperatorColumn)
     diagonal_element(ham, address) # (deprecated)
 
 Compute the diagonal matrix element of the linear operator `ham` at
@@ -258,21 +255,20 @@ address `address`, where `column = operator_column(ham, address)`.
 # Example
 
 ```jldoctest
-julia> address = BoseFS((3, 2, 1));
+julia> H = HubbardMom1D(BoseFS(3, 2, 1));
 
+julia> column = operator_column(H, starting_address(H));
 
-julia> H = HubbardMom1D(address);
-
-
-julia> diagonal_element(H, address)
+julia> diagonal_element(column)
 8.666666666666664
 ```
-Part of the [`AbstractHamiltonian`](@ref) interface.
+Part of the [`AbstractHamiltonian`](@ref) interface. See also
+[`AbstractOperatorColumn`](@ref) and [`operator_column`](@ref).
 """
 diagonal_element(m::AbstractMatrix, i) = m[i, i]
 
 """
-    num_offdiagonals(column)
+    num_offdiagonals(column::AbstractOperatorColumn)
     num_offdiagonals(ham, address) # (deprecated)
 
 Compute the number of number of reachable configurations from address `address`,
@@ -281,21 +277,20 @@ where `column = operator_column(ham, address)`. If necessary, this may be an upp
 # Example
 
 ```jldoctest
-julia> address = BoseFS((3, 2, 1));
+julia> H = HubbardMom1D(BoseFS(3, 2, 1));
 
+julia> column = operator_column(H, starting_address(H));
 
-julia> H = HubbardMom1D(address);
-
-
-julia> num_offdiagonals(H, address)
+julia> num_offdiagonals(column)
 10
 ```
-Part of the [`AbstractHamiltonian`](@ref) interface.
+Part of the [`AbstractHamiltonian`](@ref) interface. See also
+[`AbstractOperatorColumn`](@ref) and [`operator_column`](@ref).
 """
 num_offdiagonals(m::AbstractMatrix, i) = length(offdiagonals(m, i))
 
 """
-    newadd, me = get_offdiagonal(ham, address, chosen)
+    newadd, me = get_offdiagonal(ham, address, chosen) # (deprecated)
 
 Compute value `me` and new address `newadd` of a single (off-diagonal) matrix element in a
 Hamiltonian `ham`. The off-diagonal element is in the same column as address `address` and is
@@ -316,26 +311,25 @@ Part of the [`AbstractHamiltonian`](@ref) interface.
 get_offdiagonal(m::AbstractMatrix, i, n) = offdiagonals(m, i)[n]
 
 """
-    starting_address(h)
-    starting_address(column)
+    starting_address(h::AbstractHamiltonian)
+    starting_address(column::AbstractOperatorColumn)
 
-Return the starting address for Hamiltonian `h`, or for `AbstractOperatorColumn` `column`. When
-called on an `AbstractMatrix`, `starting_address` returns the index of the lowest diagonal
-element.
+Return the starting address for the Hamiltonian `h`, or for the `column`. When
+called on an `AbstractMatrix`, `starting_address` returns the index of the diagonal
+element with the smallest real part.
 
 # Example
 
 ```jldoctest
 julia> address = BoseFS((3, 2, 1));
 
-
 julia> H = HubbardMom1D(address);
-
 
 julia> address == starting_address(H)
 true
 ```
-Part of the [`AbstractHamiltonian`](@ref) interface.
+Part of the [`AbstractHamiltonian`](@ref) interface. See also
+[`AbstractOperatorColumn`](@ref).
 """
 starting_address(m::AbstractMatrix) = findmin(real.(diag(m)))[2]
 
@@ -404,7 +398,8 @@ abstract type AbstractOperatorColumn{A,T,O} end
 """
     OffdiagonalsOperatorColumn <: AbstractOperatorColumn
 
-Default column, using [`offdiagonals(op, address)`](@ref) and [`diagonal_element(op, address)`](@ref).
+Default column, using the deprecated interface with [`offdiagonals(op, address)`](@ref) and
+[`diagonal_element(op, address)`](@ref).
 
 See also [`operator_column`](@ref).
 """
@@ -417,6 +412,7 @@ end
 
 """
     operator_column(operator::AbstractOperator, address) -> column <: AbstractOperatorColumn
+    *(o::AbstractOperator, a::AbstractFockAddress)
 
 Return an object representing the column of `operator` given by `address`. In quantum
 notation, the `column` represents the object
@@ -444,7 +440,9 @@ returns an `AbstractVector`.
 
 Part of the [`AbstractHamiltonian`](@ref) interface. See also [`AbstractOperatorColumn`](@ref).
 """
-operator_column(o, a) = OffdiagonalsOperatorColumn(o, a, offdiagonals(o,a), eltype(o)(diagonal_element(o,a)))
+operator_column(o, a) = OffdiagonalsOperatorColumn(o, a, offdiagonals(o,a),
+    eltype(o)(diagonal_element(o,a)))
+Base.:*(o::AbstractOperator, a::AbstractFockAddress) = operator_column(o, a)
 
 starting_address(c::OffdiagonalsOperatorColumn) = c.address
 diagonal_element(c::OffdiagonalsOperatorColumn) = c.diagonal

--- a/src/Interfaces/hamiltonians.jl
+++ b/src/Interfaces/hamiltonians.jl
@@ -469,7 +469,8 @@ notation, the `column` represents the object
     Ĥ|α⟩ = ∑ᵦ|β⟩⟨β|Ĥ|α⟩,
 ```
 where ``α`` is the  `address` and ``β`` represents all reachable addresses with nonzero
-matrix element ``⟨β|Ĥ|α⟩`` of the `operator` ``Ĥ``.
+matrix element ``⟨β|Ĥ|α⟩`` of the `operator` ``Ĥ``. Columns iterate over pairs
+`address => matrix_element`.
 
 For more information and the definition of an interface see
 [`AbstractOperatorColumn`](@ref).
@@ -486,7 +487,7 @@ HubbardReal1D(fs"|0 1 0⟩"; u=6.0, t=1.0) * fs"|0 1 0⟩"
 julia> operator_column(H, address) == column
 true
 
-julia> diagonal_element(column) == dot(address, column) # access elements with `dot()`
+julia> diagonal_element(column) == column[address] # access elements with `getindex`
 true
 
 julia> DVec(column) # materialise as a `DVec`
@@ -513,15 +514,14 @@ num_offdiagonals(c::OffdiagonalsOperatorColumn) = num_offdiagonals(c.operator, c
 offdiagonals(c::OffdiagonalsOperatorColumn) = c.ods
 
 """
-    dot(a::AbstractFockAddress, column::AbstractOperatorColumn)
+    getindex(column::AbstractOperatorColumn, address)
 
-Compute the matrix element of the operator `column` at address `a`.
+Return the matrix element of the operator column `column` at `address`.
 
-See also [`operator_column`](@ref), [`AbstractOperatorColumn`](@ref),
-[`AbstractFockAddress`](@ref).
+See also [`operator_column`](@ref), [`AbstractOperatorColumn`](@ref).
 """
-function LinearAlgebra.dot(
-    a::A, column::AbstractOperatorColumn{A,T}
+function Base.getindex(
+    column::AbstractOperatorColumn{A,T}, a::A
 ) where {A,T} # `A` is the (compatible) address type, `T` is the eltype
     if a == starting_address(column)
         return diagonal_element(column)::T
@@ -535,14 +535,10 @@ function LinearAlgebra.dot(
     return zero(T)
 end
 
-function LinearAlgebra.dot(column::AbstractOperatorColumn, a)
-    return adjoint(LinearAlgebra.dot(a, column))
-end
-
 """
     dot(dv, column::AbstractOperatorColumn)
 
-Compute the dot product of the vector `dv` with the operator `column`.
+Compute the dot product of the vector `dv` with the operator column `column`.
 
 See also [`operator_column`](@ref), [`AbstractOperatorColumn`](@ref),
 and [`AbstractDVec`](@ref).
@@ -555,6 +551,9 @@ function LinearAlgebra.dot(
         res += conj(dv[newaddress]) * matrixelement
     end
     return res
+end
+function LinearAlgebra.dot(column::AbstractOperatorColumn, a)
+    return adjoint(LinearAlgebra.dot(a, column))
 end
 
 """

--- a/src/Interfaces/hamiltonians.jl
+++ b/src/Interfaces/hamiltonians.jl
@@ -450,7 +450,8 @@ julia> address = BoseFS(1,2,3);
 
 julia> H = HubbardRealSpace(address);
 
-julia> column = operator_column(H, address);
+julia> column = operator_column(H, address)
+OffdiagonalsOperatorColumn{BoseFS{…}, Float64, HubbardRealSpace{…}}(fs"|1 2 3⟩", …)
 
 julia> H * address == column
 true

--- a/src/Interfaces/hamiltonians.jl
+++ b/src/Interfaces/hamiltonians.jl
@@ -339,52 +339,6 @@ Part of the [`AbstractHamiltonian`](@ref) interface.
 """
 starting_address(m::AbstractMatrix) = findmin(real.(diag(m)))[2]
 
-"""
-    offdiagonals(column)
-    offdiagonals(h::AbstractHamiltonian, address) # (deprecated)
-
-Return an iterator over nonzero off-diagonal matrix elements of `h` in the same column as
-`address`. Will iterate over pairs `(newaddress, matrixelement)` or `newaddress => matrixelement`.
-
-# Example
-
-```jldoctest
-julia> address = BoseFS(3,2,1);
-
-
-julia> H = HubbardReal1D(address);
-
-
-julia> h = offdiagonals(H, address)
-6-element Rimu.Hamiltonians.Offdiagonals{BoseFS{6, 3, BitString{8, 1, UInt8}}, Float64, HubbardReal1D{Float64, BoseFS{6, 3, BitString{8, 1, UInt8}}, 1.0, 1.0}}:
- (fs"|2 3 1⟩", -3.0)
- (fs"|2 2 2⟩", -2.449489742783178)
- (fs"|3 1 2⟩", -2.0)
- (fs"|4 1 1⟩", -2.8284271247461903)
- (fs"|4 2 0⟩", -2.0)
- (fs"|3 3 0⟩", -1.7320508075688772)
-```
-Part of the [`AbstractHamiltonian`](@ref) interface.
-
-See also [`Offdiagonals`](@ref Main.Hamiltonians.Offdiagonals),
-[`AbstractOffdiagonals`](@ref Main.Hamiltonians.AbstractOffdiagonals).
-
-"""
-function offdiagonals(m::AbstractMatrix, i)
-    pairs = collect(zip(axes(m, 1), view(m, :, i)))
-    return filter!(pairs) do ((k, v))
-        k ≠ i && v ≠ 0
-    end
-end
-function offdiagonals(::AbstractOperatorColumn{A,T,O}) where {A,T,O}
-    if has_iterable_offdiagonals(O)
-        error("offdiagonals not implemented for operator type $O " *
-              "even though has_iterable_offdiagonals($O) == true")
-    else
-        throw(ArgumentError("offdiagonals not supported for operator type $O"))
-    end
-end
-
 @doc """
     LOStructure(op::AbstractHamiltonian)
     LOStructure(typeof(op))
@@ -496,6 +450,52 @@ starting_address(c::OffdiagonalsOperatorColumn) = c.address
 diagonal_element(c::OffdiagonalsOperatorColumn) = c.diagonal
 num_offdiagonals(c::OffdiagonalsOperatorColumn) = num_offdiagonals(c.operator, c.address)
 offdiagonals(c::OffdiagonalsOperatorColumn) = c.ods
+
+"""
+    offdiagonals(column)
+    offdiagonals(h::AbstractHamiltonian, address) # (deprecated)
+
+Return an iterator over nonzero off-diagonal matrix elements of `h` in the same column as
+`address`. Will iterate over pairs `(newaddress, matrixelement)` or `newaddress => matrixelement`.
+
+# Example
+
+```jldoctest
+julia> address = BoseFS(3,2,1);
+
+
+julia> H = HubbardReal1D(address);
+
+
+julia> h = offdiagonals(H, address)
+6-element Rimu.Hamiltonians.Offdiagonals{BoseFS{6, 3, BitString{8, 1, UInt8}}, Float64, HubbardReal1D{Float64, BoseFS{6, 3, BitString{8, 1, UInt8}}, 1.0, 1.0}}:
+ (fs"|2 3 1⟩", -3.0)
+ (fs"|2 2 2⟩", -2.449489742783178)
+ (fs"|3 1 2⟩", -2.0)
+ (fs"|4 1 1⟩", -2.8284271247461903)
+ (fs"|4 2 0⟩", -2.0)
+ (fs"|3 3 0⟩", -1.7320508075688772)
+```
+Part of the [`AbstractHamiltonian`](@ref) interface.
+
+See also [`Offdiagonals`](@ref Main.Hamiltonians.Offdiagonals),
+[`AbstractOffdiagonals`](@ref Main.Hamiltonians.AbstractOffdiagonals).
+
+"""
+function offdiagonals(m::AbstractMatrix, i)
+    pairs = collect(zip(axes(m, 1), view(m, :, i)))
+    return filter!(pairs) do ((k, v))
+        k ≠ i && v ≠ 0
+    end
+end
+function offdiagonals(::AbstractOperatorColumn{A,T,O}) where {A,T,O}
+    if has_iterable_offdiagonals(O)
+        error("offdiagonals not implemented for operator type $O " *
+              "even though has_iterable_offdiagonals($O) == true")
+    else
+        throw(ArgumentError("offdiagonals not supported for operator type $O"))
+    end
+end
 
 """
     random_offdiagonal(column)

--- a/src/Interfaces/hamiltonians.jl
+++ b/src/Interfaces/hamiltonians.jl
@@ -27,8 +27,10 @@ Basic interface methods to implement:
 Optional additional methods to implement:
 - [`VectorInterface.scalartype(op)`](@ref): defaults to `eltype(eltype(op))`
 - [`LOStructure(::Type{typeof(op)})`](@ref LOStructure): defaults to `AdjointUnknown`
-- [`has_random_offdiagonal(::Type{typeof(op)})`](@ref): defaults to `false`
-- [`has_iterable_offdiagonals(::Type{typeof(op)})`](@ref): defaults to `false`
+- [`has_random_offdiagonal(::Type{typeof(op)})`](@ref has_random_offdiagonal): defaults to
+  `false`
+- [`has_iterable_offdiagonals(::Type{typeof(op)})`](@ref has_iterable_offdiagonals):
+  defaults to `false`
 
 See also [`AbstractOperator`](@ref), [`AbstractHamiltonian`](@ref), [`Interfaces`](@ref).
 """
@@ -105,10 +107,11 @@ Optional additional methods to implement:
 - [`LOStructure(::Type{typeof(op)})`](@ref LOStructure): defaults to `AdjointUnknown`
 - [`dimension(op, addr)`](@ref Main.Hamiltonians.dimension): defaults to dimension of
   address space
-- [`has_iterable_offdiagonals(::Type{typeof(op)})`](@ref): defaults to `true`
-- [`has_random_offdiagonal(::Type{typeof(op)})`](@ref): defaults to `false`. If this set to
-  `true`, the method [`random_offdiagonal(column)`](@ref) needs to be
-  implemented.
+- [`has_iterable_offdiagonals(::Type{typeof(op)})`](@ref has_iterable_offdiagonals):
+  defaults to `true`
+- [`has_random_offdiagonal(::Type{typeof(op)})`](@ref has_random_offdiagonal): defaults to
+  `false`. If this set to `true`, the method [`random_offdiagonal(column)`](@ref) needs to
+  be implemented.
 
 ## Alternative Interface (deprecated)
 
@@ -186,8 +189,10 @@ Mandatory methods to implement:
 Optional additional methods to implement:
 
 * [`LOStructure(::Type{typeof(op)})`](@ref LOStructure): defaults to `AdjointUnknown`
-* [`has_random_offdiagonal(::Type{typeof(op)})`](@ref): defaults to `true`.
-* [`has_iterable_offdiagonals(::Type{typeof(op)})`](@ref): defaults to `true`.
+* [`has_random_offdiagonal(::Type{typeof(op)})`](@ref has_random_offdiagonal): defaults to
+  `true`.
+* [`has_iterable_offdiagonals(::Type{typeof(op)})`](@ref has_iterable_offdiagonals):
+  defaults to `true`.
 * [`dimension(::AbstractHamiltonian, addr)`](@ref Main.Hamiltonians.dimension): defaults to
   dimension of address space
 * [`allows_address_type(h::AbstractHamiltonian, type)`](@ref): defaults to

--- a/src/Interfaces/hamiltonians.jl
+++ b/src/Interfaces/hamiltonians.jl
@@ -418,7 +418,7 @@ has_adjoint(::LOStructure) = true
 """
     AbstractOperatorColumn{A,T,O}
 
-Abstract type for operator columns returned by [`operator_column`](@ref). 
+Abstract type for operator columns returned by [`operator_column`](@ref).
 The type parameters represent the address type (`A`), the eltype (`T`), and the
 type of the operator (`O`).
 
@@ -498,3 +498,35 @@ end
 function random_offdiagonal(ham, address)
     return random_offdiagonal(operator_column(ham, address))
 end
+
+"""
+    IterableOffdiagonalsTrait(operatortype::Type) -> IterableOffdiagonalsTrait
+
+Return a trait that indicates whether the operator's columns have iterable
+[`offdiagonals`](@ref). One of the following values will be returned:
+- [`NoIterableOffdiagonals()`](@ref): no iterable `offdiagonals` are available.
+- [`HasIterableOffdiagonals()`](@ref): `offdiagonals(column)` returns an iterable
+  object.
+
+## Example
+```jldoctest
+julia> using Rimu.Interfaces
+
+julia> h = HubbardReal1D(BoseFS(1,2,3));
+
+julia> IterableOffdiagonalsTrait(typeof(h)) isa HasIterableOffdiagonals
+true
+```
+
+When extending the interface, implement a method for
+`IterableOffdiagonalsTrait(::Type{<:MyNewOperator})`.
+
+Part of the [`AbstractHamiltonian`](@ref) interface.
+"""
+abstract type IterableOffdiagonalsTrait end
+
+struct NoIterableOffdiagonals <: IterableOffdiagonalsTrait end
+struct HasIterableOffdiagonals <: IterableOffdiagonalsTrait end
+
+IterableOffdiagonalsTrait(::Type{<:AbstractObservable}) = HasIterableOffdiagonals()
+# default trait for observables

--- a/src/Interfaces/hamiltonians.jl
+++ b/src/Interfaces/hamiltonians.jl
@@ -376,6 +376,14 @@ function offdiagonals(m::AbstractMatrix, i)
         k ≠ i && v ≠ 0
     end
 end
+function offdiagonals(::AbstractOperatorColumn{A,T,O}) where {A,T,O}
+    if has_iterable_offdiagonals(O)
+        error("offdiagonals not implemented for operator type $O " *
+              "even though has_iterable_offdiagonals($O) == true")
+    else
+        throw(ArgumentError("offdiagonals not supported for operator type $O"))
+    end
+end
 
 @doc """
     LOStructure(op::AbstractHamiltonian)
@@ -542,7 +550,9 @@ When extending the interface, implement a method for
 
 Part of the [`AbstractHamiltonian`](@ref) interface.
 """
-has_iterable_offdiagonals(op::AbstractObservable) = has_iterable_offdiagonals(type(op))
+has_iterable_offdiagonals(op::AbstractObservable) = has_iterable_offdiagonals(typeof(op))
+has_iterable_offdiagonals(::AbstractOperatorColumn{A,T,O}) where {A,T,O} =
+    has_iterable_offdiagonals(O)
 
 # default traits for operators and observables
 has_iterable_offdiagonals(::Type{<:AbstractOperator}) = true
@@ -569,7 +579,9 @@ When extending the interface, implement a method for
 
 Part of the [`AbstractHamiltonian`](@ref) interface.
 """
-has_random_offdiagonal(op::AbstractObservable) = has_random_offdiagonal(type(op))
+has_random_offdiagonal(op::AbstractObservable) = has_random_offdiagonal(typeof(op))
+has_random_offdiagonal(::AbstractOperatorColumn{A,T,O}) where {A,T,O} =
+    has_random_offdiagonal(O)
 
 # default traits for operators and observables
 has_random_offdiagonal(::Type{<:AbstractHamiltonian}) = true

--- a/src/Interfaces/hamiltonians.jl
+++ b/src/Interfaces/hamiltonians.jl
@@ -412,7 +412,7 @@ by the following functions:
 * [`column_operator(c::AbstractOperatorColumn)`](@ref) - returns the `operator`,
 * [`starting_address(c::AbstractOperatorColumn)`](@ref) - returns the starting `address`,
 * [`diagonal_element(c::AbstractOperatorColumn)`](@ref) - returns the diagonal element of
-    the column `c`, `⟨α|Ĥ|α⟩`, where ``α`` is the starting address,
+    the column `c`, ``⟨α|Ĥ|α⟩``, where ``α`` is the starting address,
 * [`num_offdiagonals(c::AbstractOperatorColumn)`](@ref) - returns an upper bound on the
     number of off-diagonal elements in the column `c`,
 * [`offdiagonals(c::AbstractOperatorColumn)`](@ref) - returns an object representing the
@@ -494,7 +494,9 @@ julia> fs"|1 3 2⟩" * column # an off-diagonal matrix element
 ```
 
 Part of the [`AbstractHamiltonian`](@ref) interface. See also
-[`AbstractOperatorColumn`](@ref).
+[`AbstractOperatorColumn`](@ref), [`column_operator`](@ref), [`starting_address`](@ref),
+[`diagonal_element`](@ref), [`offdiagonals`](@ref), [`num_offdiagonals`](@ref),
+[`random_offdiagonal`](@ref).
 """
 operator_column(o, a) = OffdiagonalsOperatorColumn(o, a, offdiagonals(o,a),
     eltype(o)(diagonal_element(o,a)))
@@ -505,7 +507,7 @@ diagonal_element(c::OffdiagonalsOperatorColumn) = c.diagonal
 num_offdiagonals(c::OffdiagonalsOperatorColumn) = num_offdiagonals(c.operator, c.address)
 offdiagonals(c::OffdiagonalsOperatorColumn) = c.ods
 
-function Base.:*(a::AbstractFockAddress, column::AbstractOperatorColumn{<:Any,T}) where {T}
+function Base.:*(a::A, column::AbstractOperatorColumn{A,T}) where {A<:AbstractFockAddress,T}
     if a == starting_address(column)
         return diagonal_element(column)::T
     else

--- a/src/Interfaces/hamiltonians.jl
+++ b/src/Interfaces/hamiltonians.jl
@@ -588,14 +588,7 @@ julia> h = offdiagonals(H * address)
 Part of the [`AbstractHamiltonian`](@ref) interface. See also
 [`AbstractOperatorColumn`](@ref) and [`operator_column`](@ref).
 """
-function offdiagonals(::AbstractOperatorColumn{A,T,O}) where {A,T,O}
-    if has_iterable_offdiagonals(O)
-        error("offdiagonals not implemented for operator type $O " *
-              "even though has_iterable_offdiagonals($O) == true")
-    else
-        throw(ArgumentError("offdiagonals not supported for operator type $O"))
-    end
-end
+offdiagonals
 
 # Iteration interface for AbstractOperatorColumn
 function Base.iterate(col::AbstractOperatorColumn)
@@ -629,15 +622,6 @@ The result is a tuple of the new address `newaddress`, the probability of this e
 Part of the [`AbstractHamiltonian`](@ref) interface. See also
 [`AbstractOperatorColumn`](@ref) and [`operator_column`](@ref).
 """
-function random_offdiagonal(::AbstractOperatorColumn{A,T,O}) where {A,T,O}
-    if has_random_offdiagonal(O)
-        error("random_offdiagonal not implemented for operator type $O " *
-                         "even though has_random_offdiagonal($O) == true")
-    else
-        throw(ArgumentError("random_offdiagonal not supported for operator type $O"))
-    end
-end
-
 function random_offdiagonal(column::OffdiagonalsOperatorColumn)
     offdiags = offdiagonals(column)
     nl = length(offdiags) # check how many sites we could reach

--- a/src/strategies_and_params/poststepstrategy.jl
+++ b/src/strategies_and_params/poststepstrategy.jl
@@ -253,8 +253,8 @@ account. The result is always normalized so that `sum(result) ≈ num_particles(
 ```jldoctest
 julia> v = DVec(fs"|⋅↑⇅↓⋅⟩" => 1.0, fs"|↓↓⋅↑↑⟩" => 0.5)
 DVec{FermiFS2C{2, 2, 5, 4, FermiFS{2, 5, BitString{5, 1, UInt8}}, FermiFS{2, 5, BitString{5, 1, UInt8}}},Float64} with 2 entries, style = IsDeterministic{Float64}()
-  fs"|↓↓⋅↑↑⟩" => 0.5
   fs"|⋅↑⇅↓⋅⟩" => 1.0
+  fs"|↓↓⋅↑↑⟩" => 0.5
 
 julia> single_particle_density(v)
 (0.2, 1.0, 1.6, 1.0, 0.2)

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -1777,11 +1777,11 @@ end
     @test col == h * addr
     @test column_operator(col) == h
     @test starting_address(col) == addr
-    @test diagonal_element(col) == addr ⋅ col == dot(addr, col) == dot(col, addr)'
-    @test fs"|0 1 2⟩" ⋅ col == -2 # off-diagonal element
-    @test fs"|0 0 3⟩" ⋅ col == 0 # zero off-diagonal element
-    @test_throws MethodError fs"|0 0 4⟩" ⋅ col # not in the address space
+    @test diagonal_element(col) == col[addr]
+    @test col[fs"|0 1 2⟩"] == -2 # off-diagonal element
+    @test col[fs"|0 0 3⟩"] == 0 # zero off-diagonal element
+    @test_throws MethodError col[fs"|0 0 4⟩"] # not in the address space
     @test length(collect(offdiagonals(col))) == 4
     dv = DVec(addr => 1.0)
-    @test dv ⋅ col == (col ⋅ dv)' == addr ⋅ col
+    @test dv ⋅ col == (col ⋅ dv)' == col[addr]
 end

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -1743,18 +1743,12 @@ end
     @test has_random_offdiagonal(typeof(h))  # default trait
     @test has_random_offdiagonal(h) # works with instance
     @test has_random_offdiagonal(col) # works with column
-    @test_throws ErrorException random_offdiagonal(col) # not implemented
-    Rimu.has_random_offdiagonal(::Type{<:TestHamiltonian}) = false
-    # set the trait
-    @test_throws ArgumentError random_offdiagonal(col) # still throws
+    @test_throws MethodError random_offdiagonal(col) # not implemented
 
     @test has_iterable_offdiagonals(typeof(h))  # default trait
     @test has_iterable_offdiagonals(h) # works with instance
     @test has_iterable_offdiagonals(col) # works with column
-    @test_throws ErrorException offdiagonals(col) # not implemented
-    Rimu.has_iterable_offdiagonals(::Type{<:TestHamiltonian}) = false
-    # set the trait
-    @test_throws ArgumentError offdiagonals(col) # still throws
+    @test_throws MethodError offdiagonals(col) # not implemented
 
     # Operator
     op = SingleParticleExcitation(1, 2)

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -9,6 +9,8 @@ using StaticArrays
 using Rimu.Hamiltonians: TransformUndoer, AbstractOffdiagonals
 using Rimu.InterfaceTests: test_observable_interface, test_operator_interface,
     test_hamiltonian_interface, test_hamiltonian_structure
+using Rimu.Interfaces: LOStructure, IsHermitian, IsDiagonal, AdjointKnown,
+    AdjointUnknown
 
 function exact_energy(ham)
     dv = DVec(starting_address(ham) => 1.0)

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -1724,3 +1724,24 @@ end
         @test eval(Meta.parse(repr(r))) == r
     end
 end
+
+@testset "Operator Traits" begin
+    struct TestHamiltonian <: Rimu.AbstractHamiltonian{Float64} end
+    struct TestColumn{A,O} <: Rimu.AbstractOperatorColumn{A,Float64,O}
+        operator::O
+        address::A
+    end
+    function Rimu.operator_column(h::TestHamiltonian, address)
+        return TestColumn(h, address)
+    end
+    h = TestHamiltonian()
+    addr = FermiFS{2,4}(1,0,1,0)
+    col = Rimu.operator_column(h, addr)
+    t = RandomOffdiagonalTrait(typeof(h))
+    @test t isa HasRandomOffdiagonal # default trait
+    @test_throws ErrorException random_offdiagonal(col)
+    Rimu.RandomOffdiagonalTrait(::Type{<:TestHamiltonian}) = NoRandomOffdiagonal()
+    # set the trait to NoRandomOffdiagonal
+    @test_throws ArgumentError random_offdiagonal(col) # still throws
+
+end

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -68,8 +68,7 @@ end
         FroehlichPolaron(OccupationNumberFS(1, 1, 1); momentum_cutoff=10.0),
         momentum(HubbardMom1D(BoseFS(0, 1, 5, 1, 0))),
     )
-        # test_hamiltonian_interface(H; test_spawning=false)
-        test_hamiltonian_interface(H; test_random_offdiagonal=!(H isa HOCartesianContactInteractions))
+        test_hamiltonian_interface(H)
         # Check that the result of show can be pasted into the REPL
         @test eval(Meta.parse(repr(H))) == H
 

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -1738,9 +1738,18 @@ end
     addr = FermiFS{2,4}(1,0,1,0)
     col = Rimu.operator_column(h, addr)
     @test has_random_offdiagonal(typeof(h))  # default trait
-    @test_throws ErrorException random_offdiagonal(col)
+    @test has_random_offdiagonal(h) # works with instance
+    @test has_random_offdiagonal(col) # works with column
+    @test_throws ErrorException random_offdiagonal(col) # not implemented
     Rimu.has_random_offdiagonal(::Type{<:TestHamiltonian}) = false
-    # set the trait to NoRandomOffdiagonal
+    # set the trait
     @test_throws ArgumentError random_offdiagonal(col) # still throws
 
+    @test has_iterable_offdiagonals(typeof(h))  # default trait
+    @test has_iterable_offdiagonals(h) # works with instance
+    @test has_iterable_offdiagonals(col) # works with column
+    @test_throws ErrorException offdiagonals(col) # not implemented
+    Rimu.has_iterable_offdiagonals(::Type{<:TestHamiltonian}) = false
+    # set the trait
+    @test_throws ArgumentError offdiagonals(col) # still throws
 end

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -1734,9 +1734,12 @@ end
     function Rimu.operator_column(h::TestHamiltonian, address)
         return TestColumn(h, address)
     end
+    Rimu.column_operator(c::TestColumn) = c.operator
+    Rimu.starting_address(c::TestColumn) = c.address
     h = TestHamiltonian()
     addr = FermiFS{2,4}(1,0,1,0)
-    col = Rimu.operator_column(h, addr)
+    col = operator_column(h, addr)
+    @test col == h * addr
     @test has_random_offdiagonal(typeof(h))  # default trait
     @test has_random_offdiagonal(h) # works with instance
     @test has_random_offdiagonal(col) # works with column
@@ -1752,4 +1755,31 @@ end
     Rimu.has_iterable_offdiagonals(::Type{<:TestHamiltonian}) = false
     # set the trait
     @test_throws ArgumentError offdiagonals(col) # still throws
+
+    # Operator
+    op = SingleParticleExcitation(1, 2)
+    @test has_iterable_offdiagonals(op)
+    @test !has_random_offdiagonal(op)
+    @test offdiagonals(op * BoseFS(1, 1)) isa AbstractVector
+    @test length(offdiagonals(op * BoseFS(1, 1))) == 1
+
+    # Observable
+    obs = ReducedDensityMatrix(1)
+    @test !has_iterable_offdiagonals(obs)
+    @test !has_random_offdiagonal(obs)
+end
+
+@testset "AbstractOperatorColumn" begin
+    # standard Hamiltonian
+    h = HubbardReal1D(BoseFS(1,1,1), t=1.0)
+    addr = BoseFS(0,2,1)
+    col = operator_column(h, addr)
+    @test col == h * addr
+    @test column_operator(col) == h
+    @test starting_address(col) == addr
+    @test diagonal_element(col) == addr * col
+    @test fs"|0 1 2⟩" * col == -2 # off-diagonal element
+    @test fs"|0 0 3⟩" * col == 0 # zero off-diagonal element
+    @test_throws MethodError fs"|0 0 4⟩" * col # not in the address space
+    @test length(collect(offdiagonals(col))) == 4
 end

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -1777,9 +1777,11 @@ end
     @test col == h * addr
     @test column_operator(col) == h
     @test starting_address(col) == addr
-    @test diagonal_element(col) == addr * col
-    @test fs"|0 1 2⟩" * col == -2 # off-diagonal element
-    @test fs"|0 0 3⟩" * col == 0 # zero off-diagonal element
-    @test_throws MethodError fs"|0 0 4⟩" * col # not in the address space
+    @test diagonal_element(col) == addr ⋅ col == dot(addr, col) == dot(col, addr)'
+    @test fs"|0 1 2⟩" ⋅ col == -2 # off-diagonal element
+    @test fs"|0 0 3⟩" ⋅ col == 0 # zero off-diagonal element
+    @test_throws MethodError fs"|0 0 4⟩" ⋅ col # not in the address space
     @test length(collect(offdiagonals(col))) == 4
+    dv = DVec(addr => 1.0)
+    @test dv ⋅ col == (col ⋅ dv)' == addr ⋅ col
 end

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -1737,10 +1737,9 @@ end
     h = TestHamiltonian()
     addr = FermiFS{2,4}(1,0,1,0)
     col = Rimu.operator_column(h, addr)
-    t = RandomOffdiagonalTrait(typeof(h))
-    @test t isa HasRandomOffdiagonal # default trait
+    @test has_random_offdiagonal(typeof(h))  # default trait
     @test_throws ErrorException random_offdiagonal(col)
-    Rimu.RandomOffdiagonalTrait(::Type{<:TestHamiltonian}) = NoRandomOffdiagonal()
+    Rimu.has_random_offdiagonal(::Type{<:TestHamiltonian}) = false
     # set the trait to NoRandomOffdiagonal
     @test_throws ArgumentError random_offdiagonal(col) # still throws
 

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -1734,7 +1734,7 @@ end
     function Rimu.operator_column(h::TestHamiltonian, address)
         return TestColumn(h, address)
     end
-    Rimu.column_operator(c::TestColumn) = c.operator
+    Rimu.parent_operator(c::TestColumn) = c.operator
     Rimu.starting_address(c::TestColumn) = c.address
     h = TestHamiltonian()
     addr = FermiFS{2,4}(1,0,1,0)
@@ -1769,7 +1769,7 @@ end
     addr = BoseFS(0,2,1)
     col = operator_column(h, addr)
     @test col == h * addr
-    @test column_operator(col) == h
+    @test parent_operator(col) == h
     @test starting_address(col) == addr
     @test diagonal_element(col) == col[addr]
     @test col[fs"|0 1 2⟩"] == -2 # off-diagonal element

--- a/test/Interfaces.jl
+++ b/test/Interfaces.jl
@@ -16,24 +16,6 @@ using DataFrames
     zerovector!(vector)
     @test vector == [0, 0, 0]
 
-    ham = [1 0 0; 2 3 0; 5 6 0]
-    @test offdiagonals(ham, 1) == [(2, 2), (3, 5)]
-    @test offdiagonals(ham, 2) == [(3, 6)]
-    @test offdiagonals(ham, 3) == []
-
-    @test num_offdiagonals(ham, 1) == 2
-    @test num_offdiagonals(ham, 2) == 1
-    @test num_offdiagonals(ham, 3) == 0
-
-    @test get_offdiagonal(ham, 1, 1) == (2, 2)
-    @test get_offdiagonal(ham, 1, 2) == (3, 5)
-    @test get_offdiagonal(ham, 2, 1) == (3, 6)
-
-    @test starting_address(ham) == 3
-
-    @test LOStructure(ham) == AdjointKnown()
-    @test has_adjoint(ham)
-
     @test_throws ArgumentError Interfaces.dot_from_right(1, 2, 3)
 end
 

--- a/test/StochasticStyles.jl
+++ b/test/StochasticStyles.jl
@@ -18,11 +18,12 @@ using Rimu.StochasticStyles:
 end
 @testset "Generic Hamiltonian-free functions" begin
     matrix = [1 2 3; 4 5 6; 7 8 9]
-    @test diagonal_element(matrix, 3) == 9
-    @test offdiagonals(matrix, 1) == [(2, 4), (3, 7)]
-    @test offdiagonals(matrix, 2) == [(1, 2), (3, 8)]
+    mh = MatrixHamiltonian(matrix)
+    @test diagonal_element(mh, 3) == 9
+    @test offdiagonals(mh, 1) == [(2, 4), (3, 7)]
+    @test offdiagonals(mh, 2) == [(1, 2), (3, 8)]
 
-    add, prob, val = random_offdiagonal(matrix, 1)
+    add, prob, val = random_offdiagonal(mh, 1)
     @test add in (2, 3)
     @test prob == 1/2
     @test val in (4, 7)
@@ -41,7 +42,7 @@ end
 
     w = [1.0, 2.0, 3.0]
 
-    @test apply_column!(w, operator_column(matrix, 1), 2) == (1, )
+    @test apply_column!(w, operator_column(mh, 1), 2) == (1, )
     @test w[1] == 1.0 + 2 * matrix[1, 1]
     @test w[2] == 2.0 + 2 * matrix[2, 1]
     @test w[3] == 3.0 + 2 * matrix[3, 1]

--- a/test/mpi_runtests.jl
+++ b/test/mpi_runtests.jl
@@ -8,6 +8,7 @@ using MPI
 
 using Rimu.StatsTools
 using Rimu.DictVectors: PointToPoint, AllToAll, copy_to_local!, NonInitiatorValue
+using Rimu.Interfaces
 
 const N_REPEATS = 5
 


### PR DESCRIPTION
This PR consolidates the changes to the `AbstractHamiltonian` interface and updates related documentation.

# New features
- `has_random_offdiagonal(operator)` function acts on the type of an operator and returns `true` if `random_offdiagonal(column)` is implemented
- `has_iterable_offdiagonals(operator)` function acts on the type of an operator and returns `true` if `offdiagonal(column)` is implemented
- `operator * address` calls `operator_column(operator, address)`
- `AbstractOperatorColumn`s iterate over Pairs
- `dot(dvec, column)` is defined and returns what is expected
- `column[l_address]` returns the matrix element ``⟨l_address|operator|address⟩``

# Bug fixes
- sort small dvecs before printing to make doctests reproducible; fixes issue #322