### PR TITLE
New constructors for `AbstractDVec`s

### DIFF
--- a/src/DictVectors/abstractdvec.jl
+++ b/src/DictVectors/abstractdvec.jl
@@ -6,7 +6,7 @@ function Base.show(io::IO, dvec::AbstractDVec)
     summary(io, dvec)
     limit, _ = displaysize()
     # sort if length(dvec) is small to make doctests reproducible
-    pldvec = length(dvec) < 20 ? sort!(collect(pairs(localpart(dvec)))) :
+    pldvec = length(dvec) < 20 ? sort!(collect(pairs(localpart(dvec))); by=first) :
         pairs(localpart(dvec))
 
     for (i, p) in enumerate(pldvec)
@@ -320,4 +320,51 @@ function Interfaces.dot_from_right(target, op, source::AbstractDVec)
         dot(target, operator_column(op, address)) * value
     end
     return result::T
+end
+
+"""
+    abstractdvec_from_iterator(TYPE, iterator; kwargs...)
+
+Construct the [`AbstractDVec`](@ref) defined by `TYPE` using the data in `iterator` using
+[`deposit!`](@ref), i.e. adding multiple contributions referring to the same address.
+
+See also [`PDVec`](@ref), [`DVec`](@ref), [`InitiatorDVec`](@ref).
+"""
+function abstractdvec_from_iterator(::Type{TYPE}, iterator; kwargs...) where {TYPE}
+    E = eltype(iterator)
+    return abstractdvec_from_iterator(TYPE, E, iterator; kwargs...)
+end
+function abstractdvec_from_iterator(::Type{TYPE}, g::Base.Generator; kwargs...) where {TYPE}
+    E = Base.@default_eltype(g) # unexported Base functionality
+    return abstractdvec_from_iterator(TYPE, E, g; kwargs...)
+end
+# deconstruct eltype
+function abstractdvec_from_iterator(
+    ::Type{TYPE}, ::Type{Pair{K,V}}, iterator; kwargs...
+) where {K,V,TYPE}
+    return abstractdvec_from_iterator(TYPE, K, V, iterator; kwargs...)
+end
+# iterator with inhomogeneous value types
+function abstractdvec_from_iterator(
+    ::Type{TYPE}, ::Type{<:Pair{K}}, iterator; kwargs...
+) where {TYPE, K} # need to promote the values
+    V = promote_type((typeof(v) for (_, v) in iterator)...)
+    return abstractdvec_from_iterator(TYPE, K, V, iterator; kwargs...)
+end
+function abstractdvec_from_iterator(
+    ::Type{TYPE}, ::Type{Tuple{K,V}}, iterator; kwargs...
+) where {K,V,TYPE}
+    return abstractdvec_from_iterator(TYPE, K, V, iterator; kwargs...)
+end
+# fully deconstructed types
+function abstractdvec_from_iterator(
+    ::Type{TYPE}, ::Type{K}, ::Type{V}, iterator;
+    style::StochasticStyle=default_style(V), kwargs...
+) where {K,V,TYPE}
+    W = eltype(style) # try to convert if V ≠ W
+    dvec = TYPE{K, W}(; style, kwargs...)
+    for (k,v) in iterator
+        deposit!(dvec, k, v, k=>0)
+    end
+    return dvec
 end

--- a/src/DictVectors/dvec.jl
+++ b/src/DictVectors/dvec.jl
@@ -1,11 +1,12 @@
 """
-    DVec{K,V,D<:AbstractDict{K,V},S}
+    DVec(args...; kwargs...) <: AbstractDVec{K,V}
 
-Dictionary-based vector-like data structure for use with FCIQMC and
-[KrylovKit](https://github.com/Jutho/KrylovKit.jl). While mostly behaving like a `Dict`, it
-supports various linear algebra operations such as `norm` and `dot`. It has a
-[`StochasticStyle`](@ref) that is used to select an appropriate spawning strategy in the
-FCIQMC algorithm.
+Dictionary-based vector-like data structure for storing `key <: K` and `value <: V` pairs
+for use with [`ProjectorMonteCarloProblem`](@ref) and [`ExactDiagonalizationProblem`](@ref).
+`DVec` supports the interface from VectorInterface.jl but stores only non-zero `value`s.
+
+`DVec` is fast but does not support [`Initiator`](@ref)s (see [`InitiatorDVec`](@ref)) or
+parallel and distributed vector operations (see [`PDVec`](@ref)).
 
 See also: [`AbstractDVec`](@ref), [`InitiatorDVec`](@ref), [`PDVec`](@ref).
 
@@ -14,19 +15,21 @@ See also: [`AbstractDVec`](@ref), [`InitiatorDVec`](@ref), [`PDVec`](@ref).
 * `DVec(dict::AbstractDict[; style, capacity])`: create a `DVec` with `dict` for storage.
   Note that the data may or may not be copied.
 
-* `DVec(args...[; style, capacity])`: `args...` are passed to the `Dict` constructor. The
-  `Dict` is used for storage.
+* `DVec(args...[; style, capacity])`: `args...` can be `key => value` `Pair`s or an
+  iterator over `Pair`s or `Tuple`s.
 
 * `DVec{K,V}([; style, capacity])`: create an empty `DVec{K,V}`.
 
 * `DVec(dv::AbstractDVec[; style, capacity])`: create a `DVec` with the same contents as
    `adv`. The `style` is inherited from `dv` by default.
 
-The default `style` is selected based on the `DVec`'s `valtype` (see
-[`default_style`](@ref)). If a style is given and the `valtype` does not match the `style`'s
-`eltype`, the values are converted to an appropriate type.
-
-The capacity argument is optional and sets the initial size of the `DVec` via `Base.sizehint!`.
+## Keyword arguments
+* `style::StochasticStyle` determines the mode of stochastic operations. See
+    [`StochasticStyle`](@ref). The default `style` is selected based on the `DVec`'s
+    `valtype` (see [`default_style`](@ref)). If a style is given and the `valtype` does not
+    match the `style`'s `eltype`, the values are converted to an appropriate type.
+* `capacity`: The capacity argument is optional and sets the initial size of the `DVec` via
+    `Base.sizehint!`.
 
 ## Examples
 
@@ -49,28 +52,9 @@ end
 ###
 ### Constructors
 ###
-# Vararg
-function DVec(args...; style = nothing, kwargs...)
-    storage = Dict(args...)
-    if style === nothing
-        return DVec(storage; kwargs...)
-    else
-        # if style is given, check value type compatibility and convert if necessary
-        V = valtype(storage)
-        S = scalartype(style)
-        if V <: AbstractArray
-            if eltype(V) != S
-                throw(ArgumentError("Style $(style) is incompatible with value type $(V). "*
-                            "Use a style with scalartype(style) == $(eltype(V)) instead."))
-            end
-            # no conversion necessary, the types are compatible
-        else # V is a scalar type
-            # try to convert storage to the appropriate type
-            K = keytype(storage)
-            storage = Dict{K,S}(storage)
-        end
-        return DVec(storage; style, kwargs...)
-    end
+DVec(vararg::Vararg{Pair}; kwargs...) = DVec(vararg; kwargs...)
+function DVec(iterator; kwargs...)
+    return abstractdvec_from_iterator(DVec, iterator; kwargs...)
 end
 
 # from Dict; check style compatibility

--- a/src/DictVectors/initiatordvec.jl
+++ b/src/DictVectors/initiatordvec.jl
@@ -1,15 +1,16 @@
 """
-    InitiatorDVec{K,V} <: AbstractDVec{K,V}
+    InitiatorDVec(args...; kwargs...) <: AbstractDVec{K,V}
 
-Dictionary-based vector-like data structure for use with
-[`ProjectorMonteCarloProblem`](@ref Main.ProjectorMonteCarloProblem) and
+Dictionary-based vector-like data structure for storing `key <: K` and `value <: V` pairs
+for use with [`ProjectorMonteCarloProblem`](@ref Main.ProjectorMonteCarloProblem) and
 [`KrylovKit.jl`](https://github.com/Jutho/KrylovKit.jl). See [`AbstractDVec`](@ref).
 Functionally identical to [`DVec`](@ref), but contains [`InitiatorValue`](@ref)s internally
 in order to facilitate initiator methods. Initiator methods for controlling the Monte Carlo
 sign problem were first introduced in
 [J. Chem. Phys. 132, 041103 (2010)](https://doi.org/10.1063/1.3302277).
 How the initiators are handled is controlled by specifying an [`InitiatorRule`](@ref) with
-the `initiator` keyword argument (see below).
+the `initiator` keyword argument (see below). Note that `value`s need to be comparable to
+real numbers with `isless`.
 
 See also: [`AbstractDVec`](@ref), [`DVec`](@ref), [`PDVec`](@ref).
 
@@ -18,8 +19,8 @@ See also: [`AbstractDVec`](@ref), [`DVec`](@ref), [`PDVec`](@ref).
 * `InitiatorDVec(dict::AbstractDict[; style, initiator, capacity])`: create an
   `InitiatorDVec` with `dict` for storage.  Note that the data may or may not be copied.
 
-* `InitiatorDVec(args...[; style, initiator, capacity])`: `args...` are passed to the `Dict`
-  constructor. The `Dict` is used for storage.
+* `InitiatorDVec(args...[; style, initiator, capacity])`: `args...` can be `key => value`
+  `Pair`s or an iterator over `Pair`s or `Tuple`s.
 
 * `InitiatorDVec{K,V}([; style, initiator, capacity])`: create an empty `InitiatorDVec{K,V}`.
 
@@ -51,21 +52,16 @@ end
 ###
 ### Constructors
 ###
-# Vararg
-function InitiatorDVec(args::Vararg{Pair}; kwargs...)
-    return InitiatorDVec(args; kwargs...)
-end
-# Iterator
-function InitiatorDVec(pairs; kwargs...)
-    storage = Dict(pairs)
-    return InitiatorDVec(storage; kwargs...)
+InitiatorDVec(vararg::Vararg{Pair}; kwargs...) = InitiatorDVec(vararg; kwargs...)
+function InitiatorDVec(iterator; kwargs...)
+    return abstractdvec_from_iterator(InitiatorDVec, iterator; kwargs...)
 end
 # Dict with InitiatorValues
 function InitiatorDVec(
     dict::AbstractDict{K,W};
     style=default_style(V),
-    initiator_threshold=one(eltype(style)),
-    initiator=Initiator(eltype(style)(initiator_threshold)),
+    initiator_threshold=real(one(eltype(style))),
+    initiator=Initiator(real(eltype(style))(initiator_threshold)),
     capacity=0,
 ) where {K,V,W<:AbstractInitiatorValue{V}}
     T = eltype(style)
@@ -85,8 +81,8 @@ end
 function InitiatorDVec(
     dict::AbstractDict{K,V};
     style=default_style(V),
-    initiator_threshold=one(eltype(style)),
-    initiator=Initiator(eltype(style)(initiator_threshold)),
+    initiator_threshold=real(one(eltype(style))),
+    initiator=Initiator(real(eltype(style))(initiator_threshold)),
     capacity=0,
 ) where {K,V}
     T = eltype(style)
@@ -102,8 +98,8 @@ end
 function InitiatorDVec{K,V}(
     ;
     style=default_style(V),
-    initiator_threshold=one(V),
-    initiator=Initiator(V(initiator_threshold)),
+    initiator_threshold=real(one(V)),
+    initiator=Initiator(real(V)(initiator_threshold)),
     kwargs...
 ) where {K,V}
     W = initiator_valtype(initiator, eltype(style))
@@ -113,8 +109,8 @@ end
 function InitiatorDVec(
     dv::AbstractDVec{K,V};
     style=StochasticStyle(dv),
-    initiator_threshold=one(eltype(style)),
-    initiator=Initiator(eltype(style)(initiator_threshold)),
+    initiator_threshold=real(one(eltype(style))),
+    initiator=Initiator(real(eltype(style))(initiator_threshold)),
     capacity=0,
 ) where {K,V}
     return InitiatorDVec(copy(storage(dv)); style, initiator, capacity)
@@ -194,7 +190,7 @@ function deposit!(w::InitiatorDVec{<:Any,V,W}, add, val, (p_add, p_val)) where {
     end
     return w
 end
-
+# val is already an InitiatorValue
 function deposit!(w::InitiatorDVec{<:Any,<:Any,W}, add, val::W, _) where {W}
     dict = storage(w)
     old_val = get(dict, add, zero(W))

--- a/src/DictVectors/pdvec.jl
+++ b/src/DictVectors/pdvec.jl
@@ -9,20 +9,22 @@ function fastrange_hash(k, n::Int)
 end
 
 """
-    PDVec{K,V}(; kwargs...)
+    PDVec{K,V}(; kwargs...) <: AbstractDVec{K,V}
     PDVec(iter; kwargs...)
     PDVec(pairs...; kwargs...)
 
-Dictionary-based vector-like data structure for use with FCIQMC and
-[KrylovKit.jl](https://github.com/Jutho/KrylovKit.jl). While mostly behaving like a `Dict`,
-it supports various linear algebra operations such as `norm` and `dot`, and the interface
-defined in [VectorInterface](https://github.com/Jutho/VectorInterface.jl).
+Dictionary-based vector-like data structure for storing `key <: K` and `value <: V` pairs
+for use with [`ProjectorMonteCarloProblem`](@ref) and [`ExactDiagonalizationProblem`](@ref).
+Only pairs with non-zero `value`s are stored. `PDVec` supports various linear algebra
+operations such as `norm` and `dot`, as well as the full interface defined in
+[VectorInterface](https://github.com/Jutho/VectorInterface.jl).
 
-The P in `PDVec` stands for parallel. `PDVec`s perform `mapreduce`, `foreach`, and various
-linear algebra operations in a threaded manner. If MPI is available, these operations are
-automatically distributed as well. As such it is not recommended to iterate over `pairs`,
-`keys`, or `values` directly unless explicitly performing them on the [`localpart`](@ref) of
-the vector.
+The P in `PDVec` stands for parallel. `PDVec`s perform reductions such as `mapreduce`,
+`foreach`, and various linear algebra operations in a threaded manner on the available Julia
+threads. If MPI is available, the storage is distributed over the MPI ranks and reductions
+operate in parallel on the full distributed data structure. As such it is not recommended to
+iterate over `pairs`, `keys`, or `values` directly unless explicitly performing them on the
+[`localpart`](@ref) of the vector.
 
 See also: [`AbstractDVec`](@ref), [`DVec`](@ref), [`InitiatorDVec`](@ref).
 
@@ -38,60 +40,49 @@ See also: [`AbstractDVec`](@ref), [`DVec`](@ref), [`InitiatorDVec`](@ref).
   using MPI. The defaults are [`NotDistributed`](@ref) when not using MPI and
   [`AllToAll`](@ref) when using MPI.
 
-# Extended Help
-
-## Segmentation
-
-The vector is split into `Threads.nthreads()` subdictionaries called segments. Which
-dictionary a key-value pair is mapped to is determined by the hash of the key. The purpose
-of this segmentation is to allow parallel processing - functions such as `mapreduce`, `add!`
-or `dot` (full list below) process each subdictionary on a separate thread.
-
-See also [`PDWorkingMemory`](@ref).
-
 ### Example
 
-```julia
-julia> add = FermiFS2C((1,1,0,0), (0,0,1,1));
+```jldoctest
+julia> address = FermiFS2C((1,1,0,0), (0,0,1,1));
 
-julia> op = HubbardMom1D(add; t=4/π^2, u=4);
+julia> op = HubbardMom1D(address; t=4/π^2, u=4);
 
-julia> pv = PDVec(add => 1.0)
+julia> pv = PDVec(address => 1.0)
 1-element PDVec: style = IsDeterministic{Float64}()
   fs"|↑↑↓↓⟩" => 1.0
 
 julia> pv = op * pv
 7-element PDVec: style = IsDeterministic{Float64}()
-  fs"|↑↓↑↓⟩" => 1.0
   fs"|↑↑↓↓⟩" => 4.0
-  fs"|↓↑↓↑⟩" => 1.0
-  fs"|↓↑↑↓⟩" => -1.0
-  fs"|⇅⋅⋅⇅⟩" => 1.0
-  fs"|↑↓↓↑⟩" => -1.0
+  fs"|↑↓↑↓⟩" => 1.0
   fs"|⋅⇅⇅⋅⟩" => 1.0
+  fs"|↓↑↑↓⟩" => -1.0
+  fs"|↑↓↓↑⟩" => -1.0
+  fs"|⇅⋅⋅⇅⟩" => 1.0
+  fs"|↓↑↓↑⟩" => 1.0
 
 julia> scale!(pv, -1); pv
 7-element PDVec: style = IsDeterministic{Float64}()
-  fs"|↑↓↑↓⟩" => -1.0
   fs"|↑↑↓↓⟩" => -4.0
-  fs"|↓↑↓↑⟩" => -1.0
-  fs"|↓↑↑↓⟩" => 1.0
-  fs"|⇅⋅⋅⇅⟩" => -1.0
-  fs"|↑↓↓↑⟩" => 1.0
+  fs"|↑↓↑↓⟩" => -1.0
   fs"|⋅⇅⇅⋅⟩" => -1.0
+  fs"|↓↑↑↓⟩" => 1.0
+  fs"|↑↓↓↑⟩" => 1.0
+  fs"|⇅⋅⋅⇅⟩" => -1.0
+  fs"|↓↑↓↑⟩" => -1.0
 
 julia> dest = similar(pv)
 0-element PDVec: style = IsDeterministic{Float64}()
 
 julia> map!(x -> x + 2, dest, values(pv))
 7-element PDVec: style = IsDeterministic{Float64}()
-  fs"|↑↓↑↓⟩" => 1.0
   fs"|↑↑↓↓⟩" => -2.0
-  fs"|↓↑↓↑⟩" => 1.0
-  fs"|↓↑↑↓⟩" => 3.0
-  fs"|⇅⋅⋅⇅⟩" => 1.0
-  fs"|↑↓↓↑⟩" => 3.0
+  fs"|↑↓↑↓⟩" => 1.0
   fs"|⋅⇅⇅⋅⟩" => 1.0
+  fs"|↓↑↑↓⟩" => 3.0
+  fs"|↑↓↓↑⟩" => 3.0
+  fs"|⇅⋅⋅⇅⟩" => 1.0
+  fs"|↓↑↓↑⟩" => 1.0
 
 julia> sum(values(pv))
 -6.0
@@ -102,6 +93,17 @@ julia> dot(dest, pv)
 julia> dot(dest, op, pv)
 44.0
 ```
+
+# Extended Help
+
+## Segmentation
+
+The vector is split into `Threads.nthreads()` subdictionaries called segments. Which
+dictionary a key-value pair is mapped to is determined by the hash of the key. The purpose
+of this segmentation is to allow parallel processing - functions such as `mapreduce`, `add!`
+or `dot` (full list below) process each subdictionary on a separate thread.
+
+See also [`PDWorkingMemory`](@ref).
 
 ## MPI
 
@@ -122,22 +124,22 @@ does not distribute the memory load effectively, but does result in significant 
 
 ### Example
 
-```julia
+```jldoctest
 julia> using KrylovKit
 
-julia> add = BoseFS((0,0,5,0,0));
+julia> address = BoseFS((0,0,5,0,0));
 
-julia> op = HubbardMom1D(add; u=6.0);
+julia> op = HubbardMom1D(address; u=6.0);
 
-julia> pv = PDVec(add => 1.0);
+julia> pv = PDVec(address => 1.0);
 
 julia> results = eigsolve(op, pv, 4, :SR);
 
 julia> results[1][1:4]
 4-element Vector{Float64}:
- -3.4311156892322234
-  1.1821748602612363
-  3.7377753753082823
+ -3.431115689232223
+  1.182174860261238
+  3.737775375308286
   6.996390417443125
 ```
 
@@ -151,7 +153,6 @@ The following functions are threaded and MPI-compatible:
   `normalize`, `normalize!`
 * The full interface defined in
   [VectorInterface.jl](https://github.com/Jutho/VectorInterface.jl)
-
 """
 struct PDVec{
     K,V,N,S<:StochasticStyle{V},I<:InitiatorRule,C<:Communicator
@@ -202,18 +203,10 @@ function PDVec{K,V,N}(
 
     return PDVec(segments, style, irule, comm)
 end
-function PDVec(pairs; kwargs...)
-    # Copies made to get accurate eltype
-    keys = first.(pairs)
-    vals = last.(pairs)
-    K = eltype(keys)
-    V = eltype(vals)
-    t = PDVec{K,V}(; kwargs...)
-    copyto!(t, keys, vals)
-    return t
-end
-function PDVec(pairs::Vararg{Pair}; kwargs...)
-    return PDVec(pairs; kwargs...)
+
+PDVec(vararg::Vararg{Pair}; kwargs...) = PDVec(vararg; kwargs...)
+function PDVec(iterator; kwargs...)
+    return abstractdvec_from_iterator(PDVec, iterator; kwargs...)
 end
 function PDVec(dict::Dict{K,V}; kwargs...) where {K,V}
     t = PDVec{K,V}(; kwargs...)

--- a/src/Interfaces/hamiltonians.jl
+++ b/src/Interfaces/hamiltonians.jl
@@ -488,9 +488,8 @@ julia> diagonal_element(column) == column[address] # access elements with `getin
 true
 
 julia> DVec(column) # materialise as a `DVec`
-DVec{BoseFS{1, 3, BitString{3, 1, UInt8}},Float64} with 3 entries, style = IsDeterministic{Float64}()
+DVec{BoseFS{1, 3, BitString{3, 1, UInt8}},Float64} with 2 entries, style = IsDeterministic{Float64}()
   fs"|1 0 0⟩" => -1.0
-  fs"|0 1 0⟩" => 0.0
   fs"|0 0 1⟩" => -1.0
 ```
 

--- a/test/DictVectors.jl
+++ b/test/DictVectors.jl
@@ -14,9 +14,11 @@ function test_dvec_interface(type; kwargs...)
                 u = type(zip((:a, :b, :c), (1, 2, 3)); kwargs...)
                 v = type(Dict(:a => 1, :b => 2, :c => 3); kwargs...)
                 w = type(:a => 1, :b => 2, :c => 3; kwargs...)
+                x = type(:a => 1.0, :b => 4, :c => 3.0, :b => -2; kwargs...) # annihilation
+                y = type(k => i for (i,k) in enumerate((:a, :b, :c)); kwargs...) # generator
 
-                @test u[:a] == v[:a] == w[:a] == 1
-                @test u == v == w
+                @test u[:a] == v[:a] == w[:a] == x[:a] == y[:a] == 1
+                @test u == v == w == x == y
                 @test copy(u) == u
                 @test copy(u) ≢ u
 
@@ -114,8 +116,10 @@ function test_dvec_interface(type; kwargs...)
                 @test scalartype(zerovector(u, Int)) ≡ Int
                 @test scalartype(empty(u, Int)) ≡ Int
                 @test eltype(similar(u, Float64, Int)) ≡ Pair{Float64,Int}
-                @test eltype(similar(u, String)) ≡ Pair{Int,String}
-                @test eltype(similar(u, Float64, String)) ≡ Pair{Float64,String}
+                if type ≠ InitiatorDVec
+                    @test eltype(similar(u, String)) ≡ Pair{Int,String}
+                    @test eltype(similar(u, Float64, String)) ≡ Pair{Float64,String}
+                end
 
                 v = type(1 => 1; kwargs...)
                 @test zerovector!!(v, Int) ≡ v
@@ -266,7 +270,9 @@ function test_dvec_interface(type; kwargs...)
             @test StochasticStyle(type(:a => 1; kwargs...)) isa IsStochasticInteger{Int}
             @test StochasticStyle(type(:a => 1.5; kwargs...)) isa IsDeterministic
             @test StochasticStyle(type(:a => 1 + 2im; kwargs...)) isa IsStochastic2Pop
-            @test StochasticStyle(type(:a => SA[1 1; 1 1]; kwargs...)) isa StyleUnknown
+            if type ≠ InitiatorDVec # matrix as val doesn't make sense
+                @test StochasticStyle(type(:a => SA[1 1; 1 1]; kwargs...)) isa StyleUnknown
+            end
         end
         @testset "Stochastic styles convert eltype" begin
             u = type(:a => 0f0; kwargs...)
@@ -294,7 +300,7 @@ end
         sa = SA[1.0 2.0; 3.0 4.0]
         sai = SA[1 2; 3 4]
         @test DVec(:a => sa) == DVec(:a => sai)
-        @test_throws ArgumentError DVec(:a => sai; style=IsDynamicSemistochastic())
+        @test_throws MethodError DVec(:a => sai; style=IsDynamicSemistochastic())
         dict = Dict(:a => sai)
         @test_throws ArgumentError DVec(dict; style=IsDynamicSemistochastic())
         @test DVec(Dict(:a => sa)) == DVec(:a => sa)

--- a/test/helpers.jl
+++ b/test/helpers.jl
@@ -1,0 +1,55 @@
+using Rimu
+using StaticArrays
+using Test
+
+using Rimu: replace_keys, delete_and_warn_if_present, clean_and_warn_if_others_present,
+    split_keys
+
+@testset "helpers" begin
+    @testset "walkernumber" begin
+        v = [1, 2, 3]
+        @test walkernumber(v) == norm(v, 1)
+        dvc = DVec(:a => 2 - 5im)
+        @test StochasticStyle(dvc) isa StochasticStyles.IsStochastic2Pop
+        @test walkernumber(dvc) == 2.0 + 5.0im
+        dvi = DVec(:a => Complex{Int32}(2 - 5im))
+        @test StochasticStyle(dvi) isa StochasticStyles.IsStochastic2Pop
+        dvr = DVec(i => randn() for i in 1:100; capacity=100)
+        @test walkernumber(dvr) ≈ norm(dvr, 1)
+    end
+    @testset "MultiScalar" begin
+        a = Rimu.MultiScalar(1, 1.0, SVector(1))
+        @test a[1] ≡ 1
+        @test a[2] ≡ 1.0
+        @test a[3] ≡ SVector(1)
+        @test length(a) == 3
+        @test collect(a) == [1, 1.0, SVector(1)]
+        b = Rimu.MultiScalar(SVector(2, 3.0, SVector(4)))
+        for op in (+, min, max)
+            c = op(a, b)
+            @test op(a[1], b[1]) == c[1]
+            @test op(a[2], b[2]) == c[2]
+            @test op(a[2], b[2]) == c[2]
+        end
+        @test_throws MethodError a + Rimu.MultiScalar(1, 1, 1)
+    end
+
+    @testset "keyword helpers" begin
+        nt = (; a=1, b=2, c=3, d=4)
+        nt2 = replace_keys(nt, (:a => :x, :b => :y, :u => :v))
+        @test nt2 == (c=3, d=4, x=1, y=2)
+        nt3 = @test_logs((:warn, "The keyword(s) \"a\", \"b\" are unused and will be ignored."),
+            delete_and_warn_if_present(nt, (:a, :b, :u)))
+        @test nt3 == (; c=3, d=4)
+        nt4 = @test_logs((:warn, "The keyword(s) \"c\", \"d\" are unused and will be ignored."),
+            clean_and_warn_if_others_present(nt, (:a, :b, :u)))
+        @test nt4 == (; a=1, b=2)
+
+        split, rest = split_keys(nt, :a, :b, :e)
+        @test split_keys(nt, :a) == split_keys(nt, (:a,))
+        @test split == (; a=1, b=2)
+        @test rest == (; c=3, d=4)
+
+        @test split_keys((;), :a, :b, :c) == split_keys((), :a, :b, :c) == ((;), (;))
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,110 +26,25 @@ using ExplicitImports: check_no_implicit_imports
     # For example, replace `using Foo` with `using Foo: bar, baz`.
 end
 
-@safetestset "doctests" begin
-    include("doctests.jl")
-end
-
-@safetestset "excited states" begin
-    include("excited_states_tests.jl")
+@safetestset "Helpers" begin
+    include("helpers.jl")
 end
 
 @safetestset "Interfaces" begin
     include("Interfaces.jl")
 end
 
-@safetestset "ExactDiagonalization" begin
-    include("ExactDiagonalization.jl")
-end
-
-@safetestset "BitStringAddresses" begin
-    include("BitStringAddresses.jl")
+@safetestset "excited states" begin
+    include("excited_states_tests.jl")
 end
 
 @safetestset "StochasticStyles" begin
     include("StochasticStyles.jl")
 end
 
-@safetestset "DictVectors" begin
-    include("DictVectors.jl")
-end
-
-@testset "Hamiltonians" begin
-    include("Hamiltonians.jl")
-end
-
 @safetestset "projector_monte_carlo_problem" begin
     include("projector_monte_carlo_problem.jl")
 end
-
-@suppress_err @safetestset "lomc!" begin
-    include("lomc.jl")
-end
-
-@safetestset "RimuIO" begin
-    include("RimuIO.jl")
-end
-
-@safetestset "StatsTools" begin
-    include("StatsTools.jl")
-end
-
-using Rimu: replace_keys, delete_and_warn_if_present, clean_and_warn_if_others_present,
-    split_keys
-@testset "helpers" begin
-    @testset "walkernumber" begin
-        v = [1,2,3]
-        @test walkernumber(v) == norm(v,1)
-        dvc = DVec(:a => 2-5im)
-        @test StochasticStyle(dvc) isa StochasticStyles.IsStochastic2Pop
-        @test walkernumber(dvc) == 2.0 + 5.0im
-        dvi= DVec(:a=>Complex{Int32}(2-5im))
-        @test StochasticStyle(dvi) isa StochasticStyles.IsStochastic2Pop
-        dvr = DVec(i => randn() for i in 1:100; capacity = 100)
-        @test walkernumber(dvr) ≈ norm(dvr,1)
-    end
-    @testset "MultiScalar" begin
-        a = Rimu.MultiScalar(1, 1.0, SVector(1))
-        @test a[1] ≡ 1
-        @test a[2] ≡ 1.0
-        @test a[3] ≡ SVector(1)
-        @test length(a) == 3
-        @test collect(a) == [1, 1.0, SVector(1)]
-        b = Rimu.MultiScalar(SVector(2, 3.0, SVector(4)))
-        for op in (+, min, max)
-            c = op(a, b)
-            @test op(a[1], b[1]) == c[1]
-            @test op(a[2], b[2]) == c[2]
-            @test op(a[2], b[2]) == c[2]
-        end
-        @test_throws MethodError a + Rimu.MultiScalar(1, 1, 1)
-    end
-
-    @testset "keyword helpers" begin
-        nt = (; a=1, b=2, c=3, d=4)
-        nt2 = replace_keys(nt, (:a => :x, :b => :y, :u => :v))
-        @test nt2 == (c=3, d=4, x=1, y=2)
-        nt3 = @test_logs((:warn, "The keyword(s) \"a\", \"b\" are unused and will be ignored."),
-            delete_and_warn_if_present(nt, (:a, :b, :u)))
-        @test nt3 == (; c = 3, d = 4)
-        nt4 = @test_logs((:warn, "The keyword(s) \"c\", \"d\" are unused and will be ignored."),
-            clean_and_warn_if_others_present(nt, (:a, :b, :u)))
-        @test nt4 == (; a = 1, b = 2)
-
-        split, rest = split_keys(nt, :a, :b, :e)
-        @test split_keys(nt, :a) == split_keys(nt, (:a,))
-        @test split == (; a=1, b=2)
-        @test rest == (; c=3, d=4)
-
-        @test split_keys((;), :a, :b, :c) == split_keys((), :a, :b, :c) == ((;), (;))
-    end
-end
-
-
-@safetestset "KrylovKit" begin
-    include("KrylovKit.jl")
-end
-
 @testset "Logging" begin
     default_logger()
     l = Base.global_logger()
@@ -146,6 +61,44 @@ end
         @info "No progress bar" sl
     end
     @test default_logger() isa Logging.ConsoleLogger
+end
+
+@safetestset "RimuIO" begin
+    include("RimuIO.jl")
+end
+
+@safetestset "StatsTools" begin
+    include("StatsTools.jl")
+end
+
+@safetestset "BitStringAddresses" begin
+    include("BitStringAddresses.jl")
+end
+
+# We test loading of extension packages here (and load them), so
+# this test should run before other tests that use them (like "doctests").
+@safetestset "ExactDiagonalization" begin
+    include("ExactDiagonalization.jl")
+end
+
+@safetestset "doctests" begin
+    include("doctests.jl")
+end
+
+@safetestset "DictVectors" begin
+    include("DictVectors.jl")
+end
+
+@testset "Hamiltonians" begin
+    include("Hamiltonians.jl")
+end
+
+@safetestset "KrylovKit" begin
+    include("KrylovKit.jl")
+end
+
+@suppress_err @safetestset "lomc!" begin
+    include("lomc.jl")
 end
 
 # Note: Running Rimu with several MPI ranks is tested seperately on GitHub CI and not here.


### PR DESCRIPTION
## Changed behaviour
* When constructing  `DVec`, `InitiatorDVec` or `PDVec` with an iterator or list of pairs, the data is added using `deposit!` i.e. using the appropriate rules for adding data. In particular, zero value elements won't be stored and values for multiple entries is added correctly. 

## Fixed bugs
* Previously the constructors for `DVec`, `InitiatorDVec` and `PDVec` passed arguments to a constructor for `Dict`. When multiple contributions to the same address were passed, as when constructing from an `AbstractOperatorColumn`, only the last contribution would be counted and contributions not properly accumulated. This PR fixes this problem.

## Other changes
* Documentation for `DVec`, `InitiatorDVec` and `PDVec was updated.
 