### PR TITLE
Fix uninitialized variable in FermiFS

### DIFF
--- a/src/BitStringAddresses/fermifs.jl
+++ b/src/BitStringAddresses/fermifs.jl
@@ -68,7 +68,8 @@ function FermiFS{N,M,S}(onr::Union{SVector{M},MVector{M},NTuple{M}}) where {N,M,
     @boundscheck begin
         check_fermi_onr(onr, N, M)
         if S <: BitString
-            M == num_bits(S) || throw(ArgumentError(
+            B = num_bits(S)
+            M == B || throw(ArgumentError(
                 "invalid ONR: $B-bit BitString does not fit $M modes"
             ))
         elseif S <: SortedParticleList


### PR DESCRIPTION
## Bugfix
* This commit fixed the uninitialized `B` variable in `FermiFS` constructor function.