### PR TITLE
Fix typo in documentation for ModifiedHamiltonian

### DIFF
--- a/src/Hamiltonians/ModifiedHamiltonian.jl
+++ b/src/Hamiltonians/ModifiedHamiltonian.jl
@@ -11,7 +11,7 @@ The `ModifiedHamiltonian` can only be used to implement wrappers that modify the
 elements to the Hamiltonian.
 
 The following need to be implemented
-* [`parent_operator`](@ref Main.Hamiltonians.parent_operator)
+* [`parent_operator`](@ref Main.Hamiltonians.parent_operator(::Main.Hamiltonians.ModifiedHamiltonian))
 * [`modify_diagonal`](@ref Main.Hamiltonians.modify_diagonal)
 * [`modify_offdiagonal`](@ref Main.Hamiltonians.modify_offdiagonal)
 * [`LOStructure(p)`](@ref) and `Base.adjoint` if known, defaults to `AdjointUnknown`.

--- a/src/Hamiltonians/ModifiedHamiltonian.jl
+++ b/src/Hamiltonians/ModifiedHamiltonian.jl
@@ -11,7 +11,7 @@ The `ModifiedHamiltonian` can only be used to implement wrappers that modify the
 elements to the Hamiltonian.
 
 The following need to be implemented
-* [`parent_operator`](@ref Main.Hamiltonians.parent_operator(::Main.Hamiltonians.ModifiedHamiltonian)
+* [`parent_operator`](@ref Main.Hamiltonians.parent_operator)
 * [`modify_diagonal`](@ref Main.Hamiltonians.modify_diagonal)
 * [`modify_offdiagonal`](@ref Main.Hamiltonians.modify_offdiagonal)
 * [`LOStructure(p)`](@ref) and `Base.adjoint` if known, defaults to `AdjointUnknown`.


### PR DESCRIPTION
## Fixed bugs

Fix the link to `parent_operator` function in the documentation for `ModifiedHamiltonian` type.