### PR TITLE
Fix documentation on Julia v0.12

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: julia-actions/setup-julia@v2
         with:
-          version: 1
+          version: 1.11
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - name: Install dependencies

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: julia-actions/setup-julia@v2
         with:
           version: 1.11
+          # fails with newer versions; probably related to BenchmarkCI not supporting them yet
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - name: Install dependencies

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,7 +1,5 @@
 using Documenter
 using Rimu
-using Rimu.BitStringAddresses
-using Rimu.StatsTools
 using Literate
 
 EXAMPLES_INPUT = joinpath(@__DIR__, "../scripts")


### PR DESCRIPTION
Redundant module imports were causing referencing problems and caused errors during the build phase of the documentation. This is now fixed. 