### PR TITLE
Fix error in AllOverlaps for AbstractObservables

### DIFF
--- a/src/strategies_and_params/replicastrategy.jl
+++ b/src/strategies_and_params/replicastrategy.jl
@@ -135,9 +135,9 @@ function AllOverlaps(
     if isnothing(operator)
         operators = ()
     elseif operator isa TupleOrVector
-        if !(eltype(operator) <: AbstractOperator)
-            throw(ArgumentError("operator must be an AbstractOperator or a Tuple or "*
-                "Vector of AbstractHamiltonians"))
+        if !(eltype(operator) <: AbstractObservable)
+            throw(ArgumentError("operator must be an AbstractObservable or a Tuple or "*
+                "Vector of AbstractObservables"))
         end
         operators = operator
     else


### PR DESCRIPTION
`AllOverlaps` threw an error when a tuple or vector was passed as `operator` and any of the elements were `AbstractObservable`s and not `AbstractOperator`s. This has been fixed to allow `AbstractObservable`s when more than one observable is used.