### PR TITLE
Reproducible Projector Monte Carlo

### DIFF
--- a/src/Hamiltonians/GuidingVectorSampling.jl
+++ b/src/Hamiltonians/GuidingVectorSampling.jl
@@ -33,33 +33,33 @@ julia> v = DVec(starting_address(H) => 10);
 
 julia> G = GuidingVectorSampling(H, v, 0.1);
 
-julia> Matrix(H; sort=true)
+julia> Matrix(H; sort=true) .|> (x -> round(x;digits=4))
 4×4 Matrix{Float64}:
- 9.0      0.0       4.89898  0.0
- 0.0      0.0       4.89898  0.0
- 4.89898  4.89898  12.0      4.89898
- 0.0      0.0       4.89898  9.0
+ 9.0    0.0     4.899  0.0
+ 0.0    0.0     4.899  0.0
+ 4.899  4.899  12.0    4.899
+ 0.0    0.0     4.899  9.0
 
-julia> Matrix(G; sort=true)
+julia> Matrix(G; sort=true) .|> (x -> round(x;digits=4))
 4×4 Matrix{Float64}:
-   9.0      0.0     0.0489898    0.0
-   0.0      0.0     0.0489898    0.0
- 489.898  489.898  12.0        489.898
-   0.0      0.0     0.0489898    9.0
+   9.0      0.0     0.049    0.0
+   0.0      0.0     0.049    0.0
+ 489.898  489.898  12.0    489.898
+   0.0      0.0     0.049    9.0
 
-julia> eigen(Matrix(H)).values
+julia> eigen(Matrix(H)).values .|> (x -> round(x;digits=4))
 4-element Vector{Float64}:
- -2.3661456273236645
-  4.9594958589580465
-  8.999999999999996
- 18.406649768365643
+ -2.3661
+  4.9595
+  9.0
+ 18.4066
 
-julia> eigen(Matrix(G)).values
+julia> eigen(Matrix(G)).values .|> (x -> round(x;digits=4))
 4-element Vector{Float64}:
- -2.366145627323689
-  4.9594958589580465
-  8.999999999999998
- 18.406649768365643
+ -2.3661
+  4.9595
+  9.0
+ 18.4066
 ```
 
 # Observables

--- a/src/Hamiltonians/GutzwillerSampling.jl
+++ b/src/Hamiltonians/GutzwillerSampling.jl
@@ -27,12 +27,12 @@ HubbardMom1D(fs"|1 1 1⟩"; u=6.0, t=1.0)
 julia> G = GutzwillerSampling(H, g=0.3)
 GutzwillerSampling(HubbardMom1D(fs"|1 1 1⟩"; u=6.0, t=1.0); g=0.3)
 
-julia> Matrix(H; sort=true)
+julia> Matrix(H; sort=true) .|> (x -> round(x;digits=4))
 4×4 Matrix{Float64}:
- 9.0      0.0       4.89898  0.0
- 0.0      0.0       4.89898  0.0
- 4.89898  4.89898  12.0      4.89898
- 0.0      0.0       4.89898  9.0
+ 9.0    0.0     4.899  0.0
+ 0.0    0.0     4.899  0.0
+ 4.899  4.899  12.0    4.899
+ 0.0    0.0     4.899  9.0
 
 julia> Matrix(G; sort=true)
 4×4 Matrix{Float64}:
@@ -41,19 +41,19 @@ julia> Matrix(G; sort=true)
  1.99178  0.133858   12.0     1.99178
  0.0      0.0        12.0495  9.0
 
-julia> eigen(Matrix(H)).values
+julia> eigen(Matrix(H)).values .|> (x -> round(x;digits=4))
 4-element Vector{Float64}:
- -2.3661456273236645
-  4.9594958589580465
-  8.999999999999996
- 18.406649768365643
+ -2.3661
+  4.9595
+  9.0
+ 18.4066
 
-julia> eigen(Matrix(G)).values
+julia> eigen(Matrix(G)).values .|> (x -> round(x;digits=4))
 4-element Vector{Float64}:
- -2.366145627323686
-  4.959495858958046
-  8.999999999999998
- 18.40664976836564
+ -2.3661
+  4.9595
+  9.0
+ 18.4066
 ```
 
 # Observables

--- a/src/pmc_simulation.jl
+++ b/src/pmc_simulation.jl
@@ -99,8 +99,9 @@ function PMCSimulation(problem::ProjectorMonteCarloProblem; copy_vectors=true)
 
     # seed the random number generator
     if !isnothing(random_seed)
-        Random.seed!(random_seed + hash(mpi_rank()))
+        mpi_seed!(random_seed)
     end
+    first_rand = rand(UInt)
 
     start_at = isnothing(start_at) ? starting_address(hamiltonian) : start_at
     vectors = _set_up_starting_vectors(
@@ -160,12 +161,21 @@ function PMCSimulation(problem::ProjectorMonteCarloProblem; copy_vectors=true)
     report = Report()
     report_default_metadata!(report, state)
     metadata!(report, metadata) # add user metadata
+    metadata!(report, "random_seed", random_seed) # reproducibility support
+    metadata!(report, "first_rand", first_rand)
+    metadata!(report, "threading", threading)
+    metadata!(report, "hash(1)", hash(1))
 
     # Sanity checks.
     @assert allequal(i->state[i].algorithm, n_replicas * n_spectral) &&
         first(state).algorithm == algorithm
     @assert allequal(i -> state[i].hamiltonian, n_replicas * n_spectral) &&
         first(state).hamiltonian == hamiltonian
+    @assert if eltype(state_vectors(state)) <: PDVec
+        any(x -> length(x.segments) > 1, state_vectors(state)) === threading
+    else
+        threading === false
+    end "threading must be true if any starting vector has multiple segments, and false otherwise."
 
     return PMCSimulation(
         problem, state, report, false, false, false, "", 0.0

--- a/src/projector_monte_carlo_problem.jl
+++ b/src/projector_monte_carlo_problem.jl
@@ -132,8 +132,33 @@ number of threads used. If only one thread is used and the other values are iden
 results of two simulations can be expected to be identical.
 ## Example
 ```jldoctest
-```
+julia> p = ProjectorMonteCarloProblem(HubbardReal1D(BoseFS(1,1,1)); threading=false);
 
+julia> sim1 = solve(p);
+
+julia> sim2 = solve(p);
+
+julia> metadata(sim1, "random_seed") == metadata(sim2, "random_seed")
+true
+
+julia> metadata(sim1, "first_rand") == metadata(sim2, "first_rand")
+true
+
+julia> metadata(sim1, "hash(1)") == metadata(sim2, "hash(1)") == string(hash(1))
+true
+
+julia> state_vectors(sim1) == state_vectors(sim2) # results of PMC are bitwise identical
+true
+
+julia> p = ProjectorMonteCarloProblem(HubbardReal1D(BoseFS(1,1,1)); random_seed=false);
+
+julia> sim1 = solve(p);
+
+julia> sim2 = solve(p);
+
+julia> state_vectors(sim1) == state_vectors(sim2) # without seeding, results are not identical
+false
+```
 """
 struct ProjectorMonteCarloProblem{N,S} # is not type stable but does not matter
     # N is the number of replicas, S is the number of spectral states

--- a/src/projector_monte_carlo_problem.jl
+++ b/src/projector_monte_carlo_problem.jl
@@ -271,6 +271,13 @@ function ProjectorMonteCarloProblem(
         initiator = initiator ? Initiator() : NonInitiator()
     end
 
+    if Threads.nthreads() == 1
+        if threading === true
+            @warn "Only one thread is available, overriding the threading setting."
+        end
+        threading = false
+    end
+
     if (start_at isa PDVec && length(start_at.segments) > 1) ||
         (eltype(start_at) <: PDVec && any(x->length(x.segments) > 1, start_at))
         if threading === false

--- a/src/projector_monte_carlo_problem.jl
+++ b/src/projector_monte_carlo_problem.jl
@@ -106,6 +106,34 @@ julia> size(DataFrame(simulation))
     is not provided.
 
 See also [`init`](@ref), [`solve`](@ref).
+
+# Extended help
+
+## Reproducibility support
+
+While the Monte Carlo algorithm is based on random number generation, which follows a
+deterministic sequence if the seed is fixed, the results of `solve`ing a
+`ProjectorMonteCarloProblem` are not generally guaranteed to be bitwise identical across
+different runs, even with the same random seed. This is because
+- the order of storage of addresses in `DVec` or `PDVec` objects used internally depends
+  on the output of `hash()`, which is not guaranteed to be stable across Julia versions or
+  when a new Julia process is started, and
+- the order of operations is unpredictable when multithreading is used.
+
+However, if multithreading is not used and the random seed is fixed, the results of
+`solve`ing a `ProjectorMonteCarloProblem` will be identical across runs and within the same
+Julia session, even if the same `ProjectorMonteCarloProblem` is solved multiple times. If it
+can be confirmed that the hash values are consistent and the same random number generator is
+used, the results will also be identical across Julia sessions and versions.
+
+To support reproducibility, the metadata of the simulation report includes the random seed
+used, the value of the first random number generated, the output of `hash(1)`, and the
+number of threads used. If only one thread is used and the other values are identical, the
+results of two simulations can be expected to be identical.
+## Example
+```jldoctest
+```
+
 """
 struct ProjectorMonteCarloProblem{N,S} # is not type stable but does not matter
     # N is the number of replicas, S is the number of spectral states
@@ -216,6 +244,19 @@ function ProjectorMonteCarloProblem(
 
     if initiator isa Bool
         initiator = initiator ? Initiator() : NonInitiator()
+    end
+
+    if (start_at isa PDVec && length(start_at.segments) > 1) ||
+        (eltype(start_at) <: PDVec && any(x->length(x.segments) > 1, start_at))
+        if threading === false
+            @warn "Starting vector(s) have multiple segments, overriding the threading setting."
+        end
+        threading = true
+    elseif (start_at isa AbstractDVec || eltype(start_at) <: AbstractDVec)
+        if threading === true
+            @warn "Starting vector(s) are not PDVecs, overriding the threading setting."
+        end
+        threading = false
     end
 
     if isnothing(threading)

--- a/test/StatsTools.jl
+++ b/test/StatsTools.jl
@@ -288,8 +288,9 @@ end
             df; op_name = "Op$(d+1)", skip = skipsteps
         )
         g2_rw = df_rre[end,:val]
-        # reweighting improves the estimate
-        @test abs(g2_h0 - best_g2[d+1]) > abs(g2_rw - best_g2[d+1])
+        g2_rw_l = df_rre[end, :val_l]
+        # reweighting improves the estimate (within error bars)
+        @test g2_h0 - best_g2[d+1] > g2_rw - g2_rw_l - best_g2[d+1]
     end
 end
 
@@ -343,7 +344,8 @@ using Rimu.StatsTools: replica_fidelity
     # test variational energy directly on the result of the replica run
     ve = variational_energy_estimator(rr; skip=steps_equi, max_replicas=5)
     # the `max_replicas` option has no effect in this case
-    @test kkresults[1][1] < pmedian(ve)
+    val, val_l, val_u = val_and_errs(ve)
+    @test kkresults[1][1] < val + val_u
     @test pmedian(ve) < shift_estimator(rr; shift = :shift_r1s1, skip=steps_equi).mean
     @test_throws ArgumentError variational_energy_estimator(DataFrame()) # empty df
     vs = [rand(5) for _ in 1:4]

--- a/test/StatsTools.jl
+++ b/test/StatsTools.jl
@@ -223,7 +223,7 @@ end
     E_r = bs.mean # set up reference energy
     ge = @suppress growth_estimator(df, h; E_r, skip=steps_equi)
     pcb_est = E_r - ge.ratio # estimated PCB in the shift from reweighting
-    @test 0.2 < pmedian(pcb_est) < pcb
+    @test pquantile(pcb_est, 0.2) < pcb
     @inferred growth_estimator(rand(1000), 100 .+ rand(1000), 20, 0.01; change_type=to_measurement)
     @inferred growth_estimator(rand(1000), 100 .+ rand(1000), 20, 0.01)
     # fails due to type instability in MonteCarloMeasurements

--- a/test/mpi_runtests.jl
+++ b/test/mpi_runtests.jl
@@ -181,7 +181,7 @@ end
             s_low, s_high = Es - 3σs, Es + 3σs
             # Projected estimate.
             r = ratio_of_means(df.hproj[2000:end], df.vproj[2000:end])
-            p_low, p_high = pquantile(r, [0.0015, 0.9985])
+            p_low, p_high = pquantile(r, [0.001, 0.999])
 
             @test s_low < E0 < s_high
             @test p_low < E0 < p_high

--- a/test/mpi_runtests.jl
+++ b/test/mpi_runtests.jl
@@ -172,7 +172,7 @@ end
                 Projector(proj_1=Norm2Projector()),
             )
             prob = ProjectorMonteCarloProblem(
-                H; start_at=dv, post_step_strategy, last_step=5000, random_seed=13
+                H; start_at=dv, post_step_strategy, last_step=5000, random_seed=17
             )
             df = DataFrame(solve(prob))
 
@@ -181,7 +181,7 @@ end
             s_low, s_high = Es - 3σs, Es + 3σs
             # Projected estimate.
             r = ratio_of_means(df.hproj[2000:end], df.vproj[2000:end])
-            p_low, p_high = pquantile(r, [0.001, 0.999])
+            p_low, p_high = pquantile(r, [0.0005, 0.9995])
 
             @test s_low < E0 < s_high
             @test p_low < E0 < p_high

--- a/test/projector_monte_carlo_problem.jl
+++ b/test/projector_monte_carlo_problem.jl
@@ -17,7 +17,7 @@ using OrderedCollections: freeze
 
     simulation = init(p)
     @test simulation.hamiltonian == h
-    @test only(state_vectors(simulation)) isa PDVec
+    @test only(state_vectors(simulation)) isa (p.threading ? PDVec : DVec)
     sp = only(simulation.state).shift_parameters
     @test sp.shift == diagonal_element(h, starting_address(h))
     @test sp.pnorm == walkernumber(only(state_vectors(simulation)))
@@ -69,9 +69,10 @@ using OrderedCollections: freeze
     @test first(sm.state).pv !== dv
 
     # threading overrides
-    @test_logs (:warn, Regex("(threading)")) p = ProjectorMonteCarloProblem(h; start_at=dv, threading=false)
-    @test p.threading == true
-
+    if Threads.nthreads() > 1
+        @test_logs (:warn, Regex("(threading)")) p = ProjectorMonteCarloProblem(h; start_at=dv, threading=false)
+        @test p.threading == true
+    end
 
     # copy_vectors = false
     dv1 = deepcopy(dv)
@@ -138,7 +139,7 @@ end
         @test StochasticStyle(only(state_vectors(sm))) isa IsDynamicSemistochastic
 
         sm = init(ProjectorMonteCarloProblem(H; threading=true))
-        @test only(state_vectors(sm)) isa PDVec
+        @test only(state_vectors(sm)) isa (sm.problem.threading ? PDVec : DVec)
         @test StochasticStyle(only(state_vectors(sm))) isa IsDynamicSemistochastic
 
         sm = init(ProjectorMonteCarloProblem(H; threading=false, initiator=true))

--- a/test/projector_monte_carlo_problem.jl
+++ b/test/projector_monte_carlo_problem.jl
@@ -56,6 +56,10 @@ using OrderedCollections: freeze
     @test state_vectors(sm)[1] == dv
     @test ProjectorMonteCarloProblem(h; shift=2).initial_shift_parameters.shift == 2
 
+    # threading overrides
+    @test_logs (:warn, Regex("(threading)")) p = ProjectorMonteCarloProblem(h; start_at=dv, threading=true)
+    @test p.threading == false
+
     # passing PDVec to ProjectorMonteCarloProblem
     dv = PDVec(starting_address(h)=>3; style=IsDynamicSemistochastic())
     p = ProjectorMonteCarloProblem(h; n_replicas=3, start_at=dv)
@@ -63,6 +67,11 @@ using OrderedCollections: freeze
     @test first(state_vectors(sm)) == dv
     @test first(state_vectors(sm)) !== dv
     @test first(sm.state).pv !== dv
+
+    # threading overrides
+    @test_logs (:warn, Regex("(threading)")) p = ProjectorMonteCarloProblem(h; start_at=dv, threading=false)
+    @test p.threading == true
+
 
     # copy_vectors = false
     dv1 = deepcopy(dv)
@@ -73,6 +82,14 @@ using OrderedCollections: freeze
     @test state_vectors(sm)[2] === dv2
     @test_throws BoundsError sm.state.spectral_states[3]
 
+    # reproducibility support
+    sim1 = solve(p)
+    sim2 = solve(p)
+    @test metadata(sim1, "random_seed") == metadata(sim2, "random_seed") == string(p.random_seed)
+    @test metadata(sim1, "first_rand") == metadata(sim2, "first_rand")
+    @test metadata(sim1, "threading") == metadata(sim2, "threading") == string(p.threading)
+    @test metadata(sim1, "hash(1)") == metadata(sim2, "hash(1)") == string(hash(1))
+    @test state_vectors(sim1) == state_vectors(sim2)
 end
 
 @testset "PMCSimulation" begin
@@ -317,7 +334,7 @@ end
     @test sim.aborted == true
     @test sim.success == false
     @test sim.modified == true
-    @test sim.message == "Aborted in step 5."
+    @test startswith(sim.message, "Aborted in step")
     @test size(sim.df, 1) < 100
 
     # population does not die with sensible default shift
@@ -337,7 +354,7 @@ end
     @test sim.aborted == true
     @test sim.success == false
     @test sim.modified == true
-    @test sim.message == "Aborted in step 3."
+    @test startswith(sim.message, "Aborted in step")
     @test size(sim.df, 1) < 100
 end
 
@@ -354,7 +371,7 @@ end
     @test sm.modified == true
     @test sm.success == false
     @test sm.aborted == true
-    @test sm.message == "Aborted in step 6."
+    @test startswith(sm.message, "Aborted in step")
     @test is_finalized(sm.report) == true
     @test @suppress_err step!(sm) === sm # no effect, aborted
 


### PR DESCRIPTION
This PR fixes test failures on Julia v1.13 and clarifies under which circumstances Monte Carlo simulations are reproducible.

## New features
- New metadata fields for `PMCSimulation`
  - "random_seed" The random seed from `ProjectorMonteCarloProblem`, or `nothing` if not seeded
  - "first_rand" First random number drawn after seeding the random number generator. Can be used to assure that the random number generator hasn't changed.
  - "threading" `true` or `false` indicating whether threading is used
  - "hash(1)" the value returned by `hash(1)`. Can be used to assess whether the hash values are stable.