### PR TITLE
ModifiedHamiltonian

### DIFF
--- a/docs/src/custom_hamiltonians.md
+++ b/docs/src/custom_hamiltonians.md
@@ -73,8 +73,9 @@ AbstractObservable
 AbstractOperator
 ```
 
-## Hamiltonian wrappers
+## Hamiltonian wrapper interface
 
+[`ModifiedHamiltonian`](@ref) provides an interface for wrapping Hamiltonians into a new type with modified properties. Fully implemented Hamiltonian wrappers are documented in the [Hamiltonians](@ref Hamiltonian-wrappers) section.
 ```@docs
 Hamiltonians.ModifiedHamiltonian
 Hamiltonians.parent_hamiltonian

--- a/docs/src/custom_hamiltonians.md
+++ b/docs/src/custom_hamiltonians.md
@@ -75,7 +75,7 @@ AbstractOperator
 
 ## Hamiltonian wrapper interface
 
-[`ModifiedHamiltonian`](@ref Main.Hamiltonian) provides an interface for wrapping
+[`ModifiedHamiltonian`](@ref Main.Hamiltonians) provides an interface for wrapping
 Hamiltonians into a new type with modified properties. Fully implemented Hamiltonian
 wrappers are documented in the [Hamiltonians](@ref Hamiltonian-wrappers) section.
 

--- a/docs/src/custom_hamiltonians.md
+++ b/docs/src/custom_hamiltonians.md
@@ -73,6 +73,16 @@ AbstractObservable
 AbstractOperator
 ```
 
+## Hamiltonian wrappers
+
+```@docs
+Hamiltonians.ModifiedHamiltonian
+parent_hamiltonian
+modifty_diagonal
+modifty_offdiagonal
+```
+
+
 ## Interface tests
 Helper functions that can be used for testing the various interfaces are provided in the
 (unexported) submodule `Rimu.InterfaceTests`.

--- a/docs/src/custom_hamiltonians.md
+++ b/docs/src/custom_hamiltonians.md
@@ -75,10 +75,13 @@ AbstractOperator
 
 ## Hamiltonian wrapper interface
 
-[`ModifiedHamiltonian`](@ref) provides an interface for wrapping Hamiltonians into a new type with modified properties. Fully implemented Hamiltonian wrappers are documented in the [Hamiltonians](@ref Hamiltonian-wrappers) section.
+[`ModifiedHamiltonian`](@ref Main.Hamiltonian) provides an interface for wrapping
+Hamiltonians into a new type with modified properties. Fully implemented Hamiltonian
+wrappers are documented in the [Hamiltonians](@ref Hamiltonian-wrappers) section.
+
 ```@docs
 Hamiltonians.ModifiedHamiltonian
-Hamiltonians.parent_hamiltonian
+Hamiltonians.parent_operator
 Hamiltonians.modify_diagonal
 Hamiltonians.modify_offdiagonal
 ```

--- a/docs/src/custom_hamiltonians.md
+++ b/docs/src/custom_hamiltonians.md
@@ -75,7 +75,7 @@ AbstractOperator
 
 ## Hamiltonian wrapper interface
 
-[`ModifiedHamiltonian`](@ref Main.Hamiltonians) provides an interface for wrapping
+[`ModifiedHamiltonian`](@ref Main.Hamiltonians.ModifiedHamiltonian) provides an interface for wrapping
 Hamiltonians into a new type with modified properties. Fully implemented Hamiltonian
 wrappers are documented in the [Hamiltonians](@ref Hamiltonian-wrappers) section.
 

--- a/docs/src/custom_hamiltonians.md
+++ b/docs/src/custom_hamiltonians.md
@@ -84,7 +84,7 @@ wrappers are documented in the [Hamiltonians](@ref Hamiltonian-wrappers) section
 
 ```@docs
 Hamiltonians.ModifiedHamiltonian
-Hamiltonians.parent_operator(::ModifiedHamiltonian)
+Hamiltonians.parent_operator(::Main.Hamiltonians.ModifiedHamiltonian)
 Hamiltonians.modify_diagonal
 Hamiltonians.modify_offdiagonal
 ```

--- a/docs/src/custom_hamiltonians.md
+++ b/docs/src/custom_hamiltonians.md
@@ -33,7 +33,7 @@ AbstractHamiltonian
 starting_address
 operator_column
 AbstractOperatorColumn
-parent_operator
+parent_operator(::AbstractOperatorColumn)
 diagonal_element
 offdiagonals
 random_offdiagonal
@@ -84,7 +84,7 @@ wrappers are documented in the [Hamiltonians](@ref Hamiltonian-wrappers) section
 
 ```@docs
 Hamiltonians.ModifiedHamiltonian
-Hamiltonians.parent_operator
+Hamiltonians.parent_operator(::ModifiedHamiltonian)
 Hamiltonians.modify_diagonal
 Hamiltonians.modify_offdiagonal
 ```

--- a/docs/src/custom_hamiltonians.md
+++ b/docs/src/custom_hamiltonians.md
@@ -82,7 +82,6 @@ Hamiltonians.modify_diagonal
 Hamiltonians.modify_offdiagonal
 ```
 
-
 ## Interface tests
 Helper functions that can be used for testing the various interfaces are provided in the
 (unexported) submodule `Rimu.InterfaceTests`.

--- a/docs/src/custom_hamiltonians.md
+++ b/docs/src/custom_hamiltonians.md
@@ -1,14 +1,14 @@
 # Advanced operator usage and custom Hamiltonians
 
 `Rimu` can be used to work with custom Hamiltonians and observables that are user-defined and
- not part of the `Rimu.jl` package. To make this possible and reliable, `Rimu` exposes a number 
- of interfaces and provides helper functions to test compliance with the interfaces through the 
+ not part of the `Rimu.jl` package. To make this possible and reliable, `Rimu` exposes a number
+ of interfaces and provides helper functions to test compliance with the interfaces through the
  submodule [`Rimu.InterfaceTests`](@ref), see [Interface tests](@ref). This section covers the
  relevant interfaces, the interface functions as well as potentially useful helper functions.
 
- In order to define custom Hamiltonians or observables it is useful to know how the operator 
- type hierarchy works in `Rimu`. For an example of how to implement custom Hamiltonians that 
- are not part of the `Rimu.jl` package, see 
+ In order to define custom Hamiltonians or observables it is useful to know how the operator
+ type hierarchy works in `Rimu`. For an example of how to implement custom Hamiltonians that
+ are not part of the `Rimu.jl` package, see
  [`RimuLegacyHamiltonians.jl`](https://github.com/RimuQMC/RimuLegacyHamiltonians.jl).
 
 ## Operator type hierarchy
@@ -18,14 +18,14 @@ for operators:
 ```julia
 AbstractHamiltonian <: AbstractOperator <: AbstractObservable
 ```
-The different abstract types have different requirements and are meant to be used for different purposes. 
+The different abstract types have different requirements and are meant to be used for different purposes.
 - [`AbstractHamiltonian`](@ref)s are fully featured models that define a Hilbert space and a linear operator over a scalar field. They can be passed as a Hamiltonian into [`ProjectorMonteCarloProblem`](@ref) or [`ExactDiagonalizationProblem`](@ref).
 - [`AbstractOperator`](@ref) and [`AbstractObservable`](@ref) are supertypes of [`AbstractHamiltonian`](@ref) with less stringent conditions. They are useful for defining observables that can be used in a three-way `dot` product, or passed as observables into a [`ReplicaStrategy`](@ref) that can be inserted with the keyword `replica_strategy` into a [`ProjectorMonteCarloProblem`](@ref).
 
 ## Hamiltonians interface
 
 Behind the implementation of a particular model is a more abstract interface for defining
-Hamiltonians. If you want to define a new model you should make use of this interface. A new 
+Hamiltonians. If you want to define a new model you should make use of this interface. A new
 model Hamiltonian should subtype to `AbstractHamiltonian` and implement the relevant methods.
 
 ```@docs
@@ -50,6 +50,7 @@ allows_address_type
 Base.eltype
 VectorInterface.scalartype
 mul!
+undo_transform
 ```
 
 This interface relies on unexported functionality, including
@@ -65,7 +66,7 @@ Hamiltonians.number_conserving_fermi_dimension
 Interfaces.OffdiagonalsOperatorColumn
 ```
 
-## Operator and observable interface 
+## Operator and observable interface
 
 ```@docs
 AbstractObservable
@@ -73,8 +74,8 @@ AbstractOperator
 ```
 
 ## Interface tests
-Helper functions that can be used for testing the various interfaces are provided in the 
-(unexported) submodule `Rimu.InterfaceTests`. 
+Helper functions that can be used for testing the various interfaces are provided in the
+(unexported) submodule `Rimu.InterfaceTests`.
 
 ```@docs
 Rimu.InterfaceTests

--- a/docs/src/custom_hamiltonians.md
+++ b/docs/src/custom_hamiltonians.md
@@ -78,8 +78,8 @@ AbstractOperator
 ```@docs
 Hamiltonians.ModifiedHamiltonian
 Hamiltonians.parent_hamiltonian
-Hamiltonians.modifty_diagonal
-Hamiltonians.modifty_offdiagonal
+Hamiltonians.modify_diagonal
+Hamiltonians.modify_offdiagonal
 ```
 
 

--- a/docs/src/custom_hamiltonians.md
+++ b/docs/src/custom_hamiltonians.md
@@ -77,9 +77,9 @@ AbstractOperator
 
 ```@docs
 Hamiltonians.ModifiedHamiltonian
-parent_hamiltonian
-modifty_diagonal
-modifty_offdiagonal
+Hamiltonians.parent_hamiltonian
+Hamiltonians.modifty_diagonal
+Hamiltonians.modifty_offdiagonal
 ```
 
 

--- a/docs/src/hamiltonians.md
+++ b/docs/src/hamiltonians.md
@@ -57,7 +57,7 @@ shift_lattice_inv
 The following Hamiltonians are constructed from an existing
 Hamiltonian instance and change its behaviour:
 ```@docs
-ModifiedHamiltonian
+Hamiltonians.ModifiedHamiltonian
 GutzwillerSampling
 GuidingVectorSampling
 ParitySymmetry

--- a/docs/src/hamiltonians.md
+++ b/docs/src/hamiltonians.md
@@ -57,6 +57,7 @@ shift_lattice_inv
 The following Hamiltonians are constructed from an existing
 Hamiltonian instance and change its behaviour:
 ```@docs
+ModifiedHamiltonian
 GutzwillerSampling
 GuidingVectorSampling
 ParitySymmetry
@@ -65,11 +66,11 @@ Stoquastic
 ```
 
 ## Observables
-`Rimu.jl` offers two other supertypes for operators that are less 
-restrictive than [`AbstractHamiltonian`](@ref). 
+`Rimu.jl` offers two other supertypes for operators that are less
+restrictive than [`AbstractHamiltonian`](@ref).
 [`AbstractObservable`](@ref) and [`AbstractOperator`](@ref)s both
-can represent a physical observable. Their expectation values can be sampled during a [`ProjectorMonteCarloProblem`](@ref) simulation by 
-passing them into a suitable [`ReplicaStrategy`](@ref), e.g. 
+can represent a physical observable. Their expectation values can be sampled during a [`ProjectorMonteCarloProblem`](@ref) simulation by
+passing them into a suitable [`ReplicaStrategy`](@ref), e.g.
 [`AllOverlaps`](@ref). Some observables are also [`AbstractHamiltonian`](@ref)s. The full type hierarchy is
 ```julia
 AbstractHamiltonian{T} <: AbstractOperator{T} <: AbstractObservable{T}

--- a/docs/src/hamiltonians.md
+++ b/docs/src/hamiltonians.md
@@ -62,7 +62,7 @@ GuidingVectorSampling
 ParitySymmetry
 TimeReversalSymmetry
 Stoquastic
-TransformUndoer
+Hamiltonians.TransformUndoer
 ```
 
 ## Observables

--- a/docs/src/hamiltonians.md
+++ b/docs/src/hamiltonians.md
@@ -57,7 +57,6 @@ shift_lattice_inv
 The following Hamiltonians are constructed from an existing
 Hamiltonian instance and change its behaviour:
 ```@docs
-Hamiltonians.ModifiedHamiltonian
 GutzwillerSampling
 GuidingVectorSampling
 ParitySymmetry

--- a/docs/src/hamiltonians.md
+++ b/docs/src/hamiltonians.md
@@ -63,6 +63,7 @@ GuidingVectorSampling
 ParitySymmetry
 TimeReversalSymmetry
 Stoquastic
+TransformUndoer
 ```
 
 ## Observables
@@ -77,6 +78,7 @@ AbstractHamiltonian{T} <: AbstractOperator{T} <: AbstractObservable{T}
 ```
 
 ```@docs
+IdentityOperator
 ParticleNumberOperator
 G2RealCorrelator
 G2RealSpace

--- a/src/Hamiltonians/GuidingVectorSampling.jl
+++ b/src/Hamiltonians/GuidingVectorSampling.jl
@@ -93,8 +93,6 @@ function LinearAlgebra.adjoint(h::GuidingVectorSampling{A,T,<:Any,D}) where {A,T
     return GuidingVectorSampling{!A,T,typeof(h_adj),D}(h_adj, h.vector, h.eps)
 end
 
-requires_transform_undoer(::GuidingVectorSampling) = true
-
 parent_hamiltonian(h::GuidingVectorSampling) = h.hamiltonian
 modify_diagonal(::GuidingVectorSampling, _, value) = value
 
@@ -140,6 +138,8 @@ function TransformUndoer(k::GuidingVectorSampling, op::Union{Nothing,AbstractOpe
     end
     return TransformUndoer{T,typeof(k),typeof(op)}(k, op)
 end
+
+undo_transform(g::GuidingVectorSampling, op::AbstractOperator) = TransformUndoer(g, op)
 
 const GuidingVectorTransformUndoer{A} = TransformUndoer{<:Any,<:GuidingVectorSampling,A}
 

--- a/src/Hamiltonians/GuidingVectorSampling.jl
+++ b/src/Hamiltonians/GuidingVectorSampling.jl
@@ -130,12 +130,8 @@ the components of the guiding vector, i.e.``f_{ii} = v_i``.
 
 See [`AllOverlaps`](@ref), [`GuidingVectorSampling`](@ref).
 """
-function TransformUndoer(k::GuidingVectorSampling, op::Union{Nothing,AbstractOperator})
-    if isnothing(op)
-        T = eltype(k)
-    else
-        T = promote_type(eltype(k), eltype(op))
-    end
+function TransformUndoer(k::GuidingVectorSampling, op::AbstractOperator)
+    T = promote_type(eltype(k), eltype(op))
     return TransformUndoer{T,typeof(k),typeof(op)}(k, op)
 end
 
@@ -150,7 +146,7 @@ function LinearAlgebra.adjoint(s::GuidingVectorTransformUndoer)
     return TransformUndoer(s.transform, a_adj)
 end
 
-function modify_diagonal(s::GuidingVectorTransformUndoer{<:AbstractOperator}, addr, val)
+function modify_diagonal(s::GuidingVectorTransformUndoer, addr, val)
     guide = s.transform.vector[addr]
 
     return guiding_vector_modify(val, true, s.transform.eps, 1.0, 2 * guide)

--- a/src/Hamiltonians/GuidingVectorSampling.jl
+++ b/src/Hamiltonians/GuidingVectorSampling.jl
@@ -64,8 +64,7 @@ julia> eigen(Matrix(G)).values
 
 # Observables
 
-To calculate observables, pass the transformed Hamiltonian `G` to
-[`AllOverlaps`](@ref) with keyword argument `transform=G`.
+See [`AllOverlaps`](@ref) for calculation of observables with a transformed Hamiltonian.
 """
 struct GuidingVectorSampling{A,T,H<:AbstractHamiltonian{T},D} <: ModifiedHamiltonian{T}
     # The A parameter sets whether this is an adjoint or not.

--- a/src/Hamiltonians/GuidingVectorSampling.jl
+++ b/src/Hamiltonians/GuidingVectorSampling.jl
@@ -88,11 +88,12 @@ function LOStructure(::Type{<:GuidingVectorSampling{<:Any,<:Any,H}}) where {H}
         return AdjointKnown()
     end
 end
-
 function LinearAlgebra.adjoint(h::GuidingVectorSampling{A,T,<:Any,D}) where {A,T,D}
     h_adj = h.hamiltonian'
     return GuidingVectorSampling{!A,T,typeof(h_adj),D}(h_adj, h.vector, h.eps)
 end
+
+requires_transform_undoer(::GuidingVectorSampling) = true
 
 parent_hamiltonian(h::GuidingVectorSampling) = h.hamiltonian
 modify_diagonal(::GuidingVectorSampling, _, value) = value

--- a/src/Hamiltonians/GuidingVectorSampling.jl
+++ b/src/Hamiltonians/GuidingVectorSampling.jl
@@ -93,7 +93,7 @@ function LinearAlgebra.adjoint(h::GuidingVectorSampling{A,T,<:Any,D}) where {A,T
     return GuidingVectorSampling{!A,T,typeof(h_adj),D}(h_adj, h.vector, h.eps)
 end
 
-parent_hamiltonian(h::GuidingVectorSampling) = h.hamiltonian
+parent_operator(h::GuidingVectorSampling) = h.hamiltonian
 modify_diagonal(::GuidingVectorSampling, _, value) = value
 
 _apply_eps(x, eps) = ifelse(iszero(x), eps, ifelse(abs(x) < eps, sign(x) * eps, x))

--- a/src/Hamiltonians/GuidingVectorSampling.jl
+++ b/src/Hamiltonians/GuidingVectorSampling.jl
@@ -27,17 +27,39 @@ After construction, we can access the underlying hamiltonian with `G.hamiltonian
 # Example
 
 ```jldoctest
-julia> H = HubbardReal1D(BoseFS(1,1,1); u=6.0, t=1.0);
+julia> H = HubbardMom1D(BoseFS(1,1,1); u=6.0, t=1.0);
 
-julia> v = DVec(starting_address(H) => 10; capacity=1);
+julia> v = DVec(starting_address(H) => 10);
 
 julia> G = GuidingVectorSampling(H, v, 0.1);
 
-julia> get_offdiagonal(H, starting_address(H), 4)
-(BoseFS{3,3}(2, 0, 1), -1.4142135623730951)
+julia> Matrix(H)
+4×4 Matrix{Float64}:
+ 12.0      4.89898  4.89898  4.89898
+  4.89898  9.0      0.0      0.0
+  4.89898  0.0      9.0      0.0
+  4.89898  0.0      0.0      0.0
 
-julia> get_offdiagonal(G, starting_address(G), 4)
-(BoseFS{3,3}(2, 0, 1), -0.014142135623730952)
+julia> Matrix(G)
+4×4 Matrix{Float64}:
+ 12.0        489.898  489.898  489.898
+  0.0489898    9.0      0.0      0.0
+  0.0489898    0.0      9.0      0.0
+  0.0489898    0.0      0.0      0.0
+
+julia> eigen(Matrix(H)).values
+4-element Vector{Float64}:
+ -2.3661456273236645
+  4.9594958589580465
+  8.999999999999996
+ 18.406649768365643
+
+julia> eigen(Matrix(G)).values
+4-element Vector{Float64}:
+ -2.366145627323689
+  4.9594958589580465
+  8.999999999999998
+ 18.406649768365643
 ```
 
 # Observables

--- a/src/Hamiltonians/GuidingVectorSampling.jl
+++ b/src/Hamiltonians/GuidingVectorSampling.jl
@@ -26,7 +26,7 @@ After construction, we can access the underlying hamiltonian with `G.hamiltonian
 
 # Example
 
-```jldoctest filter = r"(\d*)\.(\d{4})\d+" => s"\1.\2"
+```jldoctest
 julia> H = HubbardMom1D(BoseFS(1,1,1); u=6.0, t=1.0);
 
 julia> v = DVec(starting_address(H) => 10);

--- a/src/Hamiltonians/GuidingVectorSampling.jl
+++ b/src/Hamiltonians/GuidingVectorSampling.jl
@@ -45,42 +45,39 @@ julia> get_offdiagonal(G, starting_address(G), 4)
 To calculate observables, pass the transformed Hamiltonian `G` to
 [`AllOverlaps`](@ref) with keyword argument `transform=G`.
 """
-struct GuidingVectorSampling{A,T,H<:AbstractHamiltonian{T},D,E} <: AbstractHamiltonian{T}
+struct GuidingVectorSampling{A,T,H<:AbstractHamiltonian{T},D} <: ModifiedHamiltonian{T}
     # The A parameter sets whether this is an adjoint or not.
-    # The E parameter is the epsilon value.
     hamiltonian::H
     vector::D
+    eps::Float64
 end
 
 function GuidingVectorSampling(h, v::AbstractDVec, eps=1e-2 * norm(v, Inf))
-    return GuidingVectorSampling{false,eltype(h),typeof(h),typeof(v),eps}(h, v)
+    return GuidingVectorSampling{false,eltype(h),typeof(h),typeof(v)}(h, v, eps)
 end
 function GuidingVectorSampling(h; vector, eps=1e-2 * norm(vector, Inf))
     return GuidingVectorSampling(h, vector, eps)
 end
 
-starting_address(h::GuidingVectorSampling) = starting_address(h.hamiltonian)
-LOStructure(::Type{<:GuidingVectorSampling{<:Any,<:Any,H}}) where {H} = _lo_str(LOStructure(H))
-
-function LinearAlgebra.adjoint(h::GuidingVectorSampling{A,T,<:Any,D,E}) where {A,T,D,E}
-    h_adj = h.hamiltonian'
-    return GuidingVectorSampling{!A,T,typeof(h_adj),D,E}(h_adj, h.vector)
+function LOStructure(::Type{<:GuidingVectorSampling{<:Any,<:Any,H}}) where {H}
+    if LOStructure(H) ≡ AdjointUnknown()
+        return AdjointUnknown()
+    else
+        return AdjointKnown()
+    end
 end
 
-dimension(h::GuidingVectorSampling, addr) = dimension(h.hamiltonian, addr)
+function LinearAlgebra.adjoint(h::GuidingVectorSampling{A,T,<:Any,D}) where {A,T,D}
+    h_adj = h.hamiltonian'
+    return GuidingVectorSampling{!A,T,typeof(h_adj),D}(h_adj, h.vector, h.eps)
+end
 
-Base.getproperty(h::GuidingVectorSampling, s::Symbol) = getproperty(h, Val(s))
-Base.getproperty(h::GuidingVectorSampling{<:Any,<:Any,<:Any,<:Any,E}, ::Val{:eps}) where E = E
-Base.getproperty(h::GuidingVectorSampling, ::Val{:hamiltonian}) = getfield(h, :hamiltonian)
-Base.getproperty(h::GuidingVectorSampling, ::Val{:vector}) = getfield(h, :vector)
-
-# Forward some interface functions.
-num_offdiagonals(h::GuidingVectorSampling, add) = num_offdiagonals(h.hamiltonian, add)
-diagonal_element(h::GuidingVectorSampling, add) = diagonal_element(h.hamiltonian, add)
+parent_hamiltonian(h::GuidingVectorSampling) = h.hamiltonian
+modify_diagonal(::GuidingVectorSampling, _, value) = value
 
 _apply_eps(x, eps) = ifelse(iszero(x), eps, ifelse(abs(x) < eps, sign(x) * eps, x))
 
-function guided_vector_modify(value, is_adjoint, eps, guide1, guide2)
+function guiding_vector_modify(value, is_adjoint, eps, guide1, guide2)
     if iszero(guide1) && iszero(guide2)
         return value
     else
@@ -94,38 +91,12 @@ function guided_vector_modify(value, is_adjoint, eps, guide1, guide2)
     end
 end
 
-function get_offdiagonal(h::GuidingVectorSampling{A}, add1, chosen) where A
-    add2, matrix_element = get_offdiagonal(h.hamiltonian, add1, chosen)
-    guide1 = h.vector[add1]
-    guide2 = h.vector[add2]
-    return add2, guided_vector_modify(matrix_element, A, h.eps, guide1, guide2)
-end
+function modify_offdiagonal(h::GuidingVectorSampling{A}, in, out, value) where {A}
+    guide1 = h.vector[in]
+    guide2 = h.vector[out]
 
-struct GuidingVectorOffdiagonals{
-    F,T,A,E,H<:AbstractHamiltonian,D,N<:AbstractOffdiagonals{F,T}
-}<:AbstractOffdiagonals{F,T}
-    hamiltonian::H
-    vector::D
-    guide::T
-    offdiagonals::N
+    return out => guiding_vector_modify(value, A, h.eps, guide1, guide2)
 end
-
-function offdiagonals(h::GuidingVectorSampling{A,T,H,D,E}, a) where {A,T,H,D,E}
-    hps = offdiagonals(h.hamiltonian, a)
-    guide = h.vector[a]
-    return GuidingVectorOffdiagonals{typeof(a),T,A,E,H,D,typeof(hps)}(
-        h.hamiltonian, h.vector, guide, hps
-    )
-end
-
-function Base.getindex(h::GuidingVectorOffdiagonals{F,T,A,E}, i)::Tuple{F,T} where {F,T,A,E}
-    add2, matrix_element = h.offdiagonals[i]
-    guide1 = h.guide
-    guide2 = h.vector[add2]
-    return add2, guided_vector_modify(matrix_element, A, E, guide1, guide2)
-end
-
-Base.size(h::GuidingVectorOffdiagonals) = size(h.offdiagonals)
 
 """
     TransformUndoer(k::GuidingVectorSampling, op::AbstractOperator)
@@ -147,38 +118,23 @@ function TransformUndoer(k::GuidingVectorSampling, op::Union{Nothing,AbstractOpe
     return TransformUndoer{T,typeof(k),typeof(op)}(k, op)
 end
 
-# methods for general operator `f^{-1} A f^{-1}`
-LOStructure(::Type{<:TransformUndoer{<:Any,<:GuidingVectorSampling,A}}) where {A} = LOStructure(A)
+const GuidingVectorTransformUndoer{A} = TransformUndoer{<:Any,<:GuidingVectorSampling,A}
 
-function LinearAlgebra.adjoint(s::TransformUndoer{T,<:GuidingVectorSampling,<:AbstractOperator}) where {T}
+LOStructure(::Type{<:GuidingVectorTransformUndoer{A}}) where {A} = LOStructure(A)
+
+function LinearAlgebra.adjoint(s::GuidingVectorTransformUndoer)
     a_adj = adjoint(s.op)
-    return TransformUndoer{T,typeof(s.transform),typeof(a_adj)}(s.transform, a_adj)
+    return TransformUndoer(s.transform, a_adj)
 end
 
-function diagonal_element(s::TransformUndoer{<:Any,<:GuidingVectorSampling,<:AbstractOperator}, add)
-    guide = s.transform.vector[add]
-    diagA = diagonal_element(s.op, add)
-    return guided_vector_modify(diagA, true, s.transform.eps, 1., 2 * guide)
+function modify_diagonal(s::GuidingVectorTransformUndoer{<:AbstractOperator}, addr, val)
+    guide = s.transform.vector[addr]
+
+    return guiding_vector_modify(val, true, s.transform.eps, 1.0, 2 * guide)
 end
+function modify_offdiagonal(s::GuidingVectorTransformUndoer, in, out, val)
+    guide1 = s.transform.vector[in]
+    guide2 = s.transform.vector[out]
 
-function num_offdiagonals(s::TransformUndoer{<:Any,<:GuidingVectorSampling,<:Any}, add)
-    return num_offdiagonals(s.op, add)
+    return out => guiding_vector_modify(val, true, s.transform.eps, 1., guide1 + guide2)
 end
-
-function get_offdiagonal(s::TransformUndoer{<:Any,<:GuidingVectorSampling,<:Any}, add1, chosen)
-    add2, offd = get_offdiagonal(s.op, add1, chosen)
-    # Guiding vector `v` is represented as a diagonal operator `f`
-    guide1 = s.transform.vector[add1]
-    guide2 = s.transform.vector[add2]
-    return add2, guided_vector_modify(offd, true, s.transform.eps, 1., guide1 + guide2)
-end
-
-# methods for special case `f^{-2}`
-LOStructure(::Type{<:TransformUndoer{<:Any,<:GuidingVectorSampling,Nothing}}) = IsDiagonal()
-
-function diagonal_element(s::TransformUndoer{<:Any,<:GuidingVectorSampling,Nothing}, add)
-    guide = s.transform.vector[add]
-    return guided_vector_modify(1., true, s.transform.eps, 1., 2 * guide)
-end
-
-num_offdiagonals(s::TransformUndoer{<:Any,<:GuidingVectorSampling,Nothing}, add) = 0

--- a/src/Hamiltonians/GuidingVectorSampling.jl
+++ b/src/Hamiltonians/GuidingVectorSampling.jl
@@ -33,19 +33,19 @@ julia> v = DVec(starting_address(H) => 10);
 
 julia> G = GuidingVectorSampling(H, v, 0.1);
 
-julia> Matrix(H)
+julia> Matrix(H; sort=true)
 4×4 Matrix{Float64}:
- 12.0      4.89898  4.89898  4.89898
-  4.89898  9.0      0.0      0.0
-  4.89898  0.0      9.0      0.0
-  4.89898  0.0      0.0      0.0
+ 9.0      0.0       4.89898  0.0
+ 0.0      0.0       4.89898  0.0
+ 4.89898  4.89898  12.0      4.89898
+ 0.0      0.0       4.89898  9.0
 
-julia> Matrix(G)
+julia> Matrix(G; sort=true)
 4×4 Matrix{Float64}:
- 12.0        489.898  489.898  489.898
-  0.0489898    9.0      0.0      0.0
-  0.0489898    0.0      9.0      0.0
-  0.0489898    0.0      0.0      0.0
+   9.0      0.0     0.0489898    0.0
+   0.0      0.0     0.0489898    0.0
+ 489.898  489.898  12.0        489.898
+   0.0      0.0     0.0489898    9.0
 
 julia> eigen(Matrix(H)).values
 4-element Vector{Float64}:

--- a/src/Hamiltonians/GuidingVectorSampling.jl
+++ b/src/Hamiltonians/GuidingVectorSampling.jl
@@ -26,7 +26,7 @@ After construction, we can access the underlying hamiltonian with `G.hamiltonian
 
 # Example
 
-```jldoctest
+```jldoctest filter = r"(\d*)\.(\d{4})\d+" => s"\1.\2"
 julia> H = HubbardMom1D(BoseFS(1,1,1); u=6.0, t=1.0);
 
 julia> v = DVec(starting_address(H) => 10);

--- a/src/Hamiltonians/GutzwillerSampling.jl
+++ b/src/Hamiltonians/GutzwillerSampling.jl
@@ -27,19 +27,19 @@ HubbardMom1D(fs"|1 1 1⟩"; u=6.0, t=1.0)
 julia> G = GutzwillerSampling(H, g=0.3)
 GutzwillerSampling(HubbardMom1D(fs"|1 1 1⟩"; u=6.0, t=1.0); g=0.3)
 
-julia> Matrix(H)
+julia> Matrix(H; sort=true)
 4×4 Matrix{Float64}:
- 12.0      4.89898  4.89898  4.89898
-  4.89898  9.0      0.0      0.0
-  4.89898  0.0      9.0      0.0
-  4.89898  0.0      0.0      0.0
+ 9.0      0.0       4.89898  0.0
+ 0.0      0.0       4.89898  0.0
+ 4.89898  4.89898  12.0      4.89898
+ 0.0      0.0       4.89898  9.0
 
-julia> Matrix(G)
+julia> Matrix(G; sort=true)
 4×4 Matrix{Float64}:
-  12.0     1.99178  1.99178  0.133858
-  12.0495  9.0      0.0      0.0
-  12.0495  0.0      9.0      0.0
- 179.294   0.0      0.0      0.0
+ 9.0      0.0        12.0495  0.0
+ 0.0      0.0       179.294   0.0
+ 1.99178  0.133858   12.0     1.99178
+ 0.0      0.0        12.0495  9.0
 
 julia> eigen(Matrix(H)).values
 4-element Vector{Float64}:

--- a/src/Hamiltonians/GutzwillerSampling.jl
+++ b/src/Hamiltonians/GutzwillerSampling.jl
@@ -38,15 +38,14 @@ julia> get_offdiagonal(G, BoseFS(2, 1, 0), 1)
 To calculate observables, pass the transformed Hamiltonian `G` to
 [`AllOverlaps`](@ref) with keyword argument `transform=G`.
 """
-struct GutzwillerSampling{A,T,H<:AbstractHamiltonian{T},G} <: AbstractHamiltonian{T}
+struct GutzwillerSampling{A,T,H<:AbstractHamiltonian{T}} <: ModifiedHamiltonian{T}
     # The A parameter sets whether this is an adjoint or not.
-    # The G parameter is g parameter value.
     hamiltonian::H
+    g::Float64
 end
 
 function GutzwillerSampling(h, g)
-    G = eltype(h)(g)
-    return GutzwillerSampling{false,eltype(h),typeof(h),G}(h)
+    return GutzwillerSampling{false,eltype(h),typeof(h)}(h, Float64(g))
 end
 GutzwillerSampling(h; g) = GutzwillerSampling(h, g)
 
@@ -56,30 +55,21 @@ function Base.show(io::IO, h::GutzwillerSampling{A}) where {A}
     A && print(io, ")")
 end
 
-starting_address(h::GutzwillerSampling) = starting_address(h.hamiltonian)
-
-LOStructure(::Type{<:GutzwillerSampling{<:Any,<:Any,H}}) where {H} = _lo_str(LOStructure(H))
-_lo_str(::LOStructure) = AdjointKnown()
-_lo_str(::AdjointUnknown) = AdjointUnknown()
-
-function LinearAlgebra.adjoint(h::GutzwillerSampling{A,T,<:Any,G}) where {A,T,G}
-    h_adj = h.hamiltonian'
-    return GutzwillerSampling{!A,T,typeof(h_adj),G}(h_adj)
+function LOStructure(::Type{<:GutzwillerSampling{<:Any,<:Any,H}}) where {H}
+    if LOStructure(H) ≡ AdjointUnknown()
+        return AdjointUnknown()
+    else
+        return AdjointKnown()
+    end
 end
-
-dimension(h::GutzwillerSampling, addr) = dimension(h.hamiltonian, addr)
-
-Base.getproperty(h::GutzwillerSampling, s::Symbol) = getproperty(h, Val(s))
-Base.getproperty(h::GutzwillerSampling{<:Any,<:Any,<:Any,G}, ::Val{:g}) where G = G
-Base.getproperty(h::GutzwillerSampling, ::Val{:hamiltonian}) = getfield(h, :hamiltonian)
+function LinearAlgebra.adjoint(h::GutzwillerSampling{A}) where {A}
+    h_adj = h.hamiltonian'
+    return GutzwillerSampling{!A,eltype(h_adj),typeof(h_adj)}(h_adj, h.g)
+end
 
 function Base.:(==)(a::GutzwillerSampling{A}, b::GutzwillerSampling{B}) where {A,B}
-    return A == B && a.g == b.g && a.hamiltonian == b.hamiltonian
+   return A == B && a.g == b.g && a.hamiltonian == b.hamiltonian
 end
-
-# Forward some interface functions.
-num_offdiagonals(h::GutzwillerSampling, add) = num_offdiagonals(h.hamiltonian, add)
-diagonal_element(h::GutzwillerSampling, add) = diagonal_element(h.hamiltonian, add)
 
 function gutzwiller_modify(matrix_element, is_adjoint, g, diag1, diag2)
     if is_adjoint
@@ -89,36 +79,14 @@ function gutzwiller_modify(matrix_element, is_adjoint, g, diag1, diag2)
     end
 end
 
-function get_offdiagonal(h::GutzwillerSampling{A}, add1, chosen) where A
-    add2, matrix_element = get_offdiagonal(h.hamiltonian, add1, chosen)
-    diag1 = diagonal_element(h, add1)
-    diag2 = diagonal_element(h, add2)
-    return add2, gutzwiller_modify(matrix_element, A, h.g, diag1, diag2)
-end
+parent_hamiltonian(h::GutzwillerSampling) = h.hamiltonian
+modify_diagonal(h::GutzwillerSampling, _, value) = value
 
-struct GutzwillerOffdiagonals{
-    F,T,A,G,H<:AbstractHamiltonian,N<:AbstractOffdiagonals{F,T}
-}<:AbstractOffdiagonals{F,T}
-    hamiltonian::H
-    diag::T
-    offdiagonals::N
+function modify_offdiagonal(h::GutzwillerSampling{A}, in, out, value) where {A}
+    diag1 = diagonal_element(operator_column(h, in))
+    diag2 = diagonal_element(operator_column(h, out))
+    return out => gutzwiller_modify(value, A, h.g, diag1, diag2)
 end
-
-function offdiagonals(ham::GutzwillerSampling{A,<:Any,<:Any,G}, a) where {A,G}
-    hps = offdiagonals(ham.hamiltonian, a)
-    diag = diagonal_element(ham, a)
-    return GutzwillerOffdiagonals{typeof(a),eltype(ham),A,G,typeof(ham),typeof(hps)}(
-        ham, diag, hps
-    )
-end
-
-function Base.getindex(h::GutzwillerOffdiagonals{F,T,A,G}, i)::Tuple{F,T} where {F,T,A,G}
-    add2, matrix_element = h.offdiagonals[i]
-    diag2 = diagonal_element(h.hamiltonian, add2)
-    return add2, gutzwiller_modify(matrix_element, A, G, h.diag, diag2)
-end
-
-Base.size(h::GutzwillerOffdiagonals) = size(h.offdiagonals)
 
 """
     TransformUndoer(k::GutzwillerSampling, op::AbstractOperator)
@@ -131,47 +99,26 @@ to calculate observables. Here ``f`` is a diagonal operator whose entries are
 
 See [`AllOverlaps`](@ref), [`GutzwillerSampling`](@ref).
 """
-function TransformUndoer(k::GutzwillerSampling, op::Union{Nothing,AbstractOperator})
-    if isnothing(op)
-        T = eltype(k)
-    else
-        T = typeof(zero(eltype(k)) * zero(eltype(op)))
-    end
+function TransformUndoer(k::GutzwillerSampling, op::AbstractOperator)
+    T = typeof(zero(eltype(k)) * zero(eltype(op)))
     return TransformUndoer{T,typeof(k),typeof(op)}(k, op)
 end
 
-# methods for general operator `f^{-1} A f^{-1}`
-LOStructure(::Type{<:TransformUndoer{<:Any,<:GutzwillerSampling,A}}) where {A} = LOStructure(A)
+const GutzwillerTransformUndoer{A} = TransformUndoer{<:Any,<:GutzwillerSampling,A}
 
-function LinearAlgebra.adjoint(s::TransformUndoer{T,<:GutzwillerSampling,<:AbstractOperator}) where {T}
+LOStructure(::Type{<:GutzwillerTransformUndoer{A}}) where {A} = LOStructure(A)
+
+function LinearAlgebra.adjoint(s::GutzwillerTransformUndoer)
     a_adj = adjoint(s.op)
-    return TransformUndoer{T,typeof(s.transform),typeof(a_adj)}(s.transform, a_adj)
+    return TransformUndoer(s.transform, a_adj)
 end
+function modify_diagonal(s::GutzwillerTransformUndoer, addr, val)
+    diag = diagonal_element(s.transform.hamiltonian, addr)
 
-function diagonal_element(s::TransformUndoer{<:Any,<:GutzwillerSampling,<:AbstractOperator}, add)
-    diagH = diagonal_element(s.transform.hamiltonian, add)
-    diagA = diagonal_element(s.op, add)
-    return gutzwiller_modify(diagA, true, s.transform.g, 0., 2 * diagH)
+    return gutzwiller_modify(val, true, s.transform.g, 0.0, 2 * diag)
 end
-
-function num_offdiagonals(s::TransformUndoer{<:Any,<:GutzwillerSampling,<:Any}, add)
-    return num_offdiagonals(s.op, add)
+function modify_offdiagonal(s::GutzwillerTransformUndoer, in, out, val)
+    diag1 = diagonal_element(s.transform.hamiltonian, in)
+    diag2 = diagonal_element(s.transform.hamiltonian, out)
+    return out => gutzwiller_modify(val, true, s.transform.g, 0.0, diag1 + diag2)
 end
-
-function get_offdiagonal(s::TransformUndoer{<:Any,<:GutzwillerSampling,<:Any}, add, chosen)
-    newadd, offd = get_offdiagonal(s.op, add, chosen)
-    # Gutzwiller `f` operator is diagonal
-    diagH1 = diagonal_element(s.transform.hamiltonian, add)
-    diagH2 = diagonal_element(s.transform.hamiltonian, newadd)
-    return newadd, gutzwiller_modify(offd, true, s.transform.g, 0., diagH1 + diagH2)
-end
-
-# methods for special case `f^{-2}`
-LOStructure(::Type{<:TransformUndoer{<:Any,<:GutzwillerSampling,Nothing}}) = IsDiagonal()
-
-function diagonal_element(s::TransformUndoer{<:Any,<:GutzwillerSampling,Nothing}, add)
-    diagH = diagonal_element(s.transform.hamiltonian, add)
-    return gutzwiller_modify(1., true, s.transform.g, 0., 2 * diagH)
-end
-
-num_offdiagonals(s::TransformUndoer{<:Any,<:GutzwillerSampling,Nothing}, add) = 0

--- a/src/Hamiltonians/GutzwillerSampling.jl
+++ b/src/Hamiltonians/GutzwillerSampling.jl
@@ -123,7 +123,7 @@ to calculate observables. Here ``f`` is a diagonal operator whose entries are
 See [`AllOverlaps`](@ref), [`GutzwillerSampling`](@ref).
 """
 function TransformUndoer(k::GutzwillerSampling, op::AbstractOperator)
-    T = typeof(zero(eltype(k)) * zero(eltype(op)))
+    T = promote_type(eltype(k), eltype(op))
     return TransformUndoer{T,typeof(k),typeof(op)}(k, op)
 end
 

--- a/src/Hamiltonians/GutzwillerSampling.jl
+++ b/src/Hamiltonians/GutzwillerSampling.jl
@@ -102,7 +102,7 @@ function gutzwiller_modify(matrix_element, is_adjoint, g, diag1, diag2)
     end
 end
 
-parent_hamiltonian(h::GutzwillerSampling) = h.hamiltonian
+parent_operator(h::GutzwillerSampling) = h.hamiltonian
 modify_diagonal(h::GutzwillerSampling, _, value) = value
 
 function modify_offdiagonal(h::GutzwillerSampling{A}, in, out, value) where {A}

--- a/src/Hamiltonians/GutzwillerSampling.jl
+++ b/src/Hamiltonians/GutzwillerSampling.jl
@@ -20,7 +20,7 @@ After construction, we can access the underlying Hamiltonian with `G.hamiltonian
 
 # Example
 
-```jldoctest filter = r"(\d*)\.(\d{4})\d+" => s"\1.\2"
+```jldoctest
 julia> H = HubbardMom1D(BoseFS(1,1,1); u=6.0, t=1.0)
 HubbardMom1D(fs"|1 1 1⟩"; u=6.0, t=1.0)
 

--- a/src/Hamiltonians/GutzwillerSampling.jl
+++ b/src/Hamiltonians/GutzwillerSampling.jl
@@ -20,7 +20,7 @@ After construction, we can access the underlying Hamiltonian with `G.hamiltonian
 
 # Example
 
-```jldoctest
+```jldoctest filter = r"(\d*)\.(\d{4})\d+" => s"\1.\2"
 julia> H = HubbardMom1D(BoseFS(1,1,1); u=6.0, t=1.0)
 HubbardMom1D(fs"|1 1 1⟩"; u=6.0, t=1.0)
 

--- a/src/Hamiltonians/GutzwillerSampling.jl
+++ b/src/Hamiltonians/GutzwillerSampling.jl
@@ -90,6 +90,8 @@ function LinearAlgebra.adjoint(h::GutzwillerSampling{A}) where {A}
     return GutzwillerSampling{!A,eltype(h_adj),typeof(h_adj)}(h_adj, h.g)
 end
 
+requires_transform_undoer(::GutzwillerSampling) = true
+
 function Base.:(==)(a::GutzwillerSampling{A}, b::GutzwillerSampling{B}) where {A,B}
    return A == B && a.g == b.g && a.hamiltonian == b.hamiltonian
 end

--- a/src/Hamiltonians/GutzwillerSampling.jl
+++ b/src/Hamiltonians/GutzwillerSampling.jl
@@ -90,8 +90,6 @@ function LinearAlgebra.adjoint(h::GutzwillerSampling{A}) where {A}
     return GutzwillerSampling{!A,eltype(h_adj),typeof(h_adj)}(h_adj, h.g)
 end
 
-requires_transform_undoer(::GutzwillerSampling) = true
-
 function Base.:(==)(a::GutzwillerSampling{A}, b::GutzwillerSampling{B}) where {A,B}
    return A == B && a.g == b.g && a.hamiltonian == b.hamiltonian
 end
@@ -128,6 +126,8 @@ function TransformUndoer(k::GutzwillerSampling, op::AbstractOperator)
     T = typeof(zero(eltype(k)) * zero(eltype(op)))
     return TransformUndoer{T,typeof(k),typeof(op)}(k, op)
 end
+
+undo_transform(g::GutzwillerSampling, op::AbstractOperator) = TransformUndoer(g, op)
 
 const GutzwillerTransformUndoer{A} = TransformUndoer{<:Any,<:GutzwillerSampling,A}
 

--- a/src/Hamiltonians/GutzwillerSampling.jl
+++ b/src/Hamiltonians/GutzwillerSampling.jl
@@ -1,13 +1,14 @@
 """
-    GutzwillerSampling(::AbstractHamiltonian; g)
+    GutzwillerSampling(H::AbstractHamiltonian; g)
 
 Wrapper over any [`AbstractHamiltonian`](@ref) that implements Gutzwiller sampling. In this
 importance sampling scheme the Hamiltonian is modified as follows
 ```math
 \\tilde{H}_{ij} = H_{ij} e^{-g(H_{ii} - H_{jj})} .
 ```
-This way off-diagonal spawns to higher-energy configurations are discouraged and
-spawns to lower-energy configurations encouraged for positive `g`.
+This way off-diagonal spawns to higher-energy configurations are discouraged and spawns to
+lower-energy configurations encouraged for positive `g` while keeping the spectrum of the
+Hamiltonian intact.
 
 # Constructor
 
@@ -26,11 +27,33 @@ HubbardMom1D(fs"|1 1 1⟩"; u=6.0, t=1.0)
 julia> G = GutzwillerSampling(H, g=0.3)
 GutzwillerSampling(HubbardMom1D(fs"|1 1 1⟩"; u=6.0, t=1.0); g=0.3)
 
-julia> get_offdiagonal(H, BoseFS(2, 1, 0), 1)
-(BoseFS{3,3}(1, 0, 2), 2.0)
+julia> Matrix(H)
+4×4 Matrix{Float64}:
+ 12.0      4.89898  4.89898  4.89898
+  4.89898  9.0      0.0      0.0
+  4.89898  0.0      9.0      0.0
+  4.89898  0.0      0.0      0.0
 
-julia> get_offdiagonal(G, BoseFS(2, 1, 0), 1)
-(BoseFS{3,3}(1, 0, 2), 0.8131393194811987)
+julia> Matrix(G)
+4×4 Matrix{Float64}:
+  12.0     1.99178  1.99178  0.133858
+  12.0495  9.0      0.0      0.0
+  12.0495  0.0      9.0      0.0
+ 179.294   0.0      0.0      0.0
+
+julia> eigen(Matrix(H)).values
+4-element Vector{Float64}:
+ -2.3661456273236645
+  4.9594958589580465
+  8.999999999999996
+ 18.406649768365643
+
+julia> eigen(Matrix(G)).values
+4-element Vector{Float64}:
+ -2.366145627323686
+  4.959495858958046
+  8.999999999999998
+ 18.40664976836564
 ```
 
 # Observables

--- a/src/Hamiltonians/GutzwillerSampling.jl
+++ b/src/Hamiltonians/GutzwillerSampling.jl
@@ -58,8 +58,7 @@ julia> eigen(Matrix(G)).values
 
 # Observables
 
-To calculate observables, pass the transformed Hamiltonian `G` to
-[`AllOverlaps`](@ref) with keyword argument `transform=G`.
+See [`AllOverlaps`](@ref) for calculation of observables with a transformed Hamiltonian.
 """
 struct GutzwillerSampling{A,T,H<:AbstractHamiltonian{T}} <: ModifiedHamiltonian{T}
     # The A parameter sets whether this is an adjoint or not.

--- a/src/Hamiltonians/Hamiltonians.jl
+++ b/src/Hamiltonians/Hamiltonians.jl
@@ -65,7 +65,8 @@ using ..BitStringAddresses
 using ..Interfaces
 using ..Interfaces: sum_mutating!
 import ..Interfaces: diagonal_element, num_offdiagonals, get_offdiagonal, starting_address,
-    offdiagonals, random_offdiagonal, LOStructure, allows_address_type, operator_column
+    offdiagonals, random_offdiagonal, LOStructure, allows_address_type, operator_column,
+    undo_transform
 
 export dimension, rayleigh_quotient, momentum
 

--- a/src/Hamiltonians/Hamiltonians.jl
+++ b/src/Hamiltonians/Hamiltonians.jl
@@ -69,6 +69,7 @@ import ..Interfaces: diagonal_element, num_offdiagonals, get_offdiagonal, starti
 
 export dimension, rayleigh_quotient, momentum
 
+export IdentityOperator
 export MatrixHamiltonian
 export HubbardReal1D, HubbardMom1D, ExtendedHubbardReal1D, ExtendedHubbardMom1D, HubbardRealSpace
 export HubbardReal1DEP, shift_lattice, shift_lattice_inv

--- a/src/Hamiltonians/Hamiltonians.jl
+++ b/src/Hamiltonians/Hamiltonians.jl
@@ -109,8 +109,6 @@ include("excitations.jl")
 
 include("MatrixHamiltonian.jl")
 
-include("ModifiedHamiltonian.jl")
-
 include("HubbardReal1D.jl")
 include("HubbardReal1DEP.jl")
 include("ExtendedHubbardMom1D.jl")
@@ -121,13 +119,16 @@ include("ExtendedHubbardReal1D.jl")
 
 include("FroehlichPolaron.jl")
 
+include("Transcorrelated1D.jl")
+
+include("ModifiedHamiltonian.jl")
+include("TransformUndoer.jl")
 include("GutzwillerSampling.jl")
 include("GuidingVectorSampling.jl")
 include("ParitySymmetry.jl")
 include("TRSymmetry.jl")
 include("Stoquastic.jl")
 
-include("Transcorrelated1D.jl")
 include("correlation_functions.jl")
 include("G2MomCorrelator.jl")
 include("DensityMatrixDiagonal.jl")

--- a/src/Hamiltonians/Hamiltonians.jl
+++ b/src/Hamiltonians/Hamiltonians.jl
@@ -107,6 +107,8 @@ include("excitations.jl")
 
 include("MatrixHamiltonian.jl")
 
+include("ModifiedHamiltonian.jl")
+
 include("HubbardReal1D.jl")
 include("HubbardReal1DEP.jl")
 include("ExtendedHubbardMom1D.jl")

--- a/src/Hamiltonians/ModifiedHamiltonian.jl
+++ b/src/Hamiltonians/ModifiedHamiltonian.jl
@@ -2,19 +2,19 @@
     abstract type ModifiedHamiltonian{T} <: AbstractHamiltonian{T} end
 
 Abstract type for defining wrappers over [`AbstractHamiltonian`](@ref)s that modify diagonal
-and off-diagonal elements via the functions [`modify_diagonal`](@ref) and
-[`modify_offdiagonal`](@ref).
+and off-diagonal elements via the functions [`modify_diagonal`](@ref Main.Hamiltonians) and
+[`modify_offdiagonal`](@ref Main.Hamiltonians).
 
 The `ModifiedHamiltonian` can only be used to implement wrappers that modify the
 (off)-diagonals individually and cannot be used to introduce additional off-diagonal
 elements to the Hamiltonian.
 
 The following need to be implemented
-* [`parent_hamiltonian`](@ref)
-* [`modify_diagonal`](@ref)
-* [`modify_offdiagonal`](@ref)
+* [`parent_hamiltonian`](@ref Main.Hamiltonians)
+* [`modify_diagonal`](@ref Main.Hamiltonians)
+* [`modify_offdiagonal`](@ref Main.Hamiltonians)
 * [`LOStructure(p)`](@ref) and `Base.adjoint` if known, defaults to
-  [`AdjointUnknown()`](@ref).
+  [`AdjointUnknown`](@ref Main.Interfaces).
 
 The follwing are provided:
 * [`starting_address(op)`](@ref)
@@ -34,6 +34,7 @@ abstract type ModifiedHamiltonian{T} <: AbstractHamiltonian{T} end
     parent_hamiltonian(::ModifiedHamiltonian)
 
 Return the Hamiltonian that is being modified.
+See [`ModifiedHamiltonian`](@ref Main.Hamiltonians).
 """
 parent_hamiltonian
 
@@ -42,6 +43,7 @@ parent_hamiltonian
 
 Modifty the diagonal element where
 `value = diagonal_element(operator_column(parent_hamiltonian(ham), source))`.
+See [`ModifiedHamiltonian`](@ref Main.Hamiltonians).
 """
 modify_diagonal
 
@@ -52,6 +54,7 @@ Modfy an offdiagonal element `dest => element` reachable from `source` in the
 [`parent_hamiltonian`](@ref) of `ham`.
 
 Should return a `Pair` of modified address `addr` and modified value `val`.
+See [`ModifiedHamiltonian`](@ref Main.Hamiltonians).
 """
 modify_offdiagonal
 

--- a/src/Hamiltonians/ModifiedHamiltonian.jl
+++ b/src/Hamiltonians/ModifiedHamiltonian.jl
@@ -10,7 +10,7 @@ The `ModifiedHamiltonian` can only be used to implement wrappers that modify the
 elements to the Hamiltonian.
 
 The following need to be implemented
-* [`parent_hamiltonian`](@ref Main.Hamiltonians)
+* [`parent_operator`](@ref Main.Hamiltonians)
 * [`modify_diagonal`](@ref Main.Hamiltonians)
 * [`modify_offdiagonal`](@ref Main.Hamiltonians)
 * [`LOStructure(p)`](@ref) and `Base.adjoint` if known, defaults to
@@ -31,18 +31,18 @@ The following are provided:
 abstract type ModifiedHamiltonian{T} <: AbstractHamiltonian{T} end
 
 """
-    parent_hamiltonian(::ModifiedHamiltonian)
+    parent_operator(::ModifiedHamiltonian)
 
 Return the Hamiltonian that is being modified.
 See [`ModifiedHamiltonian`](@ref Main.Hamiltonians).
 """
-parent_hamiltonian
+parent_operator
 
 """
     modify_diagonal(ham::ModifiedHamiltonian, source, value) -> val
 
 Modify the diagonal element `value` at address `source` to `val`. Specifically,
-`value = diagonal_element(operator_column(parent_hamiltonian(ham), source))`.
+`value = diagonal_element(operator_column(parent_operator(ham), source))`.
 See [`ModifiedHamiltonian`](@ref Main.Hamiltonians).
 """
 modify_diagonal
@@ -50,8 +50,8 @@ modify_diagonal
 """
     modify_offdiagonal(ham::ModifiedHamiltonian, source, dest, element) -> (addr => val)
 
-Modfy an offdiagonal element `dest => element` reachable from the address 
-`source` in the [`parent_hamiltonian`](@ref) of `ham`.
+Modfy an offdiagonal element `dest => element` reachable from the address
+`source` in the [`parent_operator`](@ref) of `ham`.
 
 Should return a `Pair` of modified address `addr` and modified value `val`.
 See [`ModifiedHamiltonian`](@ref Main.Hamiltonians).
@@ -59,12 +59,12 @@ See [`ModifiedHamiltonian`](@ref Main.Hamiltonians).
 modify_offdiagonal
 
 function allows_address_type(h::ModifiedHamiltonian, ::Type{A}) where {A}
-    return allows_address_type(parent_hamiltonian(h), A)
+    return allows_address_type(parent_operator(h), A)
 end
 
 LOStructure(::Type{<:ModifiedHamiltonian}) = AdjointUnknown()
-starting_address(h::ModifiedHamiltonian) = starting_address(parent_hamiltonian(h))
-dimension(h::ModifiedHamiltonian, address) = dimension(parent_hamiltonian(h), address)
+starting_address(h::ModifiedHamiltonian) = starting_address(parent_operator(h))
+dimension(h::ModifiedHamiltonian, address) = dimension(parent_operator(h), address)
 
 struct ModifiedHamiltonianColumn{
     A,T,H<:ModifiedHamiltonian{T},C
@@ -74,7 +74,7 @@ struct ModifiedHamiltonianColumn{
     column::C
 end
 function operator_column(h::ModifiedHamiltonian, address)
-    column = operator_column(parent_hamiltonian(h), address)
+    column = operator_column(parent_operator(h), address)
     return ModifiedHamiltonianColumn(address, h, column)
 end
 function Base.show(io::IO, col::ModifiedHamiltonianColumn)

--- a/src/Hamiltonians/ModifiedHamiltonian.jl
+++ b/src/Hamiltonians/ModifiedHamiltonian.jl
@@ -36,7 +36,7 @@ abstract type ModifiedHamiltonian{T} <: AbstractHamiltonian{T} end
 Return the Hamiltonian that is being modified.
 See [`ModifiedHamiltonian`](@ref Main.Hamiltonians).
 """
-parent_operator
+parent_operator(::ModifiedHamiltonian)
 
 """
     modify_diagonal(ham::ModifiedHamiltonian, source, value) -> val

--- a/src/Hamiltonians/ModifiedHamiltonian.jl
+++ b/src/Hamiltonians/ModifiedHamiltonian.jl
@@ -2,7 +2,7 @@
     abstract type ModifiedHamiltonian{T} <: AbstractHamiltonian{T} end
 
 Abstract type for defining wrappers over [`AbstractHamiltonian`](@ref)s that modify diagonal
-and off-diagonal elements via the functions 
+and off-diagonal elements via the functions
 [`modify_diagonal`](@ref Main.Hamiltonians.modify_diagonal) and
 [`modify_offdiagonal`](@ref Main.Hamiltonians.modify_offdiagonal).
 
@@ -83,6 +83,7 @@ function Base.show(io::IO, col::ModifiedHamiltonianColumn)
 end
 
 starting_address(col::ModifiedHamiltonianColumn) = starting_address(col.column)
+parent_operator(col::ModifiedHamiltonianColumn) = col.hamiltonian
 
 function diagonal_element(col::ModifiedHamiltonianColumn)
     value = diagonal_element(col.column)

--- a/src/Hamiltonians/ModifiedHamiltonian.jl
+++ b/src/Hamiltonians/ModifiedHamiltonian.jl
@@ -1,0 +1,137 @@
+"""
+    abstract type ModifiedHamiltonian{T} <: AbstractHamiltonian{T} end
+
+Abstract type for defining wrappers over [`AbstractHamiltonian`](@ref)s that modify diagonal
+and off-diagonal elements via the functions [`modify_diagonal`](@ref) and
+[`modify_offdiagonal`](@ref).
+
+The following need to be implemented
+* [`parent_hamiltonian`](@ref)
+* [`modify_diagonal`](@ref)
+* [`modify_offdiagonal`](@ref)
+* [`LOStructure(p)`](@ref) and `Base.adjoint` if known, defaults to
+  [`AdjointUnknown()`](@ref).
+
+The follwing are provided:
+* [`starting_address(op)`](@ref)
+* [`allows_address_type(op, type)`](@ref)
+* [`operator_column(op, address)`](@ref)
+* [`diagonal_element(column)`](@ref)
+* [`num_offdiagonals(column)`](@ref) (this can be an upper bound)
+* [`offdiagonals(column)`](@ref)
+* [`random_offdiagonal(column)`](@ref)
+* [`dimension(op)`](@ref)
+
+"""
+abstract type ModifiedHamiltonian{T} <: AbstractHamiltonian{T} end
+
+"""
+    parent_hamiltonian(::ModifiedHamiltonian)
+
+Return the Hamiltonian that is being modified.
+"""
+parent_hamiltonian
+
+"""
+    modify_diagonal(ham::ModifiedHamiltonian, source, value) -> val
+
+Modifty the diagonal element where
+`value = diagonal_element(operator_column(parent_hamiltonian(ham), source))`.
+"""
+modify_diagonal
+
+"""
+    modify_offdiagonal(ham::ModifiedHamiltonian, source, dest, element) -> (addr => val)
+
+Modfy an offdiagonal element `dest => element` reachable from `source` in the
+[`parent_hamiltonian`](@ref) of `ham`.
+
+Should return a `Pair` of modified address `addr` and modified value `val`.
+"""
+modify_offdiagonal
+
+function allows_address_type(h::ModifiedHamiltonian, ::Type{A}) where {A}
+    return allows_address_type(parent_hamiltonian(h), A)
+end
+
+LOStructure(::ModifiedHamiltonian) = AdjointUnknown()
+starting_address(h::ModifiedHamiltonian) = starting_address(parent_hamiltonian(h))
+
+struct ModifiedHamiltonianColumn{A,H<:ModifiedHamiltonian,C}
+    address::A
+    hamiltonian::H
+    column::C
+end
+function operator_column(h::ModifiedHamiltonian, address)
+    column = operator_column(parent_hamiltonian(h), address)
+    return ModifiedHamiltonianColumn(address, h, column)
+end
+function Base.show(io::IO, col::ModifiedHamiltonianColumn)
+    print(io, "operator_column(", col.hamiltonian, ", ")
+    print(IOContext(io, :compact=>true), col.address, ")")
+end
+
+starting_address(col::ModifiedHamiltonianColumn) = starting_address(col.column)
+
+function diagonal_element(col::ModifiedHamiltonianColumn)
+    value = diagonal_element(col.column)
+    return modify_diagonal(col.hamiltonian, starting_address(col.column), value)
+end
+function num_offdiagonals(col::ModifiedHamiltonianColumn)
+    return num_offdiagonals(col.column)
+end
+
+function random_offdiagonal(col::ModifiedHamiltonianColumn)
+    dest, prob, value = random_offdiagonal(col.column)
+    source = starting_address(col.column)
+    addr, value = modify_offdiagonal(col.hamiltonian, source, dest, value)
+    return addr, prob, value
+end
+
+function offdiagonals(col::ModifiedHamiltonianColumn)
+    ods = offdiagonals(col.column)
+    if ods isa AbstractVector
+        return ModifiedHamiltonianVectorOffdiagonals(col.address, col.hamiltonian, ods)
+    else
+        return ModifiedHamiltonianOffdiagonals(col.address, col.hamiltonian, ods)
+    end
+end
+
+struct ModifiedHamiltonianVectorOffdiagonals{
+    A,T,H<:ModifiedHamiltonian{T},O<:AbstractVector
+} <: AbstractVector{Pair{A,T}}
+    address::A
+    hamiltonian::H
+    offdiagonals::O
+end
+function Base.getindex(ods::ModifiedHamiltonianVectorOffdiagonals, i)
+    return modify_offdiagonal(ods.hamiltonian, ods.address, ods.offdiagonals[i]...)
+end
+Base.size(ods::ModifiedHamiltonianVectorOffdiagonals) = size(ods.offdiagonals)
+
+struct ModifiedHamiltonianOffdiagonals{A,T,H<:ModifiedHamiltonian{T},O}
+    address::A
+    hamiltonian::H
+    offdiagonals::O
+end
+function Base.show(io::IO, ods::ModifiedHamiltonianOffdiagonals)
+    print(io, "offdiagonals(operator_column(", ods.hamiltonian, ", ")
+    print(IOContext(io, :compact=>true), ods.address, "))")
+end
+
+function Base.iterate(ods::ModifiedHamiltonianOffdiagonals, args...)
+    it = iterate(ods.offdiagonals, args...)
+    if isnothing(it)
+        return nothing
+    else
+        result, state = it
+        return modify_offdiagonal(ods.hamiltonian, ods.address, result...), state
+    end
+end
+function Base.IteratorSize(ods::ModifiedHamiltonianOffdiagonals)
+    return Base.IteratorSize(ods.offdiagonals)
+end
+function Base.length(ods::ModifiedHamiltonianOffdiagonals)
+    return length(ods.offdiagonals)
+end
+Base.eltype(::ModifiedHamiltonianOffdiagonals{A,T}) where {A,T} = Pair{A,T}

--- a/src/Hamiltonians/ModifiedHamiltonian.jl
+++ b/src/Hamiltonians/ModifiedHamiltonian.jl
@@ -140,7 +140,6 @@ function Base.length(ods::ModifiedHamiltonianOffdiagonals)
 end
 Base.eltype(::ModifiedHamiltonianOffdiagonals{A,T}) where {A,T} = Pair{A,T}
 
-
 """
     TransformUndoer(transform::AbstractHamiltonian, op::AbstractObservable) <: AbstractHamiltonian
 

--- a/src/Hamiltonians/ModifiedHamiltonian.jl
+++ b/src/Hamiltonians/ModifiedHamiltonian.jl
@@ -11,7 +11,7 @@ The `ModifiedHamiltonian` can only be used to implement wrappers that modify the
 elements to the Hamiltonian.
 
 The following need to be implemented
-* [`parent_operator`](@ref Main.Hamiltonians.parent_operator)
+* [`parent_operator`](@ref Main.Hamiltonians.parent_operator(::Main.Hamiltonians.ModifiedHamiltonian)
 * [`modify_diagonal`](@ref Main.Hamiltonians.modify_diagonal)
 * [`modify_offdiagonal`](@ref Main.Hamiltonians.modify_offdiagonal)
 * [`LOStructure(p)`](@ref) and `Base.adjoint` if known, defaults to `AdjointUnknown`.
@@ -51,7 +51,7 @@ modify_diagonal
     modify_offdiagonal(ham::ModifiedHamiltonian, source, dest, element) -> (addr => val)
 
 Modify an offdiagonal element `dest => element` reachable from the address
-`source` in the [`parent_operator`](@ref) of `ham`.
+`source` in the [`parent_operator`](@ref Hamiltonians.parent_operator(::Main.Hamiltonians.ModifiedHamiltonian)) of `ham`.
 
 Should return a `Pair` of modified address `addr` and modified value `val`.
 See [`ModifiedHamiltonian`](@ref Main.Hamiltonians.ModifiedHamiltonian).

--- a/src/Hamiltonians/ModifiedHamiltonian.jl
+++ b/src/Hamiltonians/ModifiedHamiltonian.jl
@@ -2,8 +2,9 @@
     abstract type ModifiedHamiltonian{T} <: AbstractHamiltonian{T} end
 
 Abstract type for defining wrappers over [`AbstractHamiltonian`](@ref)s that modify diagonal
-and off-diagonal elements via the functions [`modify_diagonal`](@ref Main.Hamiltonians) and
-[`modify_offdiagonal`](@ref Main.Hamiltonians).
+and off-diagonal elements via the functions 
+[`modify_diagonal`](@ref Main.Hamiltonians.modify_diagonal) and
+[`modify_offdiagonal`](@ref Main.Hamiltonians.modify_offdiagonal).
 
 The `ModifiedHamiltonian` can only be used to implement wrappers that modify the
 (off)-diagonals individually and cannot be used to introduce additional off-diagonal

--- a/src/Hamiltonians/ModifiedHamiltonian.jl
+++ b/src/Hamiltonians/ModifiedHamiltonian.jl
@@ -16,7 +16,7 @@ The following need to be implemented
 * [`LOStructure(p)`](@ref) and `Base.adjoint` if known, defaults to
   [`AdjointUnknown`](@ref Main.Interfaces).
 
-The follwing are provided:
+The following are provided:
 * [`starting_address(op)`](@ref)
 * [`allows_address_type(op, type)`](@ref)
 * [`operator_column(op, address)`](@ref)
@@ -41,7 +41,7 @@ parent_hamiltonian
 """
     modify_diagonal(ham::ModifiedHamiltonian, source, value) -> val
 
-Modifty the diagonal element where
+Modify the diagonal element `value` at address `source` to `val`. Specifically,
 `value = diagonal_element(operator_column(parent_hamiltonian(ham), source))`.
 See [`ModifiedHamiltonian`](@ref Main.Hamiltonians).
 """
@@ -50,8 +50,8 @@ modify_diagonal
 """
     modify_offdiagonal(ham::ModifiedHamiltonian, source, dest, element) -> (addr => val)
 
-Modfy an offdiagonal element `dest => element` reachable from `source` in the
-[`parent_hamiltonian`](@ref) of `ham`.
+Modfy an offdiagonal element `dest => element` reachable from the address 
+`source` in the [`parent_hamiltonian`](@ref) of `ham`.
 
 Should return a `Pair` of modified address `addr` and modified value `val`.
 See [`ModifiedHamiltonian`](@ref Main.Hamiltonians).

--- a/src/Hamiltonians/ModifiedHamiltonian.jl
+++ b/src/Hamiltonians/ModifiedHamiltonian.jl
@@ -10,11 +10,11 @@ The `ModifiedHamiltonian` can only be used to implement wrappers that modify the
 elements to the Hamiltonian.
 
 The following need to be implemented
-* [`parent_operator`](@ref Main.Hamiltonians)
-* [`modify_diagonal`](@ref Main.Hamiltonians)
-* [`modify_offdiagonal`](@ref Main.Hamiltonians)
+* [`parent_operator`](@ref Main.Hamiltonians.parent_operator)
+* [`modify_diagonal`](@ref Main.Hamiltonians.modify_diagonal)
+* [`modify_offdiagonal`](@ref Main.Hamiltonians.modfy_offdiagonal)
 * [`LOStructure(p)`](@ref) and `Base.adjoint` if known, defaults to
-  [`AdjointUnknown`](@ref Main.Interfaces).
+  [`AdjointUnknown`](@ref Main.Interfaces.AdjointUnknown).
 
 The following are provided:
 * [`starting_address(op)`](@ref)
@@ -43,7 +43,7 @@ parent_operator
 
 Modify the diagonal element `value` at address `source` to `val`. Specifically,
 `value = diagonal_element(operator_column(parent_operator(ham), source))`.
-See [`ModifiedHamiltonian`](@ref Main.Hamiltonians).
+See [`ModifiedHamiltonian`](@ref Main.Hamiltonians.ModifiedHamiltonian).
 """
 modify_diagonal
 
@@ -54,7 +54,7 @@ Modfy an offdiagonal element `dest => element` reachable from the address
 `source` in the [`parent_operator`](@ref) of `ham`.
 
 Should return a `Pair` of modified address `addr` and modified value `val`.
-See [`ModifiedHamiltonian`](@ref Main.Hamiltonians).
+See [`ModifiedHamiltonian`](@ref Main.Hamiltonians.ModifiedHamiltonian).
 """
 modify_offdiagonal
 

--- a/src/Hamiltonians/ModifiedHamiltonian.jl
+++ b/src/Hamiltonians/ModifiedHamiltonian.jl
@@ -12,7 +12,7 @@ elements to the Hamiltonian.
 The following need to be implemented
 * [`parent_operator`](@ref Main.Hamiltonians.parent_operator)
 * [`modify_diagonal`](@ref Main.Hamiltonians.modify_diagonal)
-* [`modify_offdiagonal`](@ref Main.Hamiltonians.modfy_offdiagonal)
+* [`modify_offdiagonal`](@ref Main.Hamiltonians.modify_offdiagonal)
 * [`LOStructure(p)`](@ref) and `Base.adjoint` if known, defaults to
   [`AdjointUnknown`](@ref Main.Interfaces.AdjointUnknown).
 
@@ -50,7 +50,7 @@ modify_diagonal
 """
     modify_offdiagonal(ham::ModifiedHamiltonian, source, dest, element) -> (addr => val)
 
-Modfy an offdiagonal element `dest => element` reachable from the address
+Modify an offdiagonal element `dest => element` reachable from the address
 `source` in the [`parent_operator`](@ref) of `ham`.
 
 Should return a `Pair` of modified address `addr` and modified value `val`.

--- a/src/Hamiltonians/ModifiedHamiltonian.jl
+++ b/src/Hamiltonians/ModifiedHamiltonian.jl
@@ -13,8 +13,7 @@ The following need to be implemented
 * [`parent_operator`](@ref Main.Hamiltonians.parent_operator)
 * [`modify_diagonal`](@ref Main.Hamiltonians.modify_diagonal)
 * [`modify_offdiagonal`](@ref Main.Hamiltonians.modify_offdiagonal)
-* [`LOStructure(p)`](@ref) and `Base.adjoint` if known, defaults to
-  [`AdjointUnknown`](@ref Main.Interfaces.AdjointUnknown).
+* [`LOStructure(p)`](@ref) and `Base.adjoint` if known, defaults to `AdjointUnknown`.
 
 The following are provided:
 * [`starting_address(op)`](@ref)

--- a/src/Hamiltonians/ModifiedHamiltonian.jl
+++ b/src/Hamiltonians/ModifiedHamiltonian.jl
@@ -5,6 +5,10 @@ Abstract type for defining wrappers over [`AbstractHamiltonian`](@ref)s that mod
 and off-diagonal elements via the functions [`modify_diagonal`](@ref) and
 [`modify_offdiagonal`](@ref).
 
+The `ModifiedHamiltonian` can only be used to implement wrappers that modify the
+(off)-diagonals individually and cannot be used to introduce additional off-diagonal
+elements to the Hamiltonian.
+
 The following need to be implemented
 * [`parent_hamiltonian`](@ref)
 * [`modify_diagonal`](@ref)
@@ -139,51 +143,3 @@ function Base.length(ods::ModifiedHamiltonianOffdiagonals)
     return length(ods.offdiagonals)
 end
 Base.eltype(::ModifiedHamiltonianOffdiagonals{A,T}) where {A,T} = Pair{A,T}
-
-"""
-    TransformUndoer(transform::AbstractHamiltonian, op::AbstractObservable) <: AbstractHamiltonian
-
-Create a new operator for the purpose of calculating overlaps of transformed
-vectors, which are defined by some transformation `transform`. The new operator should
-represent the effect of undoing the transformation before calculating overlaps, including
-with an optional operator `op`.
-
-Not exported; transformations should define all necessary methods and properties,
-see [`AbstractHamiltonian`](@ref). An `ArgumentError` is thrown if used with an
-unsupported transformation.
-
-# Example
-
-A similarity transform ``\\hat{G} = f \\hat{H} f^{-1}`` has eigenvector
-``d = f \\cdot c`` where ``c`` is an eigenvector of ``\\hat{H}``. Then the
-overlap ``c' \\cdot c = d' \\cdot f^{-2} \\cdot d`` can be computed by defining all
-necessary methods for `TransformUndoer(G)` to represent the operator ``f^{-2}`` and
-calculating `dot(d, TransformUndoer(G), d)`.
-
-Observables in the transformed basis can be computed by defining `TransformUndoer(G, A)`
-to represent ``f^{-1} A f^{-1}``.
-
-# Supported transformations
-
-* [`GutzwillerSampling`](@ref)
-* [`GuidingVectorSampling`](@ref)
-"""
-struct TransformUndoer{
-    T,K<:AbstractHamiltonian,O<:AbstractObservable
-} <: ModifiedHamiltonian{T}
-    transform::K
-    op::O
-end
-function TransformUndoer(k::AbstractHamiltonian, op)
-    return throw(ArgumentError("Unsupported transformation: $k"))
-end
-function TransformUndoer(k::AbstractHamiltonian)
-    return TransformUndoer(k, IdentityOperator())
-end
-parent_hamiltonian(t::TransformUndoer) = t.op
-starting_address(t::TransformUndoer) = starting_address(t.transform)
-
-# common methods
-function Base.:(==)(a::TransformUndoer, b::TransformUndoer)
-    return a.transform == b.transform && a.op == b.op
-end

--- a/src/Hamiltonians/ModifiedHamiltonian.jl
+++ b/src/Hamiltonians/ModifiedHamiltonian.jl
@@ -18,9 +18,10 @@ The follwing are provided:
 * [`operator_column(op, address)`](@ref)
 * [`diagonal_element(column)`](@ref)
 * [`num_offdiagonals(column)`](@ref) (this can be an upper bound)
+* [`starting_address(column)`](@ref)
 * [`offdiagonals(column)`](@ref)
 * [`random_offdiagonal(column)`](@ref)
-* [`dimension(op)`](@ref)
+* [`dimension(op, address)`](@ref)
 
 """
 abstract type ModifiedHamiltonian{T} <: AbstractHamiltonian{T} end
@@ -54,10 +55,13 @@ function allows_address_type(h::ModifiedHamiltonian, ::Type{A}) where {A}
     return allows_address_type(parent_hamiltonian(h), A)
 end
 
-LOStructure(::ModifiedHamiltonian) = AdjointUnknown()
+LOStructure(::Type{<:ModifiedHamiltonian}) = AdjointUnknown()
 starting_address(h::ModifiedHamiltonian) = starting_address(parent_hamiltonian(h))
+dimension(h::ModifiedHamiltonian, address) = dimension(parent_hamiltonian(h), address)
 
-struct ModifiedHamiltonianColumn{A,H<:ModifiedHamiltonian,C}
+struct ModifiedHamiltonianColumn{
+    A,T,H<:ModifiedHamiltonian{T},C
+} <: AbstractOperatorColumn{A,T,H}
     address::A
     hamiltonian::H
     column::C
@@ -135,3 +139,52 @@ function Base.length(ods::ModifiedHamiltonianOffdiagonals)
     return length(ods.offdiagonals)
 end
 Base.eltype(::ModifiedHamiltonianOffdiagonals{A,T}) where {A,T} = Pair{A,T}
+
+
+"""
+    TransformUndoer(transform::AbstractHamiltonian, op::AbstractObservable) <: AbstractHamiltonian
+
+Create a new operator for the purpose of calculating overlaps of transformed
+vectors, which are defined by some transformation `transform`. The new operator should
+represent the effect of undoing the transformation before calculating overlaps, including
+with an optional operator `op`.
+
+Not exported; transformations should define all necessary methods and properties,
+see [`AbstractHamiltonian`](@ref). An `ArgumentError` is thrown if used with an
+unsupported transformation.
+
+# Example
+
+A similarity transform ``\\hat{G} = f \\hat{H} f^{-1}`` has eigenvector
+``d = f \\cdot c`` where ``c`` is an eigenvector of ``\\hat{H}``. Then the
+overlap ``c' \\cdot c = d' \\cdot f^{-2} \\cdot d`` can be computed by defining all
+necessary methods for `TransformUndoer(G)` to represent the operator ``f^{-2}`` and
+calculating `dot(d, TransformUndoer(G), d)`.
+
+Observables in the transformed basis can be computed by defining `TransformUndoer(G, A)`
+to represent ``f^{-1} A f^{-1}``.
+
+# Supported transformations
+
+* [`GutzwillerSampling`](@ref)
+* [`GuidingVectorSampling`](@ref)
+"""
+struct TransformUndoer{
+    T,K<:AbstractHamiltonian,O<:AbstractObservable
+} <: ModifiedHamiltonian{T}
+    transform::K
+    op::O
+end
+function TransformUndoer(k::AbstractHamiltonian, op)
+    return throw(ArgumentError("Unsupported transformation: $k"))
+end
+function TransformUndoer(k::AbstractHamiltonian)
+    return TransformUndoer(k, IdentityOperator())
+end
+parent_hamiltonian(t::TransformUndoer) = t.op
+starting_address(t::TransformUndoer) = starting_address(t.transform)
+
+# common methods
+function Base.:(==)(a::TransformUndoer, b::TransformUndoer)
+    return a.transform == b.transform && a.op == b.op
+end

--- a/src/Hamiltonians/ParitySymmetry.jl
+++ b/src/Hamiltonians/ParitySymmetry.jl
@@ -68,7 +68,7 @@ function starting_address(h::ParitySymmetry)
     return min(addr, reverse(addr))
 end
 
-parent_hamiltonian(h::ParitySymmetry) = h.hamiltonian
+parent_operator(h::ParitySymmetry) = h.hamiltonian
 modify_diagonal(::ParitySymmetry, _, val) = val
 
 function modify_offdiagonal(h::ParitySymmetry, in, out, val)

--- a/src/Hamiltonians/ParitySymmetry.jl
+++ b/src/Hamiltonians/ParitySymmetry.jl
@@ -40,7 +40,7 @@ true
 ```
 See also [`TimeReversalSymmetry`](@ref).
 """
-struct ParitySymmetry{T,H<:AbstractHamiltonian{T}} <: AbstractHamiltonian{T}
+struct ParitySymmetry{T,H<:AbstractHamiltonian{T}} <: ModifiedHamiltonian{T}
     hamiltonian::H
     even::Bool
 end
@@ -64,36 +64,17 @@ LOStructure(h::ParitySymmetry) = LOStructure(h.hamiltonian)
 Base.adjoint(h::ParitySymmetry) = ParitySymmetry(h.hamiltonian', even=h.even)
 
 function starting_address(h::ParitySymmetry)
-    add = starting_address(h.hamiltonian)
-    return min(add, reverse(add))
+    addr = starting_address(h.hamiltonian)
+    return min(addr, reverse(addr))
 end
 
-dimension(h::ParitySymmetry, addr) = dimension(h.hamiltonian, addr) # upper bound
+parent_hamiltonian(h::ParitySymmetry) = h.hamiltonian
+modify_diagonal(::ParitySymmetry, _, val) = val
 
-get_offdiagonal(h::ParitySymmetry, add, i) = offdiagonals(h, add)[i]
-num_offdiagonals(h::ParitySymmetry, add) = num_offdiagonals(h.hamiltonian, add)
-
-struct ParitySymmetryOffdiagonals{
-    A,T,O<:AbstractVector{Tuple{A,T}}
-} <: AbstractOffdiagonals{A,T}
-    add::A
-    add_even::Bool
-    od::O
-    even::Bool
-end
-Base.size(o::ParitySymmetryOffdiagonals) = size(o.od)
-
-function offdiagonals(h::ParitySymmetry, add)
-    add_even = add == reverse(add)
-    return ParitySymmetryOffdiagonals(add, add_even, offdiagonals(h.hamiltonian, add), h.even)
-end
-
-function Base.getindex(o::ParitySymmetryOffdiagonals, i)
-    in = o.add
-    out, val = o.od[i]
+function modify_offdiagonal(h::ParitySymmetry, in, out, val)
+    in_even = in == reverse(in)
 
     rev_out = reverse(out)
-    in_even = o.add_even
     out_even = out == rev_out
 
     if in_even && !out_even
@@ -104,15 +85,11 @@ function Base.getindex(o::ParitySymmetryOffdiagonals, i)
         new_val = float(val)
     end
 
-    left_out = min(rev_out, out)
-    if !o.even && left_out ≠ out
+    final_out = min(rev_out, out)
+    if !h.even && final_out ≠ out
         new_val = -new_val
-    elseif !o.even && out_even
+    elseif !h.even && out_even
         new_val = zero(new_val)
     end
-    return left_out, new_val
-end
-
-function diagonal_element(h::ParitySymmetry, add)
-    return diagonal_element(h.hamiltonian, add)
+    return final_out => new_val
 end

--- a/src/Hamiltonians/Stoquastic.jl
+++ b/src/Hamiltonians/Stoquastic.jl
@@ -6,22 +6,15 @@ elements `v` by `-abs(v)`, thus making the new Hamiltonian *stoquastic*.
 A stoquastic Hamiltonian does not have a Monte Carlo sign problem. For a hermitian `ham`
 the smallest eigenvalue of `Stoquastic(ham)` is ≤ the smallest eigenvalue of `ham`.
 """
-struct Stoquastic{T,H} <: AbstractHamiltonian{T}
+struct Stoquastic{T,H} <: ModifiedHamiltonian{T}
     hamiltonian::H
 end
 
 Stoquastic(h) = Stoquastic{eltype(h),typeof(h)}(h)
 
-starting_address(h::Stoquastic) = starting_address(h.hamiltonian)
-
 LOStructure(::Type{<:Stoquastic{<:Any,H}}) where {H} = LOStructure(H)
 Base.adjoint(h::Stoquastic) = Stoquastic(h.hamiltonian')
 
-dimension(h::Stoquastic, address) = dimension(h.hamiltonian, address)
-num_offdiagonals(h::Stoquastic, address) = num_offdiagonals(h.hamiltonian, address)
-diagonal_element(h::Stoquastic, address) = diagonal_element(h.hamiltonian, address)
-
-function get_offdiagonal(h::Stoquastic, address, chosen)
-    naddress, matrix_element = get_offdiagonal(h.hamiltonian, address, chosen)
-    return naddress, -abs(matrix_element)
-end
+parent_hamiltonian(h::Stoquastic) = h.hamiltonian
+modify_diagonal(h::Stoquastic, _, value) = value
+modify_offdiagonal(h::Stoquastic{T}, _, _, value) where {T} = T(-abs(value))

--- a/src/Hamiltonians/Stoquastic.jl
+++ b/src/Hamiltonians/Stoquastic.jl
@@ -17,4 +17,4 @@ Base.adjoint(h::Stoquastic) = Stoquastic(h.hamiltonian')
 
 parent_hamiltonian(h::Stoquastic) = h.hamiltonian
 modify_diagonal(h::Stoquastic, _, value) = value
-modify_offdiagonal(h::Stoquastic{T}, _, _, value) where {T} = T(-abs(value))
+modify_offdiagonal(h::Stoquastic{T}, _, addr, value) where {T} = addr => T(-abs(value))

--- a/src/Hamiltonians/Stoquastic.jl
+++ b/src/Hamiltonians/Stoquastic.jl
@@ -15,6 +15,6 @@ Stoquastic(h) = Stoquastic{eltype(h),typeof(h)}(h)
 LOStructure(::Type{<:Stoquastic{<:Any,H}}) where {H} = LOStructure(H)
 Base.adjoint(h::Stoquastic) = Stoquastic(h.hamiltonian')
 
-parent_hamiltonian(h::Stoquastic) = h.hamiltonian
+parent_operator(h::Stoquastic) = h.hamiltonian
 modify_diagonal(h::Stoquastic, _, value) = value
 modify_offdiagonal(h::Stoquastic{T}, _, addr, value) where {T} = addr => T(-abs(value))

--- a/src/Hamiltonians/TRSymmetry.jl
+++ b/src/Hamiltonians/TRSymmetry.jl
@@ -70,7 +70,7 @@ function starting_address(h::TimeReversalSymmetry)
     return min(add, time_reverse(add))
 end
 
-parent_hamiltonian(h::TimeReversalSymmetry) = h.hamiltonian
+parent_operator(h::TimeReversalSymmetry) = h.hamiltonian
 modify_diagonal(::TimeReversalSymmetry, _, val) = val
 
 function modify_offdiagonal(h::TimeReversalSymmetry, in, out, val)

--- a/src/Hamiltonians/TRSymmetry.jl
+++ b/src/Hamiltonians/TRSymmetry.jl
@@ -32,7 +32,7 @@ true
 ```
 See also [`ParitySymmetry`](@ref).
 """
-struct TimeReversalSymmetry{T,H<:AbstractHamiltonian{T}} <: AbstractHamiltonian{T}
+struct TimeReversalSymmetry{T,H<:AbstractHamiltonian{T}} <: ModifiedHamiltonian{T}
     hamiltonian::H
     even::Bool
 end
@@ -62,8 +62,6 @@ function Base.show(io::IO, h::TimeReversalSymmetry)
     print(io, "TimeReversalSymmetry(", h.hamiltonian, ", even=", h.even, ")")
 end
 
-dimension(h::TimeReversalSymmetry, addr) = dimension(h.hamiltonian, addr) # upper bound
-
 LOStructure(h::TimeReversalSymmetry) = LOStructure(h.hamiltonian)
 Base.adjoint(h::TimeReversalSymmetry) = TimeReversalSymmetry(h.hamiltonian', even=h.even)
 
@@ -72,30 +70,12 @@ function starting_address(h::TimeReversalSymmetry)
     return min(add, time_reverse(add))
 end
 
-get_offdiagonal(h::TimeReversalSymmetry, add, i) = offdiagonals(h, add)[i]
-num_offdiagonals(h::TimeReversalSymmetry, add) = num_offdiagonals(h.hamiltonian, add)
+parent_hamiltonian(h::TimeReversalSymmetry) = h.hamiltonian
+modify_diagonal(::TimeReversalSymmetry, _, val) = val
 
-struct TRSymmetryOffdiagonals{
-    A,T,O<:AbstractVector{Tuple{A,T}}
-} <: AbstractOffdiagonals{A,T}
-    add::A
-    add_even::Bool
-    od::O
-    even::Bool
-end
-Base.size(o::TRSymmetryOffdiagonals) = size(o.od)
-
-function offdiagonals(h::TimeReversalSymmetry, add)
-    add_even = add == time_reverse(add)
-    return TRSymmetryOffdiagonals(add, add_even, offdiagonals(h.hamiltonian, add), h.even)
-end
-
-function Base.getindex(o::TRSymmetryOffdiagonals, i)
-    in = o.add
-    out, val = o.od[i]
-
+function modify_offdiagonal(h::TimeReversalSymmetry, in, out, val)
     rev_out = time_reverse(out)
-    in_even = o.add_even
+    in_even = in == time_reverse(in)
     out_even = out == rev_out
 
     if in_even && !out_even
@@ -106,14 +86,11 @@ function Base.getindex(o::TRSymmetryOffdiagonals, i)
         new_val = float(val)
     end
 
-    left_out = min(rev_out, out)
-    if !o.even && left_out ≠ out
+    final_out = min(rev_out, out)
+    if !h.even && final_out ≠ out
         new_val = -new_val
-    elseif !o.even && out_even
+    elseif !h.even && out_even
         new_val = zero(new_val)
     end
-    return left_out, new_val
-end
-function diagonal_element(h::TimeReversalSymmetry, add)
-    return diagonal_element(h.hamiltonian, add)
+    return final_out => new_val
 end

--- a/src/Hamiltonians/TransformUndoer.jl
+++ b/src/Hamiltonians/TransformUndoer.jl
@@ -1,0 +1,47 @@
+"""
+    TransformUndoer(transform::AbstractHamiltonian, op::AbstractObservable) <: AbstractHamiltonian
+
+Create a new operator for the purpose of calculating overlaps of transformed
+vectors, which are defined by some transformation `transform`. The new operator should
+represent the effect of undoing the transformation before calculating overlaps, including
+with an optional operator `op`.
+
+Not exported; transformations should define all necessary methods and properties,
+see [`AbstractHamiltonian`](@ref). An `ArgumentError` is thrown if used with an
+unsupported transformation.
+
+# Example
+
+A similarity transform ``\\hat{G} = f \\hat{H} f^{-1}`` has eigenvector
+``d = f \\cdot c`` where ``c`` is an eigenvector of ``\\hat{H}``. Then the
+overlap ``c' \\cdot c = d' \\cdot f^{-2} \\cdot d`` can be computed by defining all
+necessary methods for `TransformUndoer(G)` to represent the operator ``f^{-2}`` and
+calculating `dot(d, TransformUndoer(G), d)`.
+
+Observables in the transformed basis can be computed by defining `TransformUndoer(G, A)`
+to represent ``f^{-1} A f^{-1}``.
+
+# Supported transformations
+
+* [`GutzwillerSampling`](@ref)
+* [`GuidingVectorSampling`](@ref)
+"""
+struct TransformUndoer{
+    T,K<:AbstractHamiltonian,O<:AbstractObservable
+} <: ModifiedHamiltonian{T}
+    transform::K
+    op::O
+end
+function TransformUndoer(k::AbstractHamiltonian, op)
+    return throw(ArgumentError("Unsupported transformation: $k"))
+end
+function TransformUndoer(k::AbstractHamiltonian)
+    return TransformUndoer(k, IdentityOperator())
+end
+parent_hamiltonian(t::TransformUndoer) = t.op
+starting_address(t::TransformUndoer) = starting_address(t.transform)
+
+# common methods
+function Base.:(==)(a::TransformUndoer, b::TransformUndoer)
+    return a.transform == b.transform && a.op == b.op
+end

--- a/src/Hamiltonians/TransformUndoer.jl
+++ b/src/Hamiltonians/TransformUndoer.jl
@@ -38,7 +38,7 @@ end
 function TransformUndoer(k::AbstractHamiltonian)
     return TransformUndoer(k, IdentityOperator())
 end
-parent_hamiltonian(t::TransformUndoer) = t.op
+parent_operator(t::TransformUndoer) = t.op
 starting_address(t::TransformUndoer) = starting_address(t.transform)
 
 # common methods

--- a/src/Hamiltonians/abstract.jl
+++ b/src/Hamiltonians/abstract.jl
@@ -263,6 +263,7 @@ operator_column(::IdentityOperator, addr) = IdentityOperatorColumn(addr)
 num_offdiagonals(::IdentityOperatorColumn) = 0
 diagonal_element(::IdentityOperatorColumn) = 1.0
 starting_address(col::IdentityOperatorColumn) = col.address
+parent_operator(::IdentityOperatorColumn) = IdentityOperator()
 
 struct IdentityOperatorOffdiagonals{A} <: AbstractVector{Pair{A,Float64}}
     address::A

--- a/src/Hamiltonians/abstract.jl
+++ b/src/Hamiltonians/abstract.jl
@@ -257,7 +257,7 @@ LOStructure(::Type{<:IdentityOperator}) = IsDiagonal()
 allows_address_type(::IdentityOperator, ::Any) = true
 allows_address_type(::IdentityOperator, ::Type{<:Any}) = true
 
-struct IdentityOperatorColumn{A}
+struct IdentityOperatorColumn{A} <: AbstractOperatorColumn{A,T,IdentityOperator}
     address::A
 end
 operator_column(::IdentityOperator, addr) = IdentityOperatorColumn(addr)

--- a/src/Hamiltonians/abstract.jl
+++ b/src/Hamiltonians/abstract.jl
@@ -246,50 +246,28 @@ function LinearAlgebra.adjoint(::IsDiagonal, op)
     end
 end
 
+
 """
-    TransformUndoer(transform::AbstractHamiltonian, op::AbstractObservable) <: AbstractHamiltonian
+    IdentityOperator() <: AbstractOperator{Float64}
 
-Create a new operator for the purpose of calculating overlaps of transformed
-vectors, which are defined by some transformation `transform`. The new operator should
-represent the effect of undoing the transformation before calculating overlaps, including
-with an optional operator `op`.
-
-Not exported; transformations should define all necessary methods and properties,
-see [`AbstractHamiltonian`](@ref). An `ArgumentError` is thrown if used with an
-unsupported transformation.
-
-# Example
-
-A similarity transform ``\\hat{G} = f \\hat{H} f^{-1}`` has eigenvector
-``d = f \\cdot c`` where ``c`` is an eigenvector of ``\\hat{H}``. Then the
-overlap ``c' \\cdot c = d' \\cdot f^{-2} \\cdot d`` can be computed by defining all
-necessary methods for `TransformUndoer(G)` to represent the operator ``f^{-2}`` and
-calculating `dot(d, TransformUndoer(G), d)`.
-
-Observables in the transformed basis can be computed by defining `TransformUndoer(G, A)`
-to represent ``f^{-1} A f^{-1}``.
-
-# Supported transformations
-
-* [`GutzwillerSampling`](@ref)
-* [`GuidingVectorSampling`](@ref)
+The diagonal operator with 1.0 along its diagonal.
 """
-struct TransformUndoer{
-    T,K<:AbstractHamiltonian,O<:Union{AbstractObservable,Nothing}
-} <: AbstractHamiltonian{T}
-    transform::K
-    op::O
-end
+struct IdentityOperator <: AbstractOperator{Float64} end
+LOStructure(::Type{<:IdentityOperator}) = IsDiagonal()
+allows_address_type(::IdentityOperator, ::Any) = true
+allows_address_type(::IdentityOperator, ::Type{<:Any}) = true
 
-function TransformUndoer(k::AbstractHamiltonian, op)
-    # default check
-    throw(ArgumentError("Unsupported transformation: $k"))
+struct IdentityOperatorColumn{A}
+    address::A
 end
-TransformUndoer(k::AbstractHamiltonian) = TransformUndoer(k::AbstractHamiltonian, nothing)
+operator_column(::IdentityOperator, addr) = IdentityOperatorColumn(addr)
+num_offdiagonals(::IdentityOperatorColumn) = 0
+diagonal_element(::IdentityOperatorColumn) = 1.0
+starting_address(col::IdentityOperatorColumn) = col.address
 
-# common methods
-starting_address(s::TransformUndoer) = starting_address(s.transform)
-dimension(s::TransformUndoer, addr) = dimension(s.transform, addr)
-function Base.:(==)(a::TransformUndoer, b::TransformUndoer)
-    return a.transform == b.transform && a.op == b.op
+struct IdentityOperatorOffdiagonals{A} <: AbstractVector{Pair{A,Float64}}
+    address::A
 end
+offdiagonals(col::IdentityOperatorColumn) = IdentityOperatorOffdiagonals(col.address)
+Base.size(::IdentityOperatorOffdiagonals) = (0,)
+Base.getindex(ods::IdentityOperatorOffdiagonals, i) = throw(BoundsError(ods, i))

--- a/src/Hamiltonians/abstract.jl
+++ b/src/Hamiltonians/abstract.jl
@@ -257,7 +257,7 @@ LOStructure(::Type{<:IdentityOperator}) = IsDiagonal()
 allows_address_type(::IdentityOperator, ::Any) = true
 allows_address_type(::IdentityOperator, ::Type{<:Any}) = true
 
-struct IdentityOperatorColumn{A} <: AbstractOperatorColumn{A,T,IdentityOperator}
+struct IdentityOperatorColumn{A} <: AbstractOperatorColumn{A,Float64,IdentityOperator}
     address::A
 end
 operator_column(::IdentityOperator, addr) = IdentityOperatorColumn(addr)

--- a/src/Hamiltonians/abstract.jl
+++ b/src/Hamiltonians/abstract.jl
@@ -271,3 +271,6 @@ end
 offdiagonals(col::IdentityOperatorColumn) = IdentityOperatorOffdiagonals(col.address)
 Base.size(::IdentityOperatorOffdiagonals) = (0,)
 Base.getindex(ods::IdentityOperatorOffdiagonals, i) = throw(BoundsError(ods, i))
+
+LinearAlgebra.dot(v::AbstractDVec, ::IdentityOperator, w::AbstractDVec) = dot(v, w)
+dot_from_right(v::AbstractDVec, ::IdentityOperator, w::AbstractDVec) = dot(v, w)

--- a/src/Hamiltonians/abstract.jl
+++ b/src/Hamiltonians/abstract.jl
@@ -254,7 +254,6 @@ The diagonal operator with 1.0 along its diagonal.
 """
 struct IdentityOperator <: AbstractOperator{Float64} end
 LOStructure(::Type{<:IdentityOperator}) = IsDiagonal()
-allows_address_type(::IdentityOperator, ::Any) = true
 allows_address_type(::IdentityOperator, ::Type{<:Any}) = true
 
 struct IdentityOperatorColumn{A} <: AbstractOperatorColumn{A,Float64,IdentityOperator}

--- a/src/Interfaces/Interfaces.jl
+++ b/src/Interfaces/Interfaces.jl
@@ -24,6 +24,7 @@ Follow the links for the definitions of the interfaces!
 * [`starting_address`](@ref)
 * [`LOStructure`](@ref)
 * [`allows_address_type`](@ref)
+* [`requires_transform_undoer`](@ref)
 
 ## working with  [`AbstractDVec`](@ref)s and [`StochasticStyle`](@ref)
 * [`deposit!`](@ref)
@@ -59,9 +60,10 @@ export
     apply_operator!, sort_into_targets!, sum_mutating!
 export
     AbstractHamiltonian, diagonal_element, num_offdiagonals, get_offdiagonal, offdiagonals,
-    random_offdiagonal, starting_address, allows_address_type,
+    random_offdiagonal, starting_address, allows_address_type, requires_transform_undoer,
     LOStructure, IsDiagonal, IsHermitian, AdjointKnown, AdjointUnknown, has_adjoint,
-    AbstractOperator, AbstractObservable, operator_column, OffdiagonalsOperatorColumn, AbstractOperatorColumn
+    AbstractOperator, AbstractObservable, operator_column, OffdiagonalsOperatorColumn,
+    AbstractOperatorColumn
 export
     num_replicas, num_spectral_states, num_overlaps
 

--- a/src/Interfaces/Interfaces.jl
+++ b/src/Interfaces/Interfaces.jl
@@ -24,7 +24,7 @@ Follow the links for the definitions of the interfaces!
 * [`starting_address`](@ref)
 * [`LOStructure`](@ref)
 * [`allows_address_type`](@ref)
-* [`requires_transform_undoer`](@ref)
+* [`undo_transform`](@ref)
 
 ## working with  [`AbstractDVec`](@ref)s and [`StochasticStyle`](@ref)
 * [`deposit!`](@ref)
@@ -60,7 +60,7 @@ export
     apply_operator!, sort_into_targets!, sum_mutating!
 export
     AbstractHamiltonian, diagonal_element, num_offdiagonals, get_offdiagonal, offdiagonals,
-    random_offdiagonal, starting_address, allows_address_type, requires_transform_undoer,
+    random_offdiagonal, starting_address, allows_address_type, undo_transform,
     LOStructure, IsDiagonal, IsHermitian, AdjointKnown, AdjointUnknown, has_adjoint,
     AbstractOperator, AbstractObservable, operator_column, OffdiagonalsOperatorColumn,
     AbstractOperatorColumn

--- a/src/Interfaces/hamiltonians.jl
+++ b/src/Interfaces/hamiltonians.jl
@@ -104,6 +104,7 @@ Alternatively, if the generation of matrix elements is more complicated:
 - [`operator_column(op, address)`](@ref)
 - [`diagonal_element(column)`](@ref)
 - [`num_offdiagonals(column)`](@ref) (this can be an upper bound)
+- [`starting_address(column)`](@ref)
 - [`offdiagonals(column)`](@ref)
 - [`random_offdiagonal(column)`](@ref)
 
@@ -418,7 +419,7 @@ has_adjoint(::LOStructure) = true
 """
     AbstractOperatorColumn{A,T,O}
 
-Abstract type for operator columns returned by [`operator_column`](@ref). 
+Abstract type for operator columns returned by [`operator_column`](@ref).
 The type parameters represent the address type (`A`), the eltype (`T`), and the
 type of the operator (`O`).
 

--- a/src/Interfaces/hamiltonians.jl
+++ b/src/Interfaces/hamiltonians.jl
@@ -503,6 +503,8 @@ construct the column with [`operator_column`](@ref).
 Part of the [`AbstractHamiltonian`](@ref) and [`AbstractOperator`](@ref) interface.
 See also [`AbstractOperatorColumn`](@ref) and [`operator_column`](@ref).
 """
+parent_operator(::AbstractOperatorColumn)
+
 parent_operator(c::OffdiagonalsOperatorColumn) = c.operator
 
 """

--- a/src/Interfaces/hamiltonians.jl
+++ b/src/Interfaces/hamiltonians.jl
@@ -113,6 +113,7 @@ Optional additional methods to implement:
 - [`LOStructure(::Type{typeof(op)})`](@ref LOStructure): defaults to `AdjointUnknown`
 - [`dimension(op, addr)`](@ref Main.Hamiltonians.dimension): defaults to dimension of
   address space
+- [`requires_transform_undoer(op)`](@ref): defaults to `false`.
 
 In order to calculate observables efficiently, it may make sense to implement custom methods
 for [`Interfaces.dot_from_right(x, op, y)`](@ref) and [`LinearAlgebra.mul!(y, op, x)`](@ref).
@@ -326,6 +327,14 @@ true
 Part of the [`AbstractHamiltonian`](@ref) interface.
 """
 starting_address(m::AbstractMatrix) = findmin(real.(diag(m)))[2]
+
+"""
+    requires_transform_undoer(::AbstractHamiltonian)
+
+Return `true` if [`TransformUndoer`](@ref) is needed to compute observables with this
+Hamiltonian.
+"""
+requires_transform_undoer(::AbstractHamiltonian) = false
 
 """
     offdiagonals(column)

--- a/src/Interfaces/hamiltonians.jl
+++ b/src/Interfaces/hamiltonians.jl
@@ -94,14 +94,14 @@ There are two options for which methods need to be implemented.
 
 If the number of non-zero matrix elements that can be reached from any address is known,
 and they can be separately generated:
-- [`allows_address_type(op, type)`](@ref)
-- [`diagonal_element(op, address)`](@ref)
-- [`num_offdiagonals(op, address)`](@ref) and
-- [`get_offdiagonal(op, address, chosen)`](@ref) or [`offdiagonals`](@ref)
+- [`allows_address_type(ham, type)`](@ref)
+- [`diagonal_element(ham, address)`](@ref)
+- [`num_offdiagonals(ham, address)`](@ref) and
+- [`get_offdiagonal(ham, address, chosen)`](@ref) or [`offdiagonals`](@ref)
 
 Alternatively, if the generation of matrix elements is more complicated:
-- [`allows_address_type(op, type)`](@ref)
-- [`operator_column(op, address)`](@ref)
+- [`allows_address_type(ham, type)`](@ref)
+- [`operator_column(ham, address)`](@ref)
 - [`diagonal_element(column)`](@ref)
 - [`num_offdiagonals(column)`](@ref) (this can be an upper bound)
 - [`starting_address(column)`](@ref)
@@ -109,14 +109,15 @@ Alternatively, if the generation of matrix elements is more complicated:
 - [`random_offdiagonal(column)`](@ref)
 
 Optional additional methods to implement:
-- [`VectorInterface.scalartype(op)`](@ref): defaults to `eltype(eltype(op))`
-- [`LOStructure(::Type{typeof(op)})`](@ref LOStructure): defaults to `AdjointUnknown`
-- [`dimension(op, addr)`](@ref Main.Hamiltonians.dimension): defaults to dimension of
+- [`VectorInterface.scalartype(ham)`](@ref): defaults to `eltype(eltype(ham))`
+- [`LOStructure(::Type{typeof(ham)})`](@ref LOStructure): defaults to `AdjointUnknown`
+- [`dimension(ham, addr)`](@ref Main.Hamiltonians.dimension): defaults to dimension of
   address space
-- [`requires_transform_undoer(op)`](@ref): defaults to `false`.
+- [`undo_transform(ham, op)`](@ref): the default implementation returns `op`.
 
 In order to calculate observables efficiently, it may make sense to implement custom methods
-for [`Interfaces.dot_from_right(x, op, y)`](@ref) and [`LinearAlgebra.mul!(y, op, x)`](@ref).
+for [`Interfaces.dot_from_right(x, ham, y)`](@ref) and
+[`LinearAlgebra.mul!(y, ham, x)`](@ref).
 
 See also [`AbstractHamiltonian`](@ref), [`Interfaces`](@ref).
 """
@@ -124,6 +125,7 @@ abstract type AbstractOperator{T} <: AbstractObservable{T} end
 
 @doc """
     LinearAlgebra.mul!(w::AbstractDVec, op::AbstractOperator, v::AbstractDVec)
+
 In place multiplication of `op` with `v` and storing the result in `w`. The result is
 returned. Note that `w` needs to have a `valtype` that can hold a product of instances
 of `eltype(op)` and `valtype(v)`. Moreover, the [`StochasticStyle`](@ref) of `w` needs to
@@ -329,12 +331,12 @@ Part of the [`AbstractHamiltonian`](@ref) interface.
 starting_address(m::AbstractMatrix) = findmin(real.(diag(m)))[2]
 
 """
-    requires_transform_undoer(::AbstractHamiltonian)
+    undo_transform(ham::AbstractHamiltonian, operator)
 
-Return `true` if [`TransformUndoer`](@ref) is needed to compute observables with this
-Hamiltonian.
+Modify the `operator` in a way that undoes the transform that was applied to `ham`.
+See [`TransformUndoer`](@ref).
 """
-requires_transform_undoer(::AbstractHamiltonian) = false
+undo_transform(::AbstractHamiltonian, op::AbstractObservable) = op
 
 """
     offdiagonals(column)

--- a/src/Interfaces/hamiltonians.jl
+++ b/src/Interfaces/hamiltonians.jl
@@ -334,7 +334,7 @@ starting_address(m::AbstractMatrix) = findmin(real.(diag(m)))[2]
     undo_transform(ham::AbstractHamiltonian, operator)
 
 Modify the `operator` in a way that undoes the transform that was applied to `ham`.
-See [`TransformUndoer`](@ref).
+See [`TransformUndoer`](@ref Main.Hamiltonians).
 """
 undo_transform(::AbstractHamiltonian, op::AbstractObservable) = op
 

--- a/src/fciqmc.jl
+++ b/src/fciqmc.jl
@@ -90,7 +90,7 @@ function FirstOrderTransitionOperator(sp::DefaultShiftParameters, hamiltonian)
     return FirstOrderTransitionOperator(hamiltonian, sp.shift, sp.time_step)
 end
 
-function Hamiltonians.parent_hamiltonian(op::FirstOrderTransitionOperator)
+function Hamiltonians.parent_operator(op::FirstOrderTransitionOperator)
     return op.hamiltonian
 end
 function Hamiltonians.modify_offdiagonal(op::FirstOrderTransitionOperator, _, addr, value)

--- a/src/fciqmc.jl
+++ b/src/fciqmc.jl
@@ -75,91 +75,35 @@ of the imaginary-time Schrödinger equation (Euler step) and repeated applicatio
 will project out the ground state eigenvector of the `hamiltonian`.  It is the
 transition operator used in [`FCIQMC`](@ref).
 """
-struct FirstOrderTransitionOperator{T,S,H} <: AbstractHamiltonian{T}
+struct FirstOrderTransitionOperator{
+    T,S,H<:AbstractHamiltonian{T}
+} <: Hamiltonians.ModifiedHamiltonian{T}
     hamiltonian::H
     shift::S
     time_step::Float64
-
-    function FirstOrderTransitionOperator(hamiltonian::H, shift::S, time_step) where {H,S}
-        T = eltype(hamiltonian)
-        return new{T,S,H}(hamiltonian, shift, Float64(time_step))
-    end
 end
-
+function FirstOrderTransitionOperator(hamiltonian::H, shift::S, time_step) where {H,S}
+    T = eltype(H)
+    return FirstOrderTransitionOperator{T,S,H}(hamiltonian, shift, Float64(time_step))
+end
 function FirstOrderTransitionOperator(sp::DefaultShiftParameters, hamiltonian)
     return FirstOrderTransitionOperator(hamiltonian, sp.shift, sp.time_step)
 end
 
-struct FirstOrderTransitionOperatorColumn{A,T,O<:FirstOrderTransitionOperator{T},C}
-    operator::O
-    address::A
-    ham_column::C
-    time_step::Float64
+function Hamiltonians.parent_hamiltonian(op::FirstOrderTransitionOperator)
+    return op.hamiltonian
 end
-
-function Hamiltonians.operator_column(t::FirstOrderTransitionOperator, add)
-    return FirstOrderTransitionOperatorColumn(t, add, operator_column(t.hamiltonian, add), t.time_step)
+function Hamiltonians.modify_offdiagonal(op::FirstOrderTransitionOperator, _, addr, value)
+    return addr => -op.time_step * value
 end
-function Hamiltonians.diagonal_element(c::FirstOrderTransitionOperatorColumn)
-    return 1 - c.time_step*(diagonal_element(c.ham_column) - c.operator.shift)
+function Hamiltonians.modify_diagonal(op::FirstOrderTransitionOperator, _, value)
+    return 1 - op.time_step * (value - op.shift)
 end
-function Hamiltonians.random_offdiagonal(c::FirstOrderTransitionOperatorColumn)
-    add, prob, val = random_offdiagonal(c.ham_column)
-    return add, prob, -c.time_step*val
+function Hamiltonians.LOStructure(op::FirstOrderTransitionOperator)
+    return LOStructure(op.hamiltonian)
 end
-Hamiltonians.num_offdiagonals(c::FirstOrderTransitionOperatorColumn) = num_offdiagonals(c.ham_column)
-Hamiltonians.starting_address(c::FirstOrderTransitionOperatorColumn) = starting_address(c.ham_column)
-
-struct FirstOrderOffdiagonalsVector{
-    A,V,O<:AbstractVector{Tuple{A,V}}
-} <: AbstractVector{Pair{A,V}}
-    time_step::Float64
-    offdiagonals::O
-end
-Base.size(o::FirstOrderOffdiagonalsVector) = size(o.offdiagonals)
-
-function Hamiltonians.offdiagonals(c::FirstOrderTransitionOperatorColumn)
-    ods = offdiagonals(c.ham_column)
-    if ods isa AbstractVector
-        return FirstOrderOffdiagonalsVector(c.time_step, ods)
-    else
-        return FirstOrderOffdiagonals(c.time_step, ods)
-    end
-end
-
-function Base.getindex(o::FirstOrderOffdiagonalsVector, i)
-    add, val = o.offdiagonals[i]
-    return add => -val * o.time_step
-end
-
-struct FirstOrderOffdiagonals{O}
-    time_step::Float64
-    offdiagonals::O
-end
-function Base.eltype(o::FirstOrderOffdiagonals)
-    odtypes = fieldtypes(eltype(o.offdiagonals))
-    return Pair{odtypes[1], float(odtypes[2])}
-end
-Base.IteratorSize(::FirstOrderOffdiagonals) = Base.SizeUnknown()
-
-function Base.iterate(o::FirstOrderOffdiagonals)
-    first = iterate(o.offdiagonals)
-    if isnothing(first)
-        return nothing
-    end
-    (add, val), state = first
-    od = -val*o.time_step
-    return (add => od, state)
-end
-
-function Base.iterate(o::FirstOrderOffdiagonals, state)
-    new = iterate(o.offdiagonals, state)
-    if isnothing(new)
-        return nothing
-    end
-    (add, val), state = new
-    od = -val*o.time_step
-    return (add => od, state)
+function Base.adjoint(op::FirstOrderTransitionOperator)
+    return FirstOrderTransitionOperator(adjoint(op.hamiltonian), op.shift, op.time_step)
 end
 
 """

--- a/src/lomc.jl
+++ b/src/lomc.jl
@@ -113,7 +113,7 @@ function lomc!(
     address=starting_address(ham),
     params::FciqmcRunStrategy=RunTillLastStep(
         laststep=100,
-        shift=float(valtype(v))(diagonal_element(ham, address))
+        shift=float(valtype(v))(diagonal_element(operator_column(ham, address)))
     ),
     maxlength = nothing,
     wm = nothing
@@ -227,8 +227,6 @@ function lomc!(state::ReplicaState, df=DataFrame(); laststep=0, name="lomc!", me
     report = Report()
     report_default_metadata!(report, state)
     report_metadata!(report, problem.metadata) # add user metadata
-    # Sanity checks.
-    check_transform(state.replica_strategy, hamiltonian)
 
     simulation = PMCSimulation(
         problem, state, report, false, false, false, "", 0.0

--- a/src/pmc_simulation.jl
+++ b/src/pmc_simulation.jl
@@ -160,9 +160,8 @@ function PMCSimulation(problem::ProjectorMonteCarloProblem; copy_vectors=true)
     report = Report()
     report_default_metadata!(report, state)
     report_metadata!(report, metadata) # add user metadata
-    # Sanity checks.
-    check_transform(state.replica_strategy, hamiltonian)
 
+    # Sanity checks.
     @assert allequal(i->state[i].algorithm, n_replicas * n_spectral) &&
         first(state).algorithm == algorithm
     @assert allequal(i -> state[i].hamiltonian, n_replicas * n_spectral) &&

--- a/src/projector_monte_carlo_problem.jl
+++ b/src/projector_monte_carlo_problem.jl
@@ -259,6 +259,9 @@ function ProjectorMonteCarloProblem(
         post_step_strategy = (post_step_strategy,)
     end
 
+    # set up transforms if needed
+    replica_strategy = apply_transform(replica_strategy, hamiltonian)
+
     if eltype(hamiltonian) <: Complex
         if (start_at isa AbstractDVec && valtype(start_at) <: Real ||
             start_at isa Union{AbstractMatrix, AbstractVector} &&

--- a/src/projector_monte_carlo_problem.jl
+++ b/src/projector_monte_carlo_problem.jl
@@ -260,7 +260,7 @@ function ProjectorMonteCarloProblem(
     end
 
     # set up transforms if needed
-    replica_strategy = apply_transform(replica_strategy, hamiltonian)
+    replica_strategy = undo_transforms(replica_strategy, hamiltonian)
 
     if eltype(hamiltonian) <: Complex
         if (start_at isa AbstractDVec && valtype(start_at) <: Real ||

--- a/src/strategies_and_params/replicastrategy.jl
+++ b/src/strategies_and_params/replicastrategy.jl
@@ -76,7 +76,7 @@ The `r{i}s{k}_dot_r{j}s{k}` overlap can be omitted with the flag `vecnorm=false`
 
 By default, overlaps of different spectral states are omitted. To include overlaps of
 different spectral states `r{i}s{k}_dot_r{j}s{l}` and `r{i}s{k}_Op{m}_r{j}s{l}`, use the
-flag `mixed_spectral_overlaps=true`. 
+flag `mixed_spectral_overlaps=true`.
 
 See [`ProjectorMonteCarloProblem`](@ref), [`ReplicaStrategy`](@ref) and
 [`AbstractOperator`](@ref Interfaces.AbstractOperator) (for an interface for implementing
@@ -114,7 +114,7 @@ For an ``m``-tuple of input operators ``(\\hat{A}_1, ..., \\hat{A}_m)``, overlap
 ``\\langle \\phi | f^{-1} \\hat{A} f^{-1} | \\phi \\rangle`` are reported as
 `r{i}s{k}_Op{m}_r{j}s{k}`. The correct vector-vector overlap ``\\langle \\phi | f^{-2} | \\phi
 \\rangle`` is reported *last* as `r{i}s{k}_Op{m+1}_r{j}s{k}`. This is in addition to the *bare*
-vector-vector overlap ``\\langle \\phi | \\phi \\rangle`` that is reported as 
+vector-vector overlap ``\\langle \\phi | \\phi \\rangle`` that is reported as
 `r{i}s{k}_dot_r{j}s{k}`.
 """
 struct AllOverlaps{N,M,O,B,S} <: ReplicaStrategy{N}
@@ -223,12 +223,12 @@ Used as a sanity check before starting main [`ProjectorMonteCarloProblem`](@ref)
 function check_transform(r::AllOverlaps, ham::AbstractHamiltonian)
     ops = r.operators
     if !isempty(ops)
-        op_transform = all(op -> typeof(op)<:Rimu.Hamiltonians.TransformUndoer, ops)
-        ham_transform = hasproperty(ham, :hamiltonian)    # need a better test for this
-        if op_transform && ham_transform && !all(op -> ham == op.transform, ops)
+        op_transformed = all(op -> op isa Rimu.Hamiltonians.TransformUndoer, ops)
+        ham_transformed = ham isa ModifiedHamiltonian
+        if op_transformed && ham_transformed && !all(op -> ham == op.transform, ops)
             # both are transformed but different
             @warn "Overlaps transformation not consistent with Hamiltonian transformation."
-        elseif op_transform ⊻ ham_transform
+        elseif op_transformed ⊻ ham_transformed
             # only one is transformed
             @warn "Expected overlaps and Hamiltonian to be transformed; got only one."
         end

--- a/src/strategies_and_params/replicastrategy.jl
+++ b/src/strategies_and_params/replicastrategy.jl
@@ -96,7 +96,7 @@ Implemented transformations are:
 In the case of a transformed Hamiltonian the overlaps are defined as follows. For a
 similarity transformation `G` of the Hamiltonian (see e.g. [`GutzwillerSampling`](@ref).)
 ```math
-    Ĝ = f Ĥ f^{-1}.
+    Ĝ = f Ĥ f⁻¹.
 ```
 The expectation value of an operator ``Â`` is
 ```math

--- a/src/strategies_and_params/replicastrategy.jl
+++ b/src/strategies_and_params/replicastrategy.jl
@@ -57,7 +57,7 @@ struct NoStats{N} <: ReplicaStrategy{N} end
 NoStats(N=1) = NoStats{N}()
 
 replica_stats(::NoStats, _) = (), ()
-apply_transform(::NoStats{N}, _) where {N} = NoStats{N}()
+undo_transforms(::NoStats{N}, _) where {N} = NoStats{N}()
 
 """
     AllOverlaps(n_replicas=2; operator=nothing, transform=nothing, vecnorm=true, mixed_spectral_overlaps=false)
@@ -83,9 +83,10 @@ operators).
 
 # Transformed Hamiltonians
 
-If a transformed Hamiltonian `G` has been passed to [`ProjectorMonteCarloProblem`](@ref)
-then overlaps can be calculated by passing the same transformed Hamiltonian to `AllOverlaps`
-by setting `transform=G`. A warning is given if these two Hamiltonians do not match.
+If a transformed Hamiltonian `G` has been passed to [`ProjectorMonteCarloProblem`](@ref), an
+inverse transformation is applied to the operators in `AllOverlaps`. Additinally, an
+operator representing the inverse transform applied to the identity operator is added to
+the list of operators.
 
 Implemented transformations are:
 
@@ -99,21 +100,18 @@ similarity transformation `G` of the Hamiltonian (see e.g. [`GutzwillerSampling`
 ```
 The expectation value of an operator ``\\hat{A}`` is
 ```math
-    \\langle \\hat{A} \\rangle = \\langle \\psi | \\hat{A} | \\psi \\rangle
-        = \\frac{\\langle \\phi | f^{-1} \\hat{A} f^{-1} | \\phi \\rangle}{\\langle \\phi | f^{-2} | \\phi \\rangle}
+    ⟨\\hat{A}⟩ = ⟨ψ| \\hat{A} |ψ⟩ = \\frac{⟨ϕ| f^{-1} \\hat{A} f^{-1} |ϕ⟩}{⟨ϕ| f^{-2} |ϕ⟩}
 ```
 where
 ```math
-    | \\phi \\rangle = f | \\psi \\rangle
+    |ϕ⟩ = f |ψ⟩
 ```
-is the (right) eigenvector of ``\\hat{G}`` and ``| \\psi \\rangle`` is an eigenvector of
-``\\hat{H}``.
+is the (right) eigenvector of ``\\hat{G}`` and ``|ψ⟩`` is an eigenvector of ``\\hat{H}``.
 
 For an ``m``-tuple of input operators ``(\\hat{A}_1, ..., \\hat{A}_m)``, overlaps of
-``\\langle \\phi | f^{-1} \\hat{A} f^{-1} | \\phi \\rangle`` are reported as
-`r{i}s{k}_Op{m}_r{j}s{k}`. The correct vector-vector overlap ``\\langle \\phi | f^{-2} | \\phi
-\\rangle`` is reported *last* as `r{i}s{k}_Op{m+1}_r{j}s{k}`. This is in addition to the *bare*
-vector-vector overlap ``\\langle \\phi | \\phi \\rangle`` that is reported as
+``⟨ϕ| f^{-1} \\hat{A} f^{-1} |ϕ⟩`` are reported as `r{i}s{k}_Op{m}_r{j}s{k}`. The correct
+vector-vector overlap ``⟨ϕ| f^{-2} |ϕ⟩`` is reported *last* as `r{i}s{k}_Op{m+1}_r{j}s{k}`.
+This is in addition to the *bare* vector-vector overlap ``⟨ϕ|ϕ⟩`` that is reported as
 `r{i}s{k}_dot_r{j}s{k}`.
 """
 struct AllOverlaps{N,M,O,B,S} <: ReplicaStrategy{N}
@@ -129,6 +127,10 @@ function AllOverlaps(
     vecnorm=true,
     mixed_spectral_overlaps=false
 )
+    if transform ≠ nothing
+        Base.depwarn("Passing `transform` to `AllOverlaps` is deprected. Transformation undoing is handled automatically.")
+    end
+
     n_replicas isa Integer || throw(ArgumentError("n_replicas must be an integer"))
     if isnothing(operator)
         operators = ()
@@ -141,19 +143,18 @@ function AllOverlaps(
     else
         operators = (operator,)
     end
-    if isnothing(transform)
-        ops = operators
-    else
-        fsq = Rimu.Hamiltonians.TransformUndoer(transform)
-        ops = (map(op -> Rimu.Hamiltonians.TransformUndoer(transform, op), operators)..., fsq)
-    end
-    if !vecnorm && length(ops) == 0
+
+    if !vecnorm && length(operators) == 0
         return NoStats(n_replicas)
     end
-    return AllOverlaps{n_replicas,length(ops),typeof(ops),vecnorm,mixed_spectral_overlaps}(ops)
+    return AllOverlaps{
+        n_replicas,length(operators),typeof(operators),vecnorm,mixed_spectral_overlaps
+    }(operators)
 end
 
-function replica_stats(rs::AllOverlaps{N,<:Any,<:Any,B,S}, spectral_states::NTuple{N}) where {N,B,S}
+function replica_stats(
+    rs::AllOverlaps{N,<:Any,<:Any,B,S}, spectral_states::NTuple{N}
+) where {N,B,S}
     n_spectral = num_spectral_states(spectral_states[1])
     vecs = SMatrix{N,n_spectral}(
         spectral_states[i][j].v for i in 1:N, j in 1:n_spectral
@@ -165,7 +166,7 @@ function replica_stats(rs::AllOverlaps{N,<:Any,<:Any,B,S}, spectral_states::NTup
 end
 
 """
-    all_overlaps(operators, vectors, working_memories, vecnorm=true, mixed_spectral_overlaps=false)
+    all_overlaps(operators, vectors, working_memories; vecnorm=true, mixed_spectral_overlaps=false)
 
 Get all overlaps between vectors and operators.  The flag `vecnorm` can disable the
 vector-vector overlap `r{i}s{k}_dot_r{j}s{k}`.
@@ -187,24 +188,24 @@ function all_overlaps(
             for j in 1:N, l in k+1:M
                 if B
                     push!(names, "r$(i)s$(k)_dot_r$(j)s$(l)")
-                    push!(values, dot(vecs[i,k], vecs[j,l]))
+                    push!(values, dot(vecs[i, k], vecs[j, l]))
                 end
                 for (m, op) in enumerate(operators)
                     push!(names, "r$(i)s$(k)_Op$(m)_r$(j)s$(l)")
                     # Using dot_from_right here because dot will try to copy_to_local! if
                     # called directly.
-                    push!(values, dot_from_right(v, op, vecs[j,l]))
+                    push!(values, dot_from_right(v, op, vecs[j, l]))
                 end
             end
         end
         for j in i+1:N
             if B
                 push!(names, "r$(i)s$(k)_dot_r$(j)s$(k)")
-                push!(values, dot(vecs[i,k], vecs[j,k]))
+                push!(values, dot(vecs[i, k], vecs[j, k]))
             end
             for (m, op) in enumerate(operators)
                 push!(names, "r$(i)s$(k)_Op$(m)_r$(j)s$(k)")
-                push!(values, dot_from_right(v, op, vecs[j,k]))
+                push!(values, dot_from_right(v, op, vecs[j, k]))
             end
         end
     end
@@ -213,20 +214,13 @@ function all_overlaps(
     return SVector{num_reports,String}(names).data, SVector{num_reports,T}(values).data
 end
 
-function apply_transform(
+function undo_transforms(
     strat::AllOverlaps{N,M,<:Any,B,S}, ham::AbstractHamiltonian
 ) where {N,M,B,S}
-    if !requires_transform_undoer(ham)
-        return strat
-    else
-        if all(op -> op isa TransformUndoer, strat.operators)
-            return strat
-        elseif any(op -> op isa TransformUndoer, strat.operators)
-            error("Some, but not all observables have a `TransformUndoer` applied")
-        else
-            operators = map(op -> TransformUnoder(ham, op), strat.operators)
-            operators = (operators..., TransformUndoer(ham))
-            return AllOverlaps{N,M,typeof(operators),B,S}(operators)
-        end
+    operators = map(op -> undo_transform(ham, op), strat.operators)
+    identity = undo_transform(ham, IdentityOperator())
+    if identity ≢ IdentityOperator()
+        operators = (operators..., identity)
     end
+    return AllOverlaps{N,M,typeof(operators),B,S}(operators)
 end

--- a/src/strategies_and_params/replicastrategy.jl
+++ b/src/strategies_and_params/replicastrategy.jl
@@ -60,7 +60,7 @@ replica_stats(::NoStats, _) = (), ()
 undo_transforms(::NoStats{N}, _) where {N} = NoStats{N}()
 
 """
-    AllOverlaps(n_replicas=2; operator=nothing, transform=nothing, vecnorm=true, mixed_spectral_overlaps=false)
+    AllOverlaps(n_replicas=2; operator=nothing, vecnorm=true, mixed_spectral_overlaps=false)
         <: ReplicaStrategy{n_replicas}
 
 Run `n_replicas` replicas and report overlaps between all pairs of replica vectors. If
@@ -86,7 +86,7 @@ operators).
 If a transformed Hamiltonian `G` has been passed to [`ProjectorMonteCarloProblem`](@ref), an
 inverse transformation is applied to the operators in `AllOverlaps`. Additionally, an
 operator representing the inverse transform applied to the identity operator is added to
-the list of operators.
+the list of operators. Passing `transform` to `AllOverlaps` is deprecated.
 
 Implemented transformations are:
 
@@ -96,9 +96,9 @@ Implemented transformations are:
 In the case of a transformed Hamiltonian the overlaps are defined as follows. For a
 similarity transformation `G` of the Hamiltonian (see e.g. [`GutzwillerSampling`](@ref).)
 ```math
-    \\hat{G} = f \\hat{H} f^{-1}.
+    Ĝ = f Ĥ f^{-1}.
 ```
-The expectation value of an operator ``\\hat{A}`` is
+The expectation value of an operator ``Â`` is
 ```math
     ⟨Â⟩ = ⟨ψ| Â |ψ⟩ = \\frac{⟨ϕ| f⁻¹ Â f⁻¹ |ϕ⟩}{⟨ϕ| f⁻² |ϕ⟩}
 ```
@@ -106,7 +106,7 @@ where
 ```math
     |ϕ⟩ = f |ψ⟩
 ```
-is the (right) eigenvector of ``\\hat{G}`` and ``|ψ⟩`` is an eigenvector of ``\\hat{H}``.
+is the (right) eigenvector of ``Ĝ`` and ``|ψ⟩`` is an eigenvector of ``Ĥ``.
 
 For an ``m``-tuple of input operators ``(\\hat{A}_1, ..., \\hat{A}_m)``, overlaps of
 ``⟨ϕ| f⁻¹ Â f⁻¹ |ϕ⟩`` are reported as `r{i}s{k}_Op{m}_r{j}s{k}`. The correct

--- a/src/strategies_and_params/replicastrategy.jl
+++ b/src/strategies_and_params/replicastrategy.jl
@@ -57,9 +57,8 @@ struct NoStats{N} <: ReplicaStrategy{N} end
 NoStats(N=1) = NoStats{N}()
 
 replica_stats(::NoStats, _) = (), ()
-check_transform(::NoStats, _) = nothing
+apply_transform(::NoStats{N}, _) where {N} = NoStats{N}()
 
-# TODO: add custom names
 """
     AllOverlaps(n_replicas=2; operator=nothing, transform=nothing, vecnorm=true, mixed_spectral_overlaps=false)
         <: ReplicaStrategy{n_replicas}
@@ -214,24 +213,20 @@ function all_overlaps(
     return SVector{num_reports,String}(names).data, SVector{num_reports,T}(values).data
 end
 
-"""
-    check_transform(r::AllOverlaps, ham)
-
-Check that the transformation provided to `r::AllOverlaps` matches the given Hamiltonian `ham`.
-Used as a sanity check before starting main [`ProjectorMonteCarloProblem`](@ref) loop.
-"""
-function check_transform(r::AllOverlaps, ham::AbstractHamiltonian)
-    ops = r.operators
-    if !isempty(ops)
-        op_transformed = all(op -> op isa Rimu.Hamiltonians.TransformUndoer, ops)
-        ham_transformed = ham isa ModifiedHamiltonian
-        if op_transformed && ham_transformed && !all(op -> ham == op.transform, ops)
-            # both are transformed but different
-            @warn "Overlaps transformation not consistent with Hamiltonian transformation."
-        elseif op_transformed ⊻ ham_transformed
-            # only one is transformed
-            @warn "Expected overlaps and Hamiltonian to be transformed; got only one."
+function apply_transform(
+    strat::AllOverlaps{N,M,<:Any,B,S}, ham::AbstractHamiltonian
+) where {N,M,B,S}
+    if !requires_transform_undoer(ham)
+        return strat
+    else
+        if all(op -> op isa TransformUndoer, strat.operators)
+            return strat
+        elseif any(op -> op isa TransformUndoer, strat.operators)
+            error("Some, but not all observables have a `TransformUndoer` applied")
+        else
+            operators = map(op -> TransformUnoder(ham, op), strat.operators)
+            operators = (operators..., TransformUndoer(ham))
+            return AllOverlaps{N,M,typeof(operators),B,S}(operators)
         end
     end
-    return nothing
 end

--- a/src/strategies_and_params/replicastrategy.jl
+++ b/src/strategies_and_params/replicastrategy.jl
@@ -128,7 +128,7 @@ function AllOverlaps(
     mixed_spectral_overlaps=false
 )
     if transform ≠ nothing
-        Base.depwarn("Passing `transform` to `AllOverlaps` is deprected. Transformation undoing is handled automatically.")
+        Base.depwarn("Passing `transform` to `AllOverlaps` is deprected. Transformation undoing is handled automatically.", :AllOverlaps)
     end
 
     n_replicas isa Integer || throw(ArgumentError("n_replicas must be an integer"))

--- a/src/strategies_and_params/replicastrategy.jl
+++ b/src/strategies_and_params/replicastrategy.jl
@@ -84,7 +84,7 @@ operators).
 # Transformed Hamiltonians
 
 If a transformed Hamiltonian `G` has been passed to [`ProjectorMonteCarloProblem`](@ref), an
-inverse transformation is applied to the operators in `AllOverlaps`. Additinally, an
+inverse transformation is applied to the operators in `AllOverlaps`. Additionally, an
 operator representing the inverse transform applied to the identity operator is added to
 the list of operators.
 
@@ -100,7 +100,7 @@ similarity transformation `G` of the Hamiltonian (see e.g. [`GutzwillerSampling`
 ```
 The expectation value of an operator ``\\hat{A}`` is
 ```math
-    ⟨\\hat{A}⟩ = ⟨ψ| \\hat{A} |ψ⟩ = \\frac{⟨ϕ| f^{-1} \\hat{A} f^{-1} |ϕ⟩}{⟨ϕ| f^{-2} |ϕ⟩}
+    ⟨Â⟩ = ⟨ψ| Â |ψ⟩ = \\frac{⟨ϕ| f⁻¹ Â f⁻¹ |ϕ⟩}{⟨ϕ| f⁻² |ϕ⟩}
 ```
 where
 ```math
@@ -109,8 +109,8 @@ where
 is the (right) eigenvector of ``\\hat{G}`` and ``|ψ⟩`` is an eigenvector of ``\\hat{H}``.
 
 For an ``m``-tuple of input operators ``(\\hat{A}_1, ..., \\hat{A}_m)``, overlaps of
-``⟨ϕ| f^{-1} \\hat{A} f^{-1} |ϕ⟩`` are reported as `r{i}s{k}_Op{m}_r{j}s{k}`. The correct
-vector-vector overlap ``⟨ϕ| f^{-2} |ϕ⟩`` is reported *last* as `r{i}s{k}_Op{m+1}_r{j}s{k}`.
+``⟨ϕ| f⁻¹ Â f⁻¹ |ϕ⟩`` are reported as `r{i}s{k}_Op{m}_r{j}s{k}`. The correct
+vector-vector overlap ``⟨ϕ| f⁻² |ϕ⟩`` is reported *last* as `r{i}s{k}_Op{m+1}_r{j}s{k}`.
 This is in addition to the *bare* vector-vector overlap ``⟨ϕ|ϕ⟩`` that is reported as
 `r{i}s{k}_dot_r{j}s{k}`.
 """

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -496,28 +496,28 @@ end
         @testset "Gutzwiller transformation" begin
             for H in (
                 HubbardMom1D(BoseFS((2,2,2)), u=6),
-                ExtendedHubbardReal1D(BoseFS((1,1,1,1,1,1,1,1,1,1,1,1)), u=6, t=2.0),
-                ExtendedHubbardMom1D(BoseFS((1,1,1,1,1,1,1,1,1,1,1,1)), u=6, t=2.0),
+                ExtendedHubbardReal1D(BoseFS(1,1,1,1,1,1), u=6, t=2.0),
+                ExtendedHubbardMom1D(BoseFS(0,0,1,1,1,0,0), u=3),
             )
+                h_matrix = sparse(H; sort=true)
+
                 # GutzwillerSampling with parameter zero is exactly equal to the original H
                 G = GutzwillerSampling(H, 0.0)
-                addr = starting_address(H)
-                @test starting_address(G) == addr
-                @test all(x == y for (x, y) in zip(offdiagonals(H, addr), offdiagonals(G, addr)))
+
+                @test sparse(G; sort=true) == h_matrix
+                @test starting_address(G) == starting_address(H)
+
                 @test LOStructure(G) isa AdjointKnown
                 @test LOStructure(TransformUndoer(G,G)) isa AdjointKnown
 
                 @test eval(Meta.parse(repr(G))) == G
                 @test eval(Meta.parse(repr(G'))) == G'
 
-                g = rand()
-                G = GutzwillerSampling(H, g)
-                for i in 1:num_offdiagonals(G, addr)
-                    addr2, me = get_offdiagonal(G, addr, i)
-                    w = exp(-g * (diagonal_element(H, addr2) - diagonal_element(H, addr)))
-                    @test get_offdiagonal(H, addr, i)[2] * w == me
-                    @test get_offdiagonal(H, addr, i)[1] == addr2
-                    @test diagonal_element(H, addr2) == diagonal_element(G, addr2)
+                g = 0.1
+                g_matrix = sparse(GutzwillerSampling(G, g); sort=true)
+                for i in axes(g_matrix, 1), j in axes(g_matrix, 2)
+                    value = exp(h_matrix[i,i] * -g) * h_matrix[i,j] * exp(h_matrix[j,j] * g)
+                    @test g_matrix[i, j] ≈ value
                 end
             end
         end
@@ -558,45 +558,47 @@ end
     @testset "GuidingVector" begin
         H = HubbardMom1D(BoseFS((2,2,2)), u=6)
         v = DVec(
-            BoseFS{6,3}((0, 0, 6)) => 0.0770580680636451,
-            BoseFS{6,3}((6, 0, 0)) => 0.0770580680636451,
-            BoseFS{6,3}((1, 1, 4)) => 0.3825802976327182,
-            BoseFS{6,3}((4, 1, 1)) => 0.3825802976327182,
-            BoseFS{6,3}((0, 6, 0)) => 0.04322440994245527,
-            BoseFS{6,3}((3, 3, 0)) => 0.2565124277520772,
-            BoseFS{6,3}((3, 0, 3)) => 0.3460652270329457,
-            BoseFS{6,3}((0, 3, 3)) => 0.2565124277520772,
-            BoseFS{6,3}((1, 4, 1)) => 0.28562685053740633,
-            BoseFS{6,3}((2, 2, 2)) => 0.6004825560434165;
-            capacity=100,
+            BoseFS(0, 0, 6) => 0.0770580680636451,
+            BoseFS(6, 0, 0) => 0.0770580680636451,
+            BoseFS(1, 1, 4) => 0.3825802976327182,
+            BoseFS(4, 1, 1) => 0.3825802976327182,
+            BoseFS(0, 6, 0) => 0.04322440994245527,
+            BoseFS(3, 3, 0) => 0.2565124277520772,
+            BoseFS(3, 0, 3) => 0.3460652270329457,
+            BoseFS(0, 3, 3) => 0.2565124277520772,
+            BoseFS(1, 4, 1) => 0.28562685053740633,
+            BoseFS(2, 2, 2) => 0.6004825560434165;
         )
+        h_matrix = sparse(H; sort=true)
         @testset "GuidingVector transformation" begin
             @testset "With empty vector" begin
                 G = GuidingVectorSampling(H, empty(v), 0.2)
 
-                addr = starting_address(H)
-                @test starting_address(G) == addr
-                @test all(x == y for (x, y) in zip(offdiagonals(H, addr), offdiagonals(G, addr)))
+                @test starting_address(G) == starting_address(H)
                 @test LOStructure(G) isa AdjointKnown
-                @test LOStructure(Rimu.Hamiltonians.TransformUndoer(G,G)) isa AdjointKnown
+                @test LOStructure(TransformUndoer(G,G)) isa AdjointKnown
+
+                @test h_matrix == sparse(G; sort=true)
             end
 
             @testset "With non-empty vector" begin
                 G = GuidingVectorSampling(H, v, 0.2)
-                addr = starting_address(H)
-                @test starting_address(G) == addr
+
+                @test starting_address(G) == starting_address(H)
                 @test LOStructure(G) isa AdjointKnown
-                @test LOStructure(Rimu.Hamiltonians.TransformUndoer(G,G)) isa AdjointKnown
+                @test LOStructure(TransformUndoer(G,G)) isa AdjointKnown
                 @test G == GuidingVectorSampling(H; vector = v, eps = 0.2) # call signature
 
-                for i in 1:num_offdiagonals(G, addr)
-                    addr2, me = get_offdiagonal(G, addr, i)
-                    top = ifelse(v[addr2] < 0.2, 0.2, v[addr2])
-                    bot = ifelse(v[addr] < 0.2, 0.2, v[addr])
-                    w = top / bot
-                    @test get_offdiagonal(H, addr, i)[2] * w ≈ me
-                    @test get_offdiagonal(H, addr, i)[1] == addr2
-                    @test diagonal_element(H, addr2) == diagonal_element(G, addr2)
+                bsr = BasisSetRepresentation(G; sort=true)
+                g_matrix = bsr.sparse_matrix
+                basis = bsr.basis
+
+                for i in axes(g_matrix, 1), j in axes(g_matrix, 2)
+                    top = ifelse(v[basis[i]] < 0.2, 0.2, v[basis[i]])
+                    bot = ifelse(v[basis[j]] < 0.2, 0.2, v[basis[j]])
+
+                    weight = top / bot
+                    @test g_matrix[i, j] == h_matrix[i, j] * weight
                 end
             end
         end
@@ -614,8 +616,8 @@ end
                 address = starting_address(H)
                 dv = DVec(address => x)
                 # transforming the Hamiltonian again should be consistent
-                fsq = Rimu.Hamiltonians.TransformUndoer(G)
-                fHf = Rimu.Hamiltonians.TransformUndoer(G, H)
+                fsq = TransformUndoer(G)
+                fHf = TransformUndoer(G, H)
                 Ebare = dot(dv, H, dv)/dot(dv, dv)
                 Egutz = dot(dv, G, dv)/dot(dv, dv)
                 Etrans = dot(dv, fHf, dv)/dot(dv, fsq, dv)
@@ -624,7 +626,7 @@ end
                 # general operators
                 m = num_modes(address)
                 g2vals = map(d -> dot(dv, G2RealCorrelator(d), dv)/dot(dv, dv), 0:m-1)
-                g2transformed = map(d -> dot(dv, Rimu.Hamiltonians.TransformUndoer(G,G2RealCorrelator(d)), dv)/dot(dv, fsq, dv), 0:m-1)
+                g2transformed = map(d -> dot(dv, TransformUndoer(G,G2RealCorrelator(d)), dv)/dot(dv, fsq, dv), 0:m-1)
                 @test all(g2vals ≈ g2transformed)
             end
         end
@@ -664,8 +666,8 @@ end
             GuidingVectorSampling(H, v, 0.2),
         )
             # test supported constructor
-            @test !isa(try Rimu.Hamiltonians.TransformUndoer(G) catch e e end, Exception)
-            @test !isa(try Rimu.Hamiltonians.TransformUndoer(G,H) catch e e end, Exception)
+            @test !isa(try TransformUndoer(G) catch e e end, Exception)
+            @test !isa(try TransformUndoer(G,H) catch e e end, Exception)
         end
         # unsupported
         for H in (
@@ -673,8 +675,8 @@ end
             ExtendedHubbardReal1D(BoseFS((1,1,1,1,1,1,1,1,1,1,1,1)), u=6, t=2.0),
             ExtendedHubbardMom1D(BoseFS((1,1,1,1,1,1,1,1,1,1,1,1)), u=6, t=2.0),
         )
-            @test_throws ArgumentError Rimu.Hamiltonians.TransformUndoer(H)
-            @test_throws ArgumentError Rimu.Hamiltonians.TransformUndoer(H, H)
+            @test_throws ArgumentError TransformUndoer(H)
+            @test_throws ArgumentError TransformUndoer(H, H)
         end
     end
 end

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -45,17 +45,17 @@ end
             ); t=[1, 2], u=[0 3; 3 0]
         ),
         GutzwillerSampling(HubbardReal1D(BoseFS((1, 2, 3)); u=6 + 2im); g=0.3),
-        GutzwillerSampling(Transcorrelated1D(FermiFS2C((0, 0, 1, 1)), (0, 1, 1, 0)); g=0.1),
+        GutzwillerSampling(Transcorrelated1D(FermiFS2C((0, 0, 1, 1), (0, 1, 1, 0)); g=0.1)),
 
         GuidingVectorSampling(HubbardReal1D(BoseFS(1, 2, 3); u=6 + 2im); v=DVec(BoseFS(1,2,3))),
-        GuidingVectorSampling(Transcorrelated1D(FermiFS2C((0, 0, 1, 1)), (0, 1, 1, 0)); v=DVec(FermiFS2C((0, 0, 1, 1)), (0, 1, 1, 0)) => 1),
+        GuidingVectorSampling(Transcorrelated1D(FermiFS2C((0, 0, 1, 1), (0, 1, 1, 0))); v=DVec(FermiFS2C((0, 0, 1, 1), (0, 1, 1, 0)) => 1),
 
         MatrixHamiltonian(Float64[1 2; 2 0]),
         GutzwillerSampling(MatrixHamiltonian([1.0 2.0; 2.0 0.0]); g=0.3),
         TransformUndoer(
             GutzwillerSampling(MatrixHamiltonian([1.0 2.0; 2.0 0.0]); g=0.3)
         ),
-        Transcorrelated1D(FermiFS2C((0, 0, 1, 1, 0)), (0, 1, 1, 0, 0); t=2),
+        Transcorrelated1D(FermiFS2C((0, 0, 1, 1, 0), (0, 1, 1, 0, 0)); t=2),
         Transcorrelated1D(CompositeFS(FermiFS((0, 0, 1, 0)), FermiFS((0, 1, 1, 0))); v=3, v_ho=1),
         HubbardMom1DEP(BoseFS((0, 0, 5, 0, 0))),
         HubbardMom1DEP(CompositeFS(FermiFS((0, 1, 1, 0, 0)), FermiFS((0, 0, 1, 0, 0))), v_ho=5),

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -45,10 +45,10 @@ end
             ); t=[1, 2], u=[0 3; 3 0]
         ),
         GutzwillerSampling(HubbardReal1D(BoseFS((1, 2, 3)); u=6 + 2im); g=0.3),
-        GutzwillerSampling(Transcorrelated1D(FermiFS2C((0, 0, 1, 1), (0, 1, 1, 0)); g=0.1)),
+        GutzwillerSampling(Transcorrelated1D(FermiFS2C((0, 0, 1, 1), (0, 1, 1, 0))); g=0.1),
 
-        GuidingVectorSampling(HubbardReal1D(BoseFS(1, 2, 3); u=6 + 2im); v=DVec(BoseFS(1,2,3))),
-        GuidingVectorSampling(Transcorrelated1D(FermiFS2C((0, 0, 1, 1), (0, 1, 1, 0))); v=DVec(FermiFS2C((0, 0, 1, 1), (0, 1, 1, 0)) => 1),
+        GuidingVectorSampling(HubbardReal1D(BoseFS(1, 2, 3); u=6 + 2im), DVec(BoseFS(1,2,3) => 1.0)),
+        GuidingVectorSampling(Transcorrelated1D(FermiFS2C((0, 0, 1, 1), (0, 1, 1, 0))), DVec(FermiFS2C((0, 0, 1, 1), (0, 1, 1, 0)) => 1.0)),
 
         MatrixHamiltonian(Float64[1 2; 2 0]),
         GutzwillerSampling(MatrixHamiltonian([1.0 2.0; 2.0 0.0]); g=0.3),
@@ -73,9 +73,11 @@ end
     ]
         # test_hamiltonian_interface(H; test_spawning=false)
         test_hamiltonian_interface(H; test_random_offdiagonal=!(H isa HOCartesianContactInteractions))
-        # Check that the result of show can be pasted into the REPL
-        @test eval(Meta.parse(repr(H))) == H
-
+        # Check that the result of show can be pasted into the REPL. Does not work with
+        # GuidingVectorSampling because it includes a DVec.
+        if !(H isa GuidingVectorSampling)
+            @test eval(Meta.parse(repr(H))) == H
+        end
     end
 end
 

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -65,6 +65,7 @@ end
         FroehlichPolaron(OccupationNumberFS(1, 1, 1)),
         FroehlichPolaron(OccupationNumberFS(1, 1, 1); momentum_cutoff=10.0),
         momentum(HubbardMom1D(BoseFS(0, 1, 5, 1, 0))),
+        Rimu.FirstOrderTransitionOperator(HubbardRealSpace(BoseFS(1,1,1,1))),
     ]
         # test_hamiltonian_interface(H; test_spawning=false)
         test_hamiltonian_interface(H; test_random_offdiagonal=!(H isa HOCartesianContactInteractions))

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -17,7 +17,7 @@ function exact_energy(ham)
 end
 
 @testset "Hamiltonian interface tests" begin
-    for H in (
+    for H in [
         HubbardReal1D(BoseFS((1, 2, 3, 4)); u=1.0, t=2.0),
         HubbardReal1D(BoseFS(1, 2, 3, 4);t=1.0im),
         HubbardReal1D(BoseFS(1, 2, 3, 4);u=1.0im),
@@ -65,7 +65,7 @@ end
         FroehlichPolaron(OccupationNumberFS(1, 1, 1)),
         FroehlichPolaron(OccupationNumberFS(1, 1, 1); momentum_cutoff=10.0),
         momentum(HubbardMom1D(BoseFS(0, 1, 5, 1, 0))),
-    )
+    ]
         # test_hamiltonian_interface(H; test_spawning=false)
         test_hamiltonian_interface(H; test_random_offdiagonal=!(H isa HOCartesianContactInteractions))
         # Check that the result of show can be pasted into the REPL
@@ -90,7 +90,8 @@ end
         (SingleParticleExcitation(2, 3), BoseFS(1, 2, 3, 4)),
         (TwoParticleExcitation(3, 2, 1, 4), BoseFS(1, 2, 3, 4)),
         (Momentum(1), BoseFS(1, 2, 3, 4)),
-        (G2MomCorrelator(3), BoseFS(1, 2, 0, 3, 0, 4, 0, 1))
+        (G2MomCorrelator(3), BoseFS(1, 2, 0, 3, 0, 4, 0, 1)),
+        (IdentityOperator(), BoseFS(1, 2, 0, 3, 0, 4, 0, 1)),
     ]
         test_operator_interface(op, addr)
         # Check that the result of show can be pasted into the REPL

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -65,7 +65,7 @@ end
         FroehlichPolaron(OccupationNumberFS(1, 1, 1)),
         FroehlichPolaron(OccupationNumberFS(1, 1, 1); momentum_cutoff=10.0),
         momentum(HubbardMom1D(BoseFS(0, 1, 5, 1, 0))),
-        Rimu.FirstOrderTransitionOperator(HubbardRealSpace(BoseFS(1,1,1,1))),
+        Rimu.FirstOrderTransitionOperator(HubbardRealSpace(BoseFS(1,1,1,1)), -5.0, 0.01),
     ]
         # test_hamiltonian_interface(H; test_spawning=false)
         test_hamiltonian_interface(H; test_random_offdiagonal=!(H isa HOCartesianContactInteractions))

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -44,14 +44,18 @@ end
                 FermiFS((1, 1, 1, 1, 0, 0, 0, 0)),
             ); t=[1, 2], u=[0 3; 3 0]
         ),
-        GutzwillerSampling(HubbardReal1D(BoseFS((1, 2, 3)); u=6); g=0.3),
         GutzwillerSampling(HubbardReal1D(BoseFS((1, 2, 3)); u=6 + 2im); g=0.3),
+        GutzwillerSampling(Transcorrelated1D(FermiFS2C((0, 0, 1, 1)), (0, 1, 1, 0)); g=0.1),
+
+        GuidingVectorSampling(HubbardReal1D(BoseFS(1, 2, 3); u=6 + 2im); v=DVec(BoseFS(1,2,3))),
+        GuidingVectorSampling(Transcorrelated1D(FermiFS2C((0, 0, 1, 1)), (0, 1, 1, 0)); v=DVec(FermiFS2C((0, 0, 1, 1)), (0, 1, 1, 0)) => 1),
+
         MatrixHamiltonian(Float64[1 2; 2 0]),
         GutzwillerSampling(MatrixHamiltonian([1.0 2.0; 2.0 0.0]); g=0.3),
         TransformUndoer(
             GutzwillerSampling(MatrixHamiltonian([1.0 2.0; 2.0 0.0]); g=0.3)
         ),
-        Transcorrelated1D(CompositeFS(FermiFS((0, 0, 1, 1, 0)), FermiFS((0, 1, 1, 0, 0))); t=2),
+        Transcorrelated1D(FermiFS2C((0, 0, 1, 1, 0)), (0, 1, 1, 0, 0); t=2),
         Transcorrelated1D(CompositeFS(FermiFS((0, 0, 1, 0)), FermiFS((0, 1, 1, 0))); v=3, v_ho=1),
         HubbardMom1DEP(BoseFS((0, 0, 5, 0, 0))),
         HubbardMom1DEP(CompositeFS(FermiFS((0, 1, 1, 0, 0)), FermiFS((0, 0, 1, 0, 0))), v_ho=5),

--- a/test/doctests.jl
+++ b/test/doctests.jl
@@ -10,4 +10,4 @@ DocMeta.setdocmeta!(
 )
 # Run with fix=true to fix docstrings. The filter compares floats only up to the first
 # 4 digits.
-#doctest(Rimu; doctestfilters=[r"(\d*)\.(\d{4})\d+" => s"\1.\2"])
+doctest(Rimu; doctestfilters=[r"(\d*)\.(\d{4})\d+" => s"\1.\2"])

--- a/test/doctests.jl
+++ b/test/doctests.jl
@@ -10,4 +10,4 @@ DocMeta.setdocmeta!(
 )
 # Run with fix=true to fix docstrings. The filter compares floats only up to the first
 # 4 digits.
-doctest(Rimu; doctestfilters=[r"(\d*)\.(\d{4})\d+" => s"\1.\2"])
+#doctest(Rimu; doctestfilters=[r"(\d*)\.(\d{4})\d+" => s"\1.\2"])

--- a/test/doctests.jl
+++ b/test/doctests.jl
@@ -6,7 +6,8 @@ DocMeta.setdocmeta!(
     :DocTestSetup,
     :(using Rimu; using Rimu.StatsTools; using DataFrames; using Random;
       using LinearAlgebra; using Suppressor);
-    recursive=true
+    recursive=true,
 )
-# Run with fix=true to fix docstrings
-doctest(Rimu)
+# Run with fix=true to fix docstrings. The filter compares floats only up to the first
+# 4 digits.
+doctest(Rimu; doctestfilters=[r"(\d*)\.(\d{4})\d+" => s"\1.\2"])

--- a/test/lomc.jl
+++ b/test/lomc.jl
@@ -112,8 +112,6 @@ Random.seed!(1234)
             @test length(state.spectral_states) == 3
             @test df.shift_r1s1 ≠ df.shift_r2s1 && df.shift_r2s1 ≠ df.shift_r3s1
             @test "shift_r4s1" ∉ names(df)
-
-            @test isnothing(Rimu.check_transform(NoStats(), H))
         end
 
         # column names are of the form r{i}s{k}_dot_r{j}s{k} and r{i}s{k}_Op{m}_r{j}s{k}.
@@ -163,18 +161,6 @@ Random.seed!(1234)
                 @test num_stats(df) == 4 * binomial(2, 2)
                 df, _ = lomc!(G, dv; replica_strategy=AllOverlaps(7; operator=(H, G), transform=G))
                 @test num_stats(df) == 4 * binomial(7, 2)
-
-                # Check transformation
-                # good transform - no warning
-                @test_logs min_level=Logging.Warn Rimu.check_transform(AllOverlaps(; operator=H, transform=G), G)
-                # no operators - no warning
-                @test_logs min_level=Logging.Warn Rimu.check_transform(AllOverlaps(;), H)
-                # Hamiltonian transformed and operators not transformed
-                @test_logs (:warn, Regex("(Expected overlaps)")) Rimu.check_transform(AllOverlaps(; operator=H), G)
-                # Hamiltonian not transformed and operators transformed
-                @test_logs (:warn, Regex("(Expected overlaps)")) Rimu.check_transform(AllOverlaps(; operator=H, transform=G), H)
-                # Different transformations
-                @test_logs (:warn, Regex("(not consistent)")) Rimu.check_transform(AllOverlaps(; operator=H, transform=GutzwillerSampling(H, 0.5)), G)
             end
         end
         @testset "AllOverlaps special cases" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,7 +20,7 @@ using ExplicitImports: check_no_implicit_imports
     # Check that no implicit imports are used in the Rimu module.
     # See https://ericphanson.github.io/ExplicitImports.jl/stable/
     @test check_no_implicit_imports(
-        Rimu; skip=(Rimu, Base, Core, VectorInterface), ignore=(:/,)
+        Rimu; skip=(Rimu, Base, Core, VectorInterface), ignore=(:/,:adjoint)
     ) === nothing
     # If this test fails, make your import statements explicit.
     # For example, replace `using Foo` with `using Foo: bar, baz`.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,7 +20,7 @@ using ExplicitImports: check_no_implicit_imports
     # Check that no implicit imports are used in the Rimu module.
     # See https://ericphanson.github.io/ExplicitImports.jl/stable/
     @test check_no_implicit_imports(
-        Rimu; skip=(Rimu, Base, Core, VectorInterface), ignore=(:/,:adjoint)
+        Rimu; skip=(Rimu, Base, Core, VectorInterface), ignore=(:/, :adjoint)
     ) === nothing
     # If this test fails, make your import statements explicit.
     # For example, replace `using Foo` with `using Foo: bar, baz`.


### PR DESCRIPTION
# New features
* Interface for creating Hamiltonians that modify the (off)-diagonal elements with less boilerplate code. This is done by making the Hamiltonian wrapper a `ModifiedHamiltonian` and implementing a small interface. Implementations for `operator_column`, `offdiagonals`, `diagonal_element` and a few other functions are then provided automatically.
* Reimplementations of existing Hamiltonian wrappers (importance sampling, symmetries, `FirstOrderTransitionOperator`, `TransformUndoer`, `Stoquastic`) using the new interface. This makes them all work correctly with Hamiltonians implemented using the new Hamiltonians interface. Previously, that functionality was broken because the wrappers were modifying the `offdiagonals` directly.
* New interface function `undo_transformation` that replaces the ad-hoc way of handling transformations with `TransformUndoer`. The transformations are now applied automatically. The results are reported in the same columns as before. Passing `transform` to `AllOverlaps` is now derpecated.
* New `IdentityOperator` which is currently only used in `TransformUndoer`.
# Breaking changes
* The reimplemented wrappers no longer support the old Hamiltonians interface.