### PR TITLE
Use custom iteration function if available for `ModifiedHamiltonian`.

### DIFF
--- a/src/Hamiltonians/ModifiedHamiltonian.jl
+++ b/src/Hamiltonians/ModifiedHamiltonian.jl
@@ -131,7 +131,18 @@ function Base.show(io::IO, ods::ModifiedHamiltonianOffdiagonals)
     print(IOContext(io, :compact=>true), ods.address, "))")
 end
 
-function Base.iterate(ods::ModifiedHamiltonianOffdiagonals, args...)
+function Base.IteratorSize(ods::ModifiedHamiltonianOffdiagonals)
+    return Base.IteratorSize(ods.offdiagonals)
+end
+function Base.length(ods::ModifiedHamiltonianOffdiagonals)
+    return length(ods.offdiagonals)
+end
+Base.eltype(::ModifiedHamiltonianOffdiagonals{A,T}) where {A,T} = Pair{A,T}
+
+function Base.iterate(
+    ods::Union{ModifiedHamiltonianOffdiagonals,ModifiedHamiltonianVectorOffdiagonals},
+    args...
+)
     it = iterate(ods.offdiagonals, args...)
     if isnothing(it)
         return nothing
@@ -140,10 +151,3 @@ function Base.iterate(ods::ModifiedHamiltonianOffdiagonals, args...)
         return modify_offdiagonal(ods.hamiltonian, ods.address, result...), state
     end
 end
-function Base.IteratorSize(ods::ModifiedHamiltonianOffdiagonals)
-    return Base.IteratorSize(ods.offdiagonals)
-end
-function Base.length(ods::ModifiedHamiltonianOffdiagonals)
-    return length(ods.offdiagonals)
-end
-Base.eltype(::ModifiedHamiltonianOffdiagonals{A,T}) where {A,T} = Pair{A,T}


### PR DESCRIPTION
# Changes

If `offdiagonals` is an `AbstractVector`, the `offdiagonals` of a `ModifiedHamiltonian` inherit that. Before this PR, iteration on modified `AbstractVector` offdiagonals was always done via `getindex`, even if the actual offdiagonals struct implements a specialised `iterate` function (that is probably more efficient). This PR fixes that.