### PR TITLE
Fix bug in `ReducedDensityMatrix`

### DIFF
--- a/src/Hamiltonians/reduced_density_matrix.jl
+++ b/src/Hamiltonians/reduced_density_matrix.jl
@@ -206,8 +206,21 @@ function Interfaces.dot_from_right(
         ReducedDensityMatrixCalculcator!{TT,P}(left, dim),
         pairs(right)
     )
-    return ρ
+    return _check_diagonal!(ρ)
 end
+
+#Check and remove the imaginary part of the diagonal element with a non-zero value
+# and smaller than `atol`.
+function _check_diagonal!(rho::Matrix{<:Complex}; atol = √eps(Float64))
+    for i in 1:size(rho, 1)
+        if abs(imag(rho[i, i])) < atol
+            rho[i, i] = real(rho[i, i])
+        end
+    end
+    return rho
+end
+_check_diagonal!(rho::Matrix{<:Real}) = rho
+
 # This struct is used to calculate matrix elements of `ReducedDensityMatrix`
 # It was introduced because passing a function to `sum` in `dot_from_right` was causing
 # type instabilites.

--- a/src/Hamiltonians/reduced_density_matrix.jl
+++ b/src/Hamiltonians/reduced_density_matrix.jl
@@ -206,7 +206,7 @@ function Interfaces.dot_from_right(
         ReducedDensityMatrixCalculcator!{TT,P}(left, dim),
         pairs(right)
     )
-    return ρ
+    return Hermitian(ρ)
 end
 # This struct is used to calculate matrix elements of `ReducedDensityMatrix`
 # It was introduced because passing a function to `sum` in `dot_from_right` was causing

--- a/src/Hamiltonians/reduced_density_matrix.jl
+++ b/src/Hamiltonians/reduced_density_matrix.jl
@@ -209,18 +209,6 @@ function Interfaces.dot_from_right(
     return ρ
 end
 
-#Check and remove the imaginary part of the diagonal element with a non-zero value
-# and smaller than `atol`.
-function _check_diagonal!(rho::Matrix{<:Complex}; atol = √eps(Float64))
-    for i in 1:size(rho, 1)
-        if abs(imag(rho[i, i])) < atol
-            rho[i, i] = real(rho[i, i])
-        end
-    end
-    return rho
-end
-_check_diagonal!(rho::Matrix{<:Real}) = rho
-
 # This struct is used to calculate matrix elements of `ReducedDensityMatrix`
 # It was introduced because passing a function to `sum` in `dot_from_right` was causing
 # type instabilites.

--- a/src/Hamiltonians/reduced_density_matrix.jl
+++ b/src/Hamiltonians/reduced_density_matrix.jl
@@ -206,7 +206,7 @@ function Interfaces.dot_from_right(
         ReducedDensityMatrixCalculcator!{TT,P}(left, dim),
         pairs(right)
     )
-    return hermitianpart!(ρ) # (ρ .+ ρ') ./ 2
+    return ρ
 end
 # This struct is used to calculate matrix elements of `ReducedDensityMatrix`
 # It was introduced because passing a function to `sum` in `dot_from_right` was causing

--- a/src/Hamiltonians/reduced_density_matrix.jl
+++ b/src/Hamiltonians/reduced_density_matrix.jl
@@ -206,7 +206,7 @@ function Interfaces.dot_from_right(
         ReducedDensityMatrixCalculcator!{TT,P}(left, dim),
         pairs(right)
     )
-    return _check_diagonal!(ρ)
+    return ρ
 end
 
 #Check and remove the imaginary part of the diagonal element with a non-zero value

--- a/src/Hamiltonians/reduced_density_matrix.jl
+++ b/src/Hamiltonians/reduced_density_matrix.jl
@@ -231,18 +231,14 @@ end
 function (calc!::ReducedDensityMatrixCalculcator!{TT, P})(result, pair) where {TT, P}
     addr_right, val_right = pair
     left = calc!.left
-    dim = calc!.dim
     
-    for j in 1:dim
+    for j in axes(result, 2)
         dsts = find_mode(addr_right, vertices(j, Val(P)))
-        for i in j:dim
+        for i in axes(result, 1)
             srcs = reverse(find_mode(addr_right, vertices(i, Val(P))))
 
             addr_left, elem = excitation(addr_right, dsts, srcs)
-            @inbounds result[i, j] += TT(conj(left[addr_left]) * elem * val_right)
-            if i ≠ j
-                @inbounds result[j, i] = conj(result[i, j])
-            end
+            result[i, j] += TT(conj(left[addr_left]) * elem * val_right)
         end
     end
     return result

--- a/src/Hamiltonians/reduced_density_matrix.jl
+++ b/src/Hamiltonians/reduced_density_matrix.jl
@@ -123,7 +123,7 @@ function get_offdiagonal(
 end
 
 """
-    ReducedDensityMatrix{T=Float64}(p) <: AbstractObservable{Hermitian{T, Matrix{T}}}
+    ReducedDensityMatrix{T=Float64}(p) <: AbstractObservable{Matrix{T}}
 
 A matrix-valued operator that can be used to calculate the `p`-particle reduced density
 matrix. The matrix elements are defined as:
@@ -159,7 +159,7 @@ julia> Op1 = ReducedDensityMatrix(1)
 ReducedDensityMatrix{Float64}(1)
 
 julia> dot(dvec_b, Op1, dvec_b)
-2×2 Hermitian{Float64, Matrix{Float64}}:
+2×2 Matrix{Float64}:
  0.75      0.353553
  0.353553  0.25
 
@@ -172,7 +172,7 @@ julia> dvec_f = PDVec(FermiFS(1,1,0,0) => 0.5, FermiFS(0,1,1,0) => 0.5)
   fs"|⋅↑↑⋅⟩" => 0.5
 
 julia> dot(dvec_f, Op2, dvec_f)
-6×6 Hermitian{Float32, Matrix{Float32}}:
+6×6 Matrix{Float32}:
  0.25  0.0  0.25  0.0  0.0  0.0
  0.0   0.0  0.0   0.0  0.0  0.0
  0.25  0.0  0.25  0.0  0.0  0.0
@@ -183,7 +183,7 @@ julia> dot(dvec_f, Op2, dvec_f)
 See also [`single_particle_density`](@ref), [`SingleParticleDensity`](@ref),
 [`SingleParticleExcitation`](@ref), [`TwoParticleExcitation`](@ref).
 """
-struct ReducedDensityMatrix{T, P} <: AbstractObservable{Hermitian{T, Matrix{T}}} end
+struct ReducedDensityMatrix{T, P} <: AbstractObservable{Matrix{T}} end
 
 ReducedDensityMatrix(p) = ReducedDensityMatrix{Float64}(p)
 ReducedDensityMatrix{T}(P::Int) where T = ReducedDensityMatrix{T, P}()
@@ -206,7 +206,7 @@ function Interfaces.dot_from_right(
         ReducedDensityMatrixCalculcator!{TT,P}(left, dim),
         pairs(right)
     )
-    return Hermitian(ρ)
+    return ρ
 end
 # This struct is used to calculate matrix elements of `ReducedDensityMatrix`
 # It was introduced because passing a function to `sum` in `dot_from_right` was causing

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -1786,11 +1786,24 @@ end
         # Check that the result of show can be pasted into the REPL
         @test eval(Meta.parse(repr(r))) == r
     end
+    # complex hermitian Hamiltonian still produces approx hermitian RDM
     H = HubbardReal1D(BoseFS(0,1,2,0); t = 1+im)
-    res = solve(ExactDiagonalizationProblem(H));
-    gs = res.vectors[1];
+    res = solve(ExactDiagonalizationProblem(H))
+    gs = res.vectors[1]
     rdm = ReducedDensityMatrix{ComplexF64}(1)
-    @test ishermitian(dot(gs, rdm, gs))
+    m = dot(gs, rdm, gs)
+    @test all(x -> abs(x) < √eps(Float64), m - m') # hermitian up to floating point noise
+    
+    # a global relative phase in the vectors results in a global phase in the RDM
+    m_phase = dot(im * gs, rdm, gs)
+    @test all(x -> abs(x) < √eps(Float64), m_phase - im * phase)
+    
+    # complex non-hermitian Hamiltonian still produces approx hermitian RDM
+    Hc = HubbardReal1D(BoseFS(0,1,2,0); u = 1+im)
+    resc = solve(ExactDiagonalizationProblem(Hc))
+    gsc = resc.vectors[1]
+    mc = dot(gsc, rdm, gsc)
+    @test all(x -> abs(x) < √eps(Float64), mc - mc') # hermitian up to floating point noise
 end
 
 @testset "HamiltonianProduct" begin

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -1786,6 +1786,11 @@ end
         # Check that the result of show can be pasted into the REPL
         @test eval(Meta.parse(repr(r))) == r
     end
+    H = HubbardReal1D(BoseFS(0,1,2,0); t = 1+im)
+    res = solve(ExactDiagonalizationProblem(H));
+    gs = res.vectors[1];
+    rdm = ReducedDensityMatrix{ComplexF64}(1)
+    @test ishermitian(dot(gs, rdm, gs))
 end
 
 @testset "HamiltonianProduct" begin

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -1796,7 +1796,7 @@ end
     
     # a global relative phase in the vectors results in a global phase in the RDM
     m_phase = dot(im * gs, rdm, gs)
-    @test all(x -> abs(x) < √eps(Float64), m_phase - im * phase)
+    @test all(x -> abs(x) < √eps(Float64), m_phase + im * m)
     
     # complex non-hermitian Hamiltonian still produces approx hermitian RDM
     Hc = HubbardReal1D(BoseFS(0,1,2,0); u = 1+im)


### PR DESCRIPTION
# Bugs removed
- Results from `ReducedDensityMatrix` were returned as a `Hermitian` matrix by taking the `hermitianpart!`, even in cases where this was not appropriate. This was removed. Now the user is responsible for making sure that the matrix is Hermitian, if it should be.
