### PR TITLE
Revised action settings

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        julia-version: ['1', 'nightly', '1.9']
+        julia-version: ['1', 'pre', 'min']
         os: [ubuntu-latest]
         include:
           - julia-version: '1'


### PR DESCRIPTION
Replaces `nightly` by `pre` version for the github action settings. The idea is that the Julia pre-release version (alpha or beta) is more stable and also more relevant for testing compatibility compared to the less stable nightly releases.