### PR TITLE
Add manual "Run workflow" button to GitHub Actions browser tab

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -3,6 +3,7 @@ name: Run tests
 on:
   push:
   pull_request:
+  workflow_dispatch: # Allows manual triggering from the web UI
 
 jobs:
   test:


### PR DESCRIPTION
CompatHelper opens PRs automatically, but with recent changes by GitHub, CI is not run and the suggested changes are not tested. This PR adds a "Run workflow" button to the GitHub Actions browser tab such that tests can be triggered from the browser interface with the push of a button.