### PR TITLE
Variable particle number for FermiFS and HarcoreBoseFS

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Rimu"
 uuid = "c53c40cc-bd84-11e9-2cf4-a9fde2b9386e"
-version = "0.16.0"
+version = "0.16.1"
 authors = ["Joachim Brand <j.brand@massey.ac.nz>"]
 
 [deps]

--- a/docs/src/addresses.md
+++ b/docs/src/addresses.md
@@ -1,25 +1,26 @@
 # Module `BitStringAddresses`
 
-This module contains the implementations of [`BitString`](@ref) and various Fock addresses.
-The addresses serve as a basis for a Hamiltonian.
-
-While there are not restrictions on the type of address a Hamiltonian uses, Rimu provides
-implementations for Bosonic, Fermionic, and mixed [Fock
-States](https://en.wikipedia.org/wiki/Fock_state).
-
-When implementing a new address type, care must be taken to make them space-efficient and
-stack-allocated - avoid using (heap-allocated) arrays to represent your addresses at all costs!
+This module contains the implementations of the underlying data structures to efficiently represent
+[Fock states](https://en.wikipedia.org/wiki/Fock_state). In Rimu.jl, Fock states are used as the basis 
+for linear (Hilbert) space. The concrete implementations of Fock states are used as addresses to identify
+matrix elements of operators, or elements of state vectors.
 
 ## Fock addresses
 
-Rimu provides a variety of address implementations that should make it
-straightforward to implement efficient Hamiltonians. Examples are:
+Many Hamiltonians in Rimu.jl are implemented in a generic way and crucial information that defines the size of Hilbert space and the quantum statistics of particle are defined by passing a Fock state address. Rimu.jl provides a variety of address types that enable the efficient implementation of 
+many-body Hamiltonians. All implementations of Fock states are subtype to the
+[`AbstractFockAddress`](@ref) abstract type. For Fock states representing a single component of indistinguishable quantum particles there is the more specialised 
+type [`SingleComponentFockAddress`](@ref).
+
+Examples of Fock addresses are:
 
 - [`BoseFS`](@ref) Single-component bosonic Fock state with fixed particle and mode number.
-- [`HardcoreBoseFS`](@ref) Single-component hardcore bosonic Fock state with fixed particle and mode number.
-- [`FermiFS`](@ref) Single-component fermionic Fock state with fixed particle and mode number.
-- [`CompositeFS`](@ref) Multi-component Fock state composed of the above types.
 - [`OccupationNumberFS`](@ref) Single-component bosonic Fock state with a fixed number of modes. The number of particles is not part of the type and can be changed by operators.
+- [`HardcoreBoseFS`](@ref) Single-component hardcore bosonic Fock state with fixed or variable particle and mode number.
+- [`FermiFS`](@ref) Single-component fermionic Fock state with fixed or variable particle and mode number.
+- [`CompositeFS`](@ref) Multi-component Fock state composed of the above types.
+
+The various address types make use efficient underlying data storage types like [`BitString`](@ref) and [`SortedParticleList`](@ref).
 
 ### Fock address API
 
@@ -38,11 +39,11 @@ Private = false
 
 ## Internal representations
 
-The atomic addresses, [`BoseFS`](@ref) and [`FermiFS`](@ref), are implemented as either
-bitstrings or sorted lists of particles. Using these approaches over an occupation number
-representation makes the addresses much more space-efficient.
+The addresses types [`BoseFS`](@ref), [`FermiFS`](@ref) and [`HardcoreBoseFS`](@ref) are 
+implemented as either bitstrings through [`BitString`](@ref), or sorted lists of particles 
+with [`SortedParticleList`](@ref). This allows for a space efficient representation.
 
-Therewhile [`OccupationNumberFS`](@ref) internally uses the occupation number representation, 
+Therewhile, [`OccupationNumberFS`](@ref) internally uses the occupation number representation, 
 which allows it to handle excitation operations that change the particle number. This is fast
 but requires more storage space.
 

--- a/docs/src/addresses.md
+++ b/docs/src/addresses.md
@@ -14,10 +14,13 @@ type [`SingleComponentFockAddress`](@ref).
 
 Examples of Fock addresses are:
 
-- [`BoseFS`](@ref) Single-component bosonic Fock state with fixed particle and mode number.
-- [`OccupationNumberFS`](@ref) Single-component bosonic Fock state with a fixed number of modes. The number of particles is not part of the type and can be changed by operators.
-- [`HardcoreBoseFS`](@ref) Single-component hardcore bosonic Fock state with fixed or variable particle and mode number.
-- [`FermiFS`](@ref) Single-component fermionic Fock state with fixed or variable particle and mode number.
+- [`BoseFS`](@ref): Bosonic Fock state with fixed particle and mode number.
+- [`FermiFS`](@ref): Fermionic Fock state with fixed mode number and fixed or variable
+    particle number.
+- [`OccupationNumberFS`](@ref): Bosonic Fock state with a fixed number of modes. The number
+    of particles is not part of the type and can be changed by operators.
+- [`HardcoreBoseFS`](@ref): Fock state for hardcore bosons with fixed mode number and fixed
+    or variable particle number.
 - [`CompositeFS`](@ref) Multi-component Fock state composed of the above types.
 
 The various address types make use efficient underlying data storage types like [`BitString`](@ref) and [`SortedParticleList`](@ref).

--- a/src/BitStringAddresses/bitstring.jl
+++ b/src/BitStringAddresses/bitstring.jl
@@ -771,17 +771,17 @@ end
 end
 
 function fermi_excitation(
-    bs::BitString, creations::NTuple{N}, destructions::NTuple{N}
-) where {N}
+    bs::BitString, creations::NTuple{NC}, destructions::NTuple{ND}
+) where {NC, ND}
     orig_bs = bs
     count = 0
-    for i in N:-1:1
+    for i in ND:-1:1
         d = destructions[i].mode
         bs, x, val = _flip_and_count(bs, UInt(d - 0x1))
         val && return orig_bs, 0.0
         count += x
     end
-    for i in N:-1:1
+    for i in NC:-1:1
         c = creations[i].mode
         bs, x, val = _flip_and_count(bs, UInt(c - 0x1))
         !val && return orig_bs, 0.0

--- a/src/BitStringAddresses/bosefs.jl
+++ b/src/BitStringAddresses/bosefs.jl
@@ -296,9 +296,15 @@ end
 
 # find_occupied_mode provided by generic implementation
 
-function excitation(b::B, creations, destructions) where {B<:BoseFS}
+function excitation(b::B, creations::NTuple{C}, destructions::NTuple{C}) where {B<:BoseFS, C}
     new_bs, val = bose_excitation(b.bs, creations, destructions)
     return B(new_bs), val
+end
+function excitation(b::BoseFS{N,M}, c::NTuple{C}, d::NTuple{D}) where {N, M, C, D}
+    ofs = OccupationNumberFS(b)
+    new_ofs, val = excitation(ofs, c, d)
+    NNEW = N + C - D # done at compile time
+    return BoseFS{NNEW, M}(onr(new_ofs)), val
 end
 
 """

--- a/src/BitStringAddresses/bosefs.jl
+++ b/src/BitStringAddresses/bosefs.jl
@@ -177,12 +177,17 @@ BoseFS{10,4}(3, 3, 2, 2)
 function near_uniform(T::Type{<:SingleComponentFockAddress{N,M}}) where {N,M}
     return T(near_uniform_onr(Val(N), Val(M)))
 end
-near_uniform(b::SingleComponentFockAddress) = near_uniform(typeof(b))
 function near_uniform(T::Type{<:SingleComponentFockAddress}, N::Integer, M::Integer)
     return near_uniform(T, Val(N), Val(M))
 end
 function near_uniform(T::Type{<:SingleComponentFockAddress}, ::Val{N}, ::Val{M}) where {N,M}
     return T(near_uniform_onr(Val(N), Val(M)))
+end
+near_uniform(b::SingleComponentFockAddress) = near_uniform(typeof(b))
+function near_uniform(b::SingleComponentFockAddress{missing})
+    N = num_particles(b)
+    M = num_modes(b)
+    return near_uniform(typeof(b), Val(N), Val(M))
 end
 
 onr(b::BoseFS{<:Any,M}) where {M} = to_bose_onr(b.bs, Val(M))

--- a/src/BitStringAddresses/bosefs.jl
+++ b/src/BitStringAddresses/bosefs.jl
@@ -152,8 +152,9 @@ function near_uniform_onr(::Val{N}, ::Val{M}) where {N, M}
 end
 
 """
-    near_uniform(T::Type{<:SingleComponentFockAddress{N,M}}) -> address::T
-    near_uniform(T::Type{<:SingleComponentFockAddress}, N::Integer, M::Integer) -> address::T
+    near_uniform(T::Type{<:SingleComponentFockAddress{N,M}}) → address::T
+    near_uniform(T::Type{<:SingleComponentFockAddress}, N::Integer, M::Integer) → address::T
+    near_uniform(address::SingleComponentFockAddress) → address::typeof(address)
 
 Create a single component Fock state with `M` modes and `N` particles with near uniform
 occupation numbers.
@@ -168,15 +169,15 @@ FermiFS{3,5}(1, 1, 1, 0, 0)
 
 julia> near_uniform(HardcoreBoseFS{missing}, 3, 5)
 HardcoreBoseFS{missing,5}(1, 1, 1, 0, 0)
+
+julia> near_uniform(BoseFS(10,0,0,0))
+BoseFS{10,4}(3, 3, 2, 2)
 ```
 """
 function near_uniform(T::Type{<:SingleComponentFockAddress{N,M}}) where {N,M}
     return T(near_uniform_onr(Val(N), Val(M)))
 end
-# function near_uniform(::Type{<:BoseFS{N,M}}) where {N,M}
-#     return BoseFS{N,M}(near_uniform_onr(Val(N),Val(M)))
-# end
-# near_uniform(b::AbstractFockAddress) = near_uniform(typeof(b))
+near_uniform(b::SingleComponentFockAddress) = near_uniform(typeof(b))
 function near_uniform(T::Type{<:SingleComponentFockAddress}, N::Integer, M::Integer)
     return near_uniform(T, Val(N), Val(M))
 end

--- a/src/BitStringAddresses/bosefs.jl
+++ b/src/BitStringAddresses/bosefs.jl
@@ -152,10 +152,11 @@ function near_uniform_onr(::Val{N}, ::Val{M}) where {N, M}
 end
 
 """
-    near_uniform(BoseFS{N,M}) -> BoseFS{N,M}
+    near_uniform(T::Type{<:SingleComponentFockAddress{N,M}}) -> address::T
+    near_uniform(T::Type{<:SingleComponentFockAddress}, N::Integer, M::Integer) -> address::T
 
-Create bosonic Fock state with near uniform occupation number of `M` modes with
-a total of `N` particles.
+Create a single component Fock state with `M` modes and `N` particles with near uniform
+occupation numbers.
 
 # Examples
 ```jldoctest
@@ -164,12 +165,24 @@ BoseFS{7,5}(2, 2, 1, 1, 1)
 
 julia> near_uniform(FermiFS{3,5})
 FermiFS{3,5}(1, 1, 1, 0, 0)
+
+julia> near_uniform(HardcoreBoseFS{missing}, 3, 5)
+HardcoreBoseFS{missing,5}(1, 1, 1, 0, 0)
 ```
 """
-function near_uniform(::Type{<:BoseFS{N,M}}) where {N,M}
-    return BoseFS{N,M}(near_uniform_onr(Val(N),Val(M)))
+function near_uniform(T::Type{<:SingleComponentFockAddress{N,M}}) where {N,M}
+    return T(near_uniform_onr(Val(N), Val(M)))
 end
-near_uniform(b::AbstractFockAddress) = near_uniform(typeof(b))
+# function near_uniform(::Type{<:BoseFS{N,M}}) where {N,M}
+#     return BoseFS{N,M}(near_uniform_onr(Val(N),Val(M)))
+# end
+# near_uniform(b::AbstractFockAddress) = near_uniform(typeof(b))
+function near_uniform(T::Type{<:SingleComponentFockAddress}, N::Integer, M::Integer)
+    return near_uniform(T, Val(N), Val(M))
+end
+function near_uniform(T::Type{<:SingleComponentFockAddress}, ::Val{N}, ::Val{M}) where {N,M}
+    return T(near_uniform_onr(Val(N), Val(M)))
+end
 
 onr(b::BoseFS{<:Any,M}) where {M} = to_bose_onr(b.bs, Val(M))
 const occupation_number_representation = onr # resides here because `onr` has to be defined

--- a/src/BitStringAddresses/bosefs.jl
+++ b/src/BitStringAddresses/bosefs.jl
@@ -298,13 +298,10 @@ end
 
 function excitation(b::B, creations::NTuple{C}, destructions::NTuple{C}) where {B<:BoseFS, C}
     new_bs, val = bose_excitation(b.bs, creations, destructions)
-    return B(new_bs), val
+    return B(new_bs), val # type doesn't change
 end
-function excitation(b::BoseFS{N,M}, c::NTuple{C}, d::NTuple{D}) where {N, M, C, D}
-    ofs = OccupationNumberFS(b)
-    new_ofs, val = excitation(ofs, c, d)
-    NNEW = N + C - D # done at compile time
-    return BoseFS{NNEW, M}(onr(new_ofs)), val
+function excitation(b::BoseFS, c::NTuple{C}, d::NTuple{D}) where {C, D}
+    throw(ArgumentError("number of creations and destructions must be equal, got $C and $D"))
 end
 
 """

--- a/src/BitStringAddresses/fermifs.jl
+++ b/src/BitStringAddresses/fermifs.jl
@@ -146,9 +146,11 @@ end
 function excitation(
     a::FermiFS{N,M,S}, creations::NTuple{NC}, destructions::NTuple{ND}
 ) where {N,M,S,NC,ND}
+    if NC != ND && !ismissing(N)
+        throw(ArgumentError("number of creations and destructions must be equal, got $NC and $ND"))
+    end
     new_bs, value = fermi_excitation(a.bs, creations, destructions)
-    NN = ismissing(N) ? missing : N + NC - ND # done at compile time
-    return FermiFS{NN,M,S}(new_bs), value # carries sign, different from HardcoreBoseFS
+    return FermiFS{N,M,S}(new_bs), value # carries sign, different from HardcoreBoseFS
 end
 
 # joint functions for FermiFS and HardcoreBoseFS

--- a/src/BitStringAddresses/fermifs.jl
+++ b/src/BitStringAddresses/fermifs.jl
@@ -159,7 +159,8 @@ Interfaces.num_particles(a::FermiOrHardcoreBoseFS{missing}) = count_ones(a.bs)
 Base.bitstring(a::FermiOrHardcoreBoseFS) = bitstring(a.bs)
 Base.isless(a::F, b::F) where {F <: FermiOrHardcoreBoseFS} = isless(a.bs, b.bs)
 Base.hash(a::FermiOrHardcoreBoseFS, h::UInt) = hash(a.bs, h)
-Base.:(==)(a::FermiOrHardcoreBoseFS, b::FermiOrHardcoreBoseFS) = a.bs == b.bs
+Base.:(==)(a::FermiFS, b::FermiFS) = a.bs == b.bs
+Base.:(==)(a::HardcoreBoseFS, b::HardcoreBoseFS) = a.bs == b.bs
 
 num_occupied_modes(a::FermiOrHardcoreBoseFS) = num_particles(a)
 num_unoccupied_modes(a::FermiOrHardcoreBoseFS) = num_modes(a) - num_particles(a)

--- a/src/BitStringAddresses/fermifs.jl
+++ b/src/BitStringAddresses/fermifs.jl
@@ -3,7 +3,8 @@
 
 Address type that represents a Fock state of `N` fermions of the same spin in `M` modes by
 wrapping a [`BitString`](@ref), or a [`SortedParticleList`](@ref). Which is wrapped is
-chosen automatically based on the properties of the address.
+chosen automatically based on the properties of the address. Set `N` to `missing` if the
+number of particles is not known at compile time.
 
 # Constructors
 
@@ -56,7 +57,7 @@ struct FermiFS{N,M,S} <: SingleComponentFockAddress{N,M}
 end
 
 function check_fermi_onr(onr, N, M)
-    sum(onr) == N ||
+    ismissing(N) || sum(onr) == N ||
         throw(ArgumentError("Invalid ONR: $N particles expected, $(sum(onr)) given."))
     length(onr) == M ||
         throw(ArgumentError("Invalid ONR: $M modes expected, $(length(onr)) given."))
@@ -82,6 +83,11 @@ function FermiFS{N,M,S}(onr::Union{SVector{M},MVector{M},NTuple{M}}) where {N,M,
 end
 function FermiFS{N,M}(onr::Union{AbstractArray{<:Integer},NTuple{M,<:Integer}}) where {N,M}
     @boundscheck check_fermi_onr(onr, N, M)
+    if ismissing(N)
+        S = typeof(BitString{M}(0))
+        return FermiFS{N,M,S}(from_fermi_onr(S, onr))
+    end
+
     spl_type = select_int_type(M)
     # Pick smaller address type, but prefer dense.
     # Alway pick dense if it fits into one chunk.
@@ -102,20 +108,32 @@ function FermiFS(onr)
     N = sum(onr)
     return FermiFS{N,M}(onr)
 end
+function FermiFS{N}(onr) where {N}
+    onr = Tuple(onr)
+    M = length(onr)
+    return FermiFS{N,M}(onr)
+end
+
 FermiFS(vals::Integer...) = FermiFS(vals) # list occupation numbers
 FermiFS(val::Integer) = FermiFS((val,)) # single mode
+FermiFS{N}(vals::Integer...) where N = FermiFS{N}(vals) # list occupation numbers
+FermiFS{N}(val::Integer) where {N} = FermiFS{N}((val,)) # single mode
 FermiFS{N,M}(vals::Integer...) where {N,M} = FermiFS{N,M}(vals)
 
 # Sparse constructors
 FermiFS(M::Integer, pairs::Pair...) = FermiFS(M, pairs)
+FermiFS{N}(M::Integer, pairs::Pair...) where {N} = FermiFS{N}(M, pairs)
 FermiFS(M::Integer, pairs) = FermiFS(sparse_to_onr(M, pairs))
-FermiFS{N,M}(pairs::Vararg{Pair,N}) where {N,M} = FermiFS{N,M}(pairs)
-FermiFS{N,M}(pairs) where {N,M} = FermiFS{N,M}(sparse_to_onr(M, pairs))
+FermiFS{N}(M::Integer, pairs) where {N} = FermiFS{N}(sparse_to_onr(M, pairs))
+FermiFS{N,M}(pairs::Vararg{Pair}) where {N,M} = FermiFS{N,M}(pairs)
+FermiFS{N,M}(pairs) where {N,M} = FermiFS{N}(sparse_to_onr(M, pairs))
 FermiFS(pairs::Pair...) = throw(ArgumentError("number of modes must be provided"))
 
 function print_address(io::IO, f::FermiFS{N,M}; compact=false) where {N,M}
     if compact && f.bs isa SortedParticleList
         print(io, "|f ", M, ": ", join(Int.(f.bs.storage), ' '), "⟩")
+    elseif compact && ismissing(N)
+        print(io, "|", join(map(o -> o == 0 ? '⋅' : '↑', onr(f))), "⟩{}")
     elseif compact
         print(io, "|", join(map(o -> o == 0 ? '⋅' : '↑', onr(f))), "⟩")
     elseif f.bs isa SortedParticleList
@@ -125,28 +143,32 @@ function print_address(io::IO, f::FermiFS{N,M}; compact=false) where {N,M}
     end
 end
 
-function near_uniform(::Type{FermiFS{N,M}}) where {N,M}
-    return FermiFS([fill(1, N); fill(0, M - N)])
-end
-
-function excitation(a::FermiFS{N,M,S}, creations, destructions) where {N,M,S}
+function excitation(
+    a::FermiFS{N,M,S}, creations::NTuple{NC}, destructions::NTuple{ND}
+) where {N,M,S,NC,ND}
     new_bs, value = fermi_excitation(a.bs, creations, destructions)
-    return FermiFS{N,M,S}(new_bs), value # carries sign, different from HardcoreBoseFS
+    NN = ismissing(N) ? missing : N + NC - ND # done at compile time
+    return FermiFS{NN,M,S}(new_bs), value # carries sign, different from HardcoreBoseFS
 end
 
 # joint functions for FermiFS and HardcoreBoseFS
 const FermiOrHardcoreBoseFS{N,M,S} = Union{FermiFS{N,M,S}, HardcoreBoseFS{N,M,S}}
 
+Interfaces.num_particles(a::FermiOrHardcoreBoseFS{missing}) = count_ones(a.bs)
+# only required for missing, as the fallback for other types is defined in the abstract type
 Base.bitstring(a::FermiOrHardcoreBoseFS) = bitstring(a.bs)
 Base.isless(a::F, b::F) where {F <: FermiOrHardcoreBoseFS} = isless(a.bs, b.bs)
 Base.hash(a::FermiOrHardcoreBoseFS, h::UInt) = hash(a.bs, h)
-Base.:(==)(a::F, b::F) where {F<:FermiOrHardcoreBoseFS} = a.bs == b.bs
+Base.:(==)(a::FermiOrHardcoreBoseFS, b::FermiOrHardcoreBoseFS) = a.bs == b.bs
 
-num_occupied_modes(::FermiOrHardcoreBoseFS{N}) where {N} = N
-num_unoccupied_modes(::FermiOrHardcoreBoseFS{N,M}) where {N,M} = M - N
+num_occupied_modes(a::FermiOrHardcoreBoseFS) = num_particles(a)
+num_unoccupied_modes(a::FermiOrHardcoreBoseFS) = num_modes(a) - num_particles(a)
 
 occupied_modes(a::FermiOrHardcoreBoseFS{N,<:Any,S}) where {N,S} = FermiOccupiedModes{N,S}(a.bs)
 unoccupied_modes(a::FermiOrHardcoreBoseFS{N,M,S}) where {N,M,S} = FermiUnoccupiedModes{M - N,S}(a.bs)
+function unoccupied_modes(a::FermiOrHardcoreBoseFS{missing,<:Any,S}) where {S}
+    FermiUnoccupiedModes{missing,S}(a.bs)
+end
 
 @inline function onr(a::FermiOrHardcoreBoseFS{<:Any,M}) where {M}
     result = zero(MVector{M,Int32})
@@ -200,7 +222,7 @@ true
 ```
 See also [`occupied_mode_map`](@ref).
 """
-function unoccupied_mode_map(addr::FermiOrHardcoreBoseFS{N,M}) where {N,M}
+function unoccupied_mode_map(addr::FermiOrHardcoreBoseFS)
     modes = unoccupied_modes(addr)
     T = eltype(modes)
     L = num_unoccupied_modes(addr)

--- a/src/BitStringAddresses/fermifs.jl
+++ b/src/BitStringAddresses/fermifs.jl
@@ -4,7 +4,7 @@
 Address type that represents a Fock state of `N` fermions of the same spin in `M` modes by
 wrapping a [`BitString`](@ref), or a [`SortedParticleList`](@ref). Which is wrapped is
 chosen automatically based on the properties of the address. Set `N` to `missing` if the
-number of particles is not known at compile time.
+number of particles is not known at compile time and can be changed by excitations.
 
 # Constructors
 
@@ -30,7 +30,7 @@ number of particles is not known at compile time.
 # Examples
 
 ```jldoctest
-julia> FermiFS{3,5}(0, 1, 1, 1, 0)
+julia> FermiFS(0, 1, 1, 1, 0)
 FermiFS{3,5}(0, 1, 1, 1, 0)
 
 julia> FermiFS([abs(i - 3) ≤ 1 for i in 1:5])
@@ -44,6 +44,9 @@ FermiFS{3,5}(0, 1, 1, 1, 0)
 
 julia> fs"|⋅↑↑↑⋅⟩" # \\uparrow(tab) -> ↑, \\cdot(tab) -> ⋅, \\rangle(tab) -> ⟩
 FermiFS{3,5}(0, 1, 1, 1, 0)
+
+julia> FermiFS{missing}(0, 1, 1, 1, 0) == fs"|⋅↑↑↑⋅⟩{}" # missing particle number
+true
 
 julia> fs"|f 5: 2 3 4⟩"
 FermiFS{3,5}(0, 1, 1, 1, 0)

--- a/src/BitStringAddresses/fockaddress.jl
+++ b/src/BitStringAddresses/fockaddress.jl
@@ -166,8 +166,10 @@ unoccupied_modes
     excitation(addr::SingleComponentFockAddress, creations::NTuple, destructions::NTuple)
 
 Generate an excitation on address `addr` by applying `creations` and `destructions`, which
-are tuples of the appropriate address indices (i.e. [`BoseFSIndex`](@ref) for bosons, or
-[`FermiFSIndex`](@ref) for fermions).
+are tuples of the appropriate address indices (i.e. [`BoseFSIndex`](@ref) for
+[`BoseFS`](@ref) and [`OccupationNumberFS`](@ref), or
+[`FermiFSIndex`](@ref) for [`FermiFS`](@ref) and [`HardcoreBoseFSIndex`](@ref);
+ [`OccupationNumberFS`](@ref) also supports integer indices).
 
 ```math
 a^†_{c_1} a^†_{c_2} … a_{d_1} a_{d_2} … |f⟩ → α|f'⟩
@@ -175,7 +177,9 @@ a^†_{c_1} a^†_{c_2} … a_{d_1} a_{d_2} … |f⟩ → α|f'⟩
 
 Returns the new address `f'` and the factor `α`. The value of `α` is given by the square
 root of the product of mode occupations before destruction and after creation. If the
-excitation is illegal, returns an arbitrary address and the value `0.0`.
+excitation is illegal, returns an arbitrary address and the value `0.0`. Note that the
+number of particles may change if the number of creation and destruction operators is not
+equal. This may affect the type of the returned address. See examples below.
 
 # Example
 
@@ -189,11 +193,26 @@ julia> i, j, k, l = find_mode(f, (3,4,2,5))
 julia> excitation(f, (i,j), (k,l)) # number conserving excitation
 (FermiFS{6,8}(1, 0, 1, 1, 0, 1, 1, 1), -1.0)
 
-julia> fm = FermiFS{missing}(1,1,0,0,1,1,1,1)
+julia> excitation(f, (j,), (k,l)) # particle number changes, different address type
+(FermiFS{5,8}(1, 0, 0, 1, 0, 1, 1, 1), 1.0)
+
+julia> fm = FermiFS{missing}(1,1,0,0,1,1,1,1) # number non-conserving address
 FermiFS{missing,8}(1, 1, 0, 0, 1, 1, 1, 1)
 
-julia> excitation(fm, (i,), (k,l)) # particle number changes
+julia> excitation(fm, (i,), (k,l)) # particle number changes, same address type
 (FermiFS{missing,8}(1, 0, 1, 0, 0, 1, 1, 1), 1.0)
+
+julia> s = fs"|1 2 3⟩{}"
+OccupationNumberFS{3, UInt8}(1, 2, 3)
+
+julia> num_particles(s)
+6
+
+julia> es, α = excitation(s, (1,1), (3,))
+(OccupationNumberFS{3, UInt8}(3, 2, 2), 4.242640687119285)
+
+julia> num_particles(es)
+7
 ```
 
 See [`SingleComponentFockAddress`](@ref).

--- a/src/BitStringAddresses/fockaddress.jl
+++ b/src/BitStringAddresses/fockaddress.jl
@@ -6,7 +6,14 @@
 
 A type representing a single component Fock state with `N` particles and `M` modes.
 
-Implemented subtypes: [`BoseFS`](@ref), [`FermiFS`](@ref).
+Implemented subtypes:
+- [`BoseFS`](@ref): Bosonic Fock state with fixed particle and mode number.
+- [`FermiFS`](@ref): Fermionic Fock state with fixed mode number and fixed or variable
+    particle number.
+- [`OccupationNumberFS`](@ref): Bosonic Fock state with a fixed number of modes. The number
+    of particles is not part of the type and can be changed by operators.
+- [`HardcoreBoseFS`](@ref): Fock state for hardcore bosons with fixed mode number and fixed
+    or variable particle number.
 
 # Supported functionality
 
@@ -609,7 +616,9 @@ end
 """
     BoseFSIndex
 
-Struct used for indexing and performing [`excitation`](@ref)s on a [`BoseFS`](@ref).
+Struct used for indexing and performing [`excitation`](@ref)s on a [`BoseFS`](@ref) or
+[`OccupationNumberFS`](@ref). `BoseFSIndex` is returned by [`find_mode`](@ref) and
+[`find_occupied_mode`](@ref).
 
 ## Fields:
 
@@ -619,6 +628,8 @@ Struct used for indexing and performing [`excitation`](@ref)s on a [`BoseFS`](@r
  the address is represented by a bitstring, and the position in the list when it is
  represented by `SortedParticleList`.
 
+See also [`FermiFSIndex`](@ref), [`find_mode`](@ref), [`find_occupied_mode`](@ref),
+[`excitation`](@ref).
 """
 Base.@kwdef struct BoseFSIndex<:FieldVector{3,Int}
     occnum::Int
@@ -636,7 +647,7 @@ Base.show(io::IO, ::MIME"text/plain", i::BoseFSIndex) = show(io, i)
     BoseOccupiedModes{C,S<:BoseFS}
 
 Iterator for occupied modes in [`BoseFS`](@ref). The definition of `iterate` is dispatched
-on the storage type.
+on the storage type. The iterator returns [`BoseFSIndex`](@ref)s.
 
 See [`occupied_modes`](@ref).
 
@@ -726,7 +737,8 @@ bose_num_occupied_modes
     FermiFSIndex
 
 Struct used for indexing and performing [`excitation`](@ref)s on a [`FermiFS`](@ref)
-and [`HardcoreBoseFS`](@ref).
+and [`HardcoreBoseFS`](@ref). `FermiFSIndex` is returned by [`find_mode`](@ref) and
+[`find_occupied_mode`](@ref).
 
 ## Fields:
 
@@ -735,6 +747,8 @@ and [`HardcoreBoseFS`](@ref).
 * `offset`: the position of the mode in the address. This is `mode - 1` when the address is
   represented by a bitstring, and the position in the list when using `SortedParticleList`.
 
+See also [`BoseFSIndex`](@ref), [`find_mode`](@ref), [`find_occupied_mode`](@ref),
+[`excitation`](@ref).
 """
 Base.@kwdef struct FermiFSIndex<:FieldVector{3,Int}
     occnum::Int
@@ -751,7 +765,8 @@ Base.show(io::IO, ::MIME"text/plain", i::FermiFSIndex) = show(io, i)
 """
     FermiOccupiedModes{N,S<:BitString}
 
-Iterator over occupied modes in address. `N` is the number of fermions. See [`occupied_modes`](@ref).
+Iterator over occupied modes in address. `N` is the number of fermions. See
+[`occupied_modes`](@ref). The iterator returns [`FermiFSIndex`](@ref)s.
 """
 struct FermiOccupiedModes{N,S} <: ModeIterator
     storage::S
@@ -764,7 +779,8 @@ Base.eltype(::FermiOccupiedModes) = FermiFSIndex
 """
     FermiUnoccupiedModes{N}
 
-Iterator over unoccupied modes in address. `N` is the number of unoccupied orbitals. See [`unoccupied_modes`](@ref).
+Iterator over unoccupied modes in address. `N` is the number of unoccupied orbitals. See
+[`unoccupied_modes`](@ref). The iterator returns [`FermiFSIndex`](@ref)s.
 """
 struct FermiUnoccupiedModes{N,S} <: ModeIterator
     storage::S
@@ -786,7 +802,7 @@ This function is a part of the interface for an underlying storage format used b
 from_fermi_onr
 
 """
-    fermi_find_mode(bs::B, i::Integer) -> FermiFSIndex
+    fermi_find_mode(bs::B, i::Integer) → FermiFSIndex
 
 Find `i`-th mode in `bs` if `bs` is a fermionic address. Should return an appropriately
 formatted [`FermiFSIndex`](@ref).
@@ -799,7 +815,7 @@ fermi_find_mode
 """
     fermi_excitation(
         bs::B, creations::NTuple{N,FermiFSIndex}, destructions::NTuple{N,FermiFSIndex}
-    ) -> Tuple{B,Float64}
+    ) → Tuple{B,Float64}
 
 Perform excitation as if `bs` was a fermionic address.
 

--- a/src/BitStringAddresses/fockaddress.jl
+++ b/src/BitStringAddresses/fockaddress.jl
@@ -186,7 +186,8 @@ Returns the new address `f'` and the factor `α`. The value of `α` is given by 
 root of the product of mode occupations before destruction and after creation. If the
 excitation is illegal, returns an arbitrary address and the value `0.0`. Note that the
 number of particles may change if the number of creation and destruction operators is not
-equal. This may affect the type of the returned address. See examples below.
+equal and `num_particles(typeof(addr))` is `missing`.
+See examples below.
 
 # Example
 
@@ -199,9 +200,6 @@ julia> i, j, k, l = find_mode(f, (3,4,2,5))
 
 julia> excitation(f, (i,j), (k,l)) # number conserving excitation
 (FermiFS{6,8}(1, 0, 1, 1, 0, 1, 1, 1), -1.0)
-
-julia> excitation(f, (j,), (k,l)) # particle number changes, different address type
-(FermiFS{5,8}(1, 0, 0, 1, 0, 1, 1, 1), 1.0)
 
 julia> fm = FermiFS{missing}(1,1,0,0,1,1,1,1) # number non-conserving address
 FermiFS{missing,8}(1, 1, 0, 0, 1, 1, 1, 1)

--- a/src/BitStringAddresses/fockaddress.jl
+++ b/src/BitStringAddresses/fockaddress.jl
@@ -365,7 +365,7 @@ function parse_address(str)
     m = match(r"⊗", str)
     if !isnothing(m)
         if !isnothing(match(r"[↓⇅]", str))
-            throw(ArgumentError("invalid Fock state format \"$str\""))
+            throw(ArgumentError("invalid Fock state format \"$str\"; 2-component FermiFS cannot be combined with ⊗"))
         else
             return CompositeFS(map(parse_address, split(str, r" *⊗ *"))...)
         end
@@ -373,8 +373,11 @@ function parse_address(str)
     # FermiFS2C
     m = match(r"[↓⇅]", str)
     if !isnothing(m)
-        m = match(r"\|([↑↓⇅⋅ ]+)⟩{}", str)
+        m = match(r"\|([↑↓⇅⋅ ]+)⟩{", str)
         if !isnothing(m) # FermiFS2C with missing particle number
+            if isnothing(match(r"{}", str))
+                throw(ArgumentError("invalid Fock state format \"$str\""))
+            end
             chars = filter(!=(' '), Vector{Char}(m.captures[1]))
             f1 = FermiFS{missing}((chars .== '↑') .| (chars .== '⇅'))
             f2 = FermiFS{missing}((chars .== '↓') .| (chars .== '⇅'))
@@ -390,17 +393,44 @@ function parse_address(str)
             return CompositeFS(f1, f2)
         end
     end
+    # Sparse OccupationNumberFS
+    m = match(r"\|b *([0-9]+): *([ 0-9]+)⟩{", str)
+    if !isnothing(m)
+        if isnothing(match(r"{}", str))
+            throw(ArgumentError("invalid Fock state format \"$str\""))
+        end
+        particles = parse.(Int, filter(!isempty, split(m.captures[2], r" +")))
+        return OccupationNumberFS(parse(Int, m.captures[1]), zip(particles, fill(1, length(particles))))
+    end
     # Sparse BoseFS
     m = match(r"\|b *([0-9]+): *([ 0-9]+)⟩", str)
     if !isnothing(m)
         particles = parse.(Int, filter(!isempty, split(m.captures[2], r" +")))
         return BoseFS(parse(Int, m.captures[1]), zip(particles, fill(1, length(particles))))
     end
+    # Sparse HardcoreBoseFS with missing particle number
+    m = match(r"\|h *([0-9]+): *([ 0-9]+)⟩{", str)
+    if !isnothing(m)
+        if isnothing(match(r"{}", str))
+            throw(ArgumentError("invalid Fock state format \"$str\""))
+        end
+        particles = parse.(Int, filter(!isempty, split(m.captures[2], r" +")))
+        return HardcoreBoseFS{missing}(parse(Int, m.captures[1]), zip(particles, fill(1, length(particles))))
+    end
     # Sparse HardcoreBoseFS
     m = match(r"\|h *([0-9]+): *([ 0-9]+)⟩", str)
     if !isnothing(m)
         particles = parse.(Int, filter(!isempty, split(m.captures[2], r" +")))
         return HardcoreBoseFS(parse(Int, m.captures[1]), zip(particles, fill(1, length(particles))))
+    end
+    # Sparse FermiFS with missing particle number
+    m = match(r"\|f *([0-9]+): *([ 0-9]+)⟩{", str)
+    if !isnothing(m)
+        if isnothing(match(r"{}", str))
+            throw(ArgumentError("invalid Fock state format \"$str\""))
+        end
+        particles = parse.(Int, filter(!isempty, split(m.captures[2], r" +")))
+        return FermiFS{missing}(parse(Int, m.captures[1]), zip(particles, fill(1, length(particles))))
     end
     # Sparse FermiFS
     m = match(r"\|f *([0-9]+): *([ 0-9]+)⟩", str)
@@ -445,8 +475,11 @@ function parse_address(str)
     end
 
     # HardcoreBoseFS with missing particle number
-    m = match(r"\|([ ∘●]+)⟩{}", str)
+    m = match(r"\|([ ∘●]+)⟩{", str)
     if !isnothing(m)
+        if isnothing(match(r"{}", str))
+            throw(ArgumentError("invalid Fock state format \"$str\""))
+        end
         chars = filter(!=(' '), Vector{Char}(m.captures[1]))
         return HardcoreBoseFS{missing}(chars .== '●')
     end
@@ -457,8 +490,11 @@ function parse_address(str)
         return HardcoreBoseFS(chars .== '●')
     end
     # Single FermiFS with missing particle number
-    m = match(r"\|([ ⋅↑]+)⟩{}", str)
+    m = match(r"\|([ ⋅↑]+)⟩{", str)
     if !isnothing(m)
+        if isnothing(match(r"{}", str))
+            throw(ArgumentError("invalid Fock state format \"$str\""))
+        end
         chars = filter(!=(' '), Vector{Char}(m.captures[1]))
         return FermiFS{missing}(chars .== '↑')
     end
@@ -493,10 +529,16 @@ CompositeFS(
   BoseFS{1,3}(0, 1, 0),
 )
 
-julia> fs"|↑↓↑⟩" # construct a fermionic Fock state; \\uparrow(tab) -> ↑, \\downarrow(tab) -> ↓
+julia> fs"|↑↓↑⟩" # 2-component fermions; \\uparrow(tab) -> ↑, \\downarrow(tab) -> ↓
 CompositeFS(
   FermiFS{2,3}(1, 0, 1),
   FermiFS{1,3}(0, 1, 0),
+)
+
+julia> fs"|↑↓↑⇅⟩{}" # spinor fermions; \\dblarrowupdown(tab) -> ⇅
+CompositeFS(
+  FermiFS{missing,4}(1, 0, 1, 1),
+  FermiFS{missing,4}(0, 1, 0, 1),
 )
 
 julia> s = fs"|0 1 2 0⟩{}" # constructing OccupationNumberFS with default UInt8 container
@@ -697,8 +739,8 @@ struct FermiOccupiedModes{N,S} <: ModeIterator
 end
 
 Base.length(::FermiOccupiedModes{N}) where {N} = N
+Base.length(it::FermiOccupiedModes{missing}) = count_ones(it.storage)
 Base.eltype(::FermiOccupiedModes) = FermiFSIndex
-Base.IteratorSize(::FermiOccupiedModes{missing}) = Base.SizeUnknown()
 
 """
     FermiUnoccupiedModes{N}
@@ -709,8 +751,8 @@ struct FermiUnoccupiedModes{N,S} <: ModeIterator
     storage::S
 end
 Base.length(::FermiUnoccupiedModes{N}) where {N} = N
+Base.length(it::FermiUnoccupiedModes{missing}) = count_zeros(it.storage)
 Base.eltype(::FermiUnoccupiedModes) = FermiFSIndex
-Base.IteratorSize(::FermiUnoccupiedModes{missing}) = Base.SizeUnknown()
 
 """
     from_fermi_onr(::Type{B}, onr) -> B

--- a/src/BitStringAddresses/fockaddress.jl
+++ b/src/BitStringAddresses/fockaddress.jl
@@ -168,7 +168,7 @@ unoccupied_modes
 Generate an excitation on address `addr` by applying `creations` and `destructions`, which
 are tuples of the appropriate address indices (i.e. [`BoseFSIndex`](@ref) for
 [`BoseFS`](@ref) and [`OccupationNumberFS`](@ref), or
-[`FermiFSIndex`](@ref) for [`FermiFS`](@ref) and [`HardcoreBoseFSIndex`](@ref);
+[`FermiFSIndex`](@ref) for [`FermiFS`](@ref) and [`HardcoreBoseFS`](@ref);
  [`OccupationNumberFS`](@ref) also supports integer indices).
 
 ```math

--- a/src/BitStringAddresses/fockaddress.jl
+++ b/src/BitStringAddresses/fockaddress.jl
@@ -170,11 +170,10 @@ are tuples of the appropriate address indices (i.e. [`BoseFSIndex`](@ref) for bo
 [`FermiFSIndex`](@ref) for fermions).
 
 ```math
-a^†_{c_1} a^†_{c_2} \\ldots a_{d_1} a_{d_2} \\ldots |\\mathrm{addr}\\rangle \\to
-α|\\mathrm{naddr}\\rangle
+a^†_{c_1} a^†_{c_2} … a_{d_1} a_{d_2} … |f⟩ → α|f'⟩
 ```
 
-Returns the new address `naddr` and the factor `α`. The value of `α` is given by the square
+Returns the new address `f'` and the factor `α`. The value of `α` is given by the square
 root of the product of mode occupations before destruction and after creation. If the
 excitation is illegal, returns an arbitrary address and the value `0.0`.
 
@@ -187,8 +186,14 @@ FermiFS{6,8}(1, 1, 0, 0, 1, 1, 1, 1)
 julia> i, j, k, l = find_mode(f, (3,4,2,5))
 (FermiFSIndex(occnum=0, mode=3, offset=2), FermiFSIndex(occnum=0, mode=4, offset=3), FermiFSIndex(occnum=1, mode=2, offset=1), FermiFSIndex(occnum=1, mode=5, offset=4))
 
-julia> excitation(f, (i,j), (k,l))
+julia> excitation(f, (i,j), (k,l)) # number conserving excitation
 (FermiFS{6,8}(1, 0, 1, 1, 0, 1, 1, 1), -1.0)
+
+julia> fm = FermiFS{missing}(1,1,0,0,1,1,1,1)
+FermiFS{missing,8}(1, 1, 0, 0, 1, 1, 1, 1)
+
+julia> excitation(fm, (i,), (k,l)) # particle number changes
+(FermiFS{missing,8}(1, 0, 1, 0, 0, 1, 1, 1), 1.0)
 ```
 
 See [`SingleComponentFockAddress`](@ref).
@@ -360,7 +365,7 @@ function parse_address(str)
     m = match(r"⊗", str)
     if !isnothing(m)
         if !isnothing(match(r"[↓⇅]", str))
-            throw(ArgumentError("invalid fock state format \"$str\""))
+            throw(ArgumentError("invalid Fock state format \"$str\""))
         else
             return CompositeFS(map(parse_address, split(str, r" *⊗ *"))...)
         end
@@ -368,9 +373,16 @@ function parse_address(str)
     # FermiFS2C
     m = match(r"[↓⇅]", str)
     if !isnothing(m)
+        m = match(r"\|([↑↓⇅⋅ ]+)⟩{}", str)
+        if !isnothing(m) # FermiFS2C with missing particle number
+            chars = filter(!=(' '), Vector{Char}(m.captures[1]))
+            f1 = FermiFS{missing}((chars .== '↑') .| (chars .== '⇅'))
+            f2 = FermiFS{missing}((chars .== '↓') .| (chars .== '⇅'))
+            return CompositeFS(f1, f2)
+        end
         m = match(r"\|([↑↓⇅⋅ ]+)⟩", str)
         if isnothing(m)
-            throw(ArgumentError("invalid fock state format \"$str\""))
+            throw(ArgumentError("invalid Fock state format \"$str\""))
         else
             chars = filter(!=(' '), Vector{Char}(m.captures[1]))
             f1 = FermiFS((chars .== '↑') .| (chars .== '⇅'))
@@ -431,11 +443,24 @@ function parse_address(str)
     if !isnothing(m)
         return BoseFS(parse.(Int, split(m.captures[1], r" +")))
     end
-    # Single HardcoreBoseFS
+
+    # HardcoreBoseFS with missing particle number
+    m = match(r"\|([ ∘●]+)⟩{}", str)
+    if !isnothing(m)
+        chars = filter(!=(' '), Vector{Char}(m.captures[1]))
+        return HardcoreBoseFS{missing}(chars .== '●')
+    end
+    # HardcoreBoseFS
     m = match(r"\|([ ∘●]+)⟩", str)
     if !isnothing(m)
         chars = filter(!=(' '), Vector{Char}(m.captures[1]))
         return HardcoreBoseFS(chars .== '●')
+    end
+    # Single FermiFS with missing particle number
+    m = match(r"\|([ ⋅↑]+)⟩{}", str)
+    if !isnothing(m)
+        chars = filter(!=(' '), Vector{Char}(m.captures[1]))
+        return FermiFS{missing}(chars .== '↑')
     end
     # Single FermiFS
     m = match(r"\|([ ⋅↑]+)⟩", str)
@@ -673,6 +698,7 @@ end
 
 Base.length(::FermiOccupiedModes{N}) where {N} = N
 Base.eltype(::FermiOccupiedModes) = FermiFSIndex
+Base.IteratorSize(::FermiOccupiedModes{missing}) = Base.SizeUnknown()
 
 """
     FermiUnoccupiedModes{N}
@@ -684,6 +710,7 @@ struct FermiUnoccupiedModes{N,S} <: ModeIterator
 end
 Base.length(::FermiUnoccupiedModes{N}) where {N} = N
 Base.eltype(::FermiUnoccupiedModes) = FermiFSIndex
+Base.IteratorSize(::FermiUnoccupiedModes{missing}) = Base.SizeUnknown()
 
 """
     from_fermi_onr(::Type{B}, onr) -> B

--- a/src/BitStringAddresses/hardcorebosefs.jl
+++ b/src/BitStringAddresses/hardcorebosefs.jl
@@ -4,7 +4,8 @@
 Address type that represents a Fock state of `N` hardcore bosons in `M` modes, with
 occupancies restricted to 0 or 1 per mode, by wrapping a [`BitString`](@ref) or a
 [`SortedParticleList`](@ref). Which is wrapped is chosen automatically based on the
-properties of the address.
+properties of the address. Set `N` to `missing` if the number of particles is not known at
+compile time.
 
 # Constructors
 
@@ -76,6 +77,11 @@ function HardcoreBoseFS{N,M,S}(onr::Union{SVector{M},MVector{M},NTuple{M}}) wher
 end
 function HardcoreBoseFS{N,M}(onr::Union{AbstractArray{<:Integer},NTuple{M,<:Integer}}) where {N,M}
     @boundscheck check_fermi_onr(onr, N, M)
+    if ismissing(N)
+        S = typeof(BitString{M}(0))
+        return HardcoreBoseFS{N,M,S}(from_fermi_onr(S, onr))
+    end
+
     spl_type = select_int_type(M)
     # Pick smaller address type, but prefer dense.
     # Alway pick dense if it fits into one chunk.
@@ -96,20 +102,32 @@ function HardcoreBoseFS(onr)
     N = sum(onr)
     return HardcoreBoseFS{N,M}(onr)
 end
+function HardcoreBoseFS{N}(onr) where {N}
+    onr = Tuple(onr)
+    M = length(onr)
+    return HardcoreBoseFS{N,M}(onr)
+end
+
 HardcoreBoseFS(vals::Integer...) = HardcoreBoseFS(vals) # list occupation numbers
 HardcoreBoseFS(val::Integer) = HardcoreBoseFS((val,)) # single mode
+HardcoreBoseFS{N}(vals::Integer...) where N = HardcoreBoseFS{N}(vals) # list occupation numbers
+HardcoreBoseFS{N}(val::Integer) where {N} = HardcoreBoseFS{N}((val,)) # single mode
 HardcoreBoseFS{N,M}(vals::Integer...) where {N,M} = HardcoreBoseFS{N,M}(vals)
 
 # Sparse constructors
 HardcoreBoseFS(M::Integer, pairs::Pair...) = HardcoreBoseFS(M, pairs)
+HardcoreBoseFS{N}(M::Integer, pairs::Pair...) where {N} = HardcoreBoseFS{N}(M, pairs)
 HardcoreBoseFS(M::Integer, pairs) = HardcoreBoseFS(sparse_to_onr(M, pairs))
-HardcoreBoseFS{N,M}(pairs::Vararg{Pair,N}) where {N,M} = HardcoreBoseFS{N,M}(pairs)
-HardcoreBoseFS{N,M}(pairs) where {N,M} = HardcoreBoseFS{N,M}(sparse_to_onr(M, pairs))
+HardcoreBoseFS{N}(M::Integer, pairs) where {N} = HardcoreBoseFS{N}(sparse_to_onr(M, pairs))
+HardcoreBoseFS{N,M}(pairs::Vararg{Pair}) where {N,M} = HardcoreBoseFS{N,M}(pairs)
+HardcoreBoseFS{N,M}(pairs) where {N,M} = HardcoreBoseFS{N}(sparse_to_onr(M, pairs))
 HardcoreBoseFS(pairs::Pair...) = throw(ArgumentError("number of modes must be provided"))
 
 function print_address(io::IO, f::HardcoreBoseFS{N,M}; compact=false) where {N,M}
     if compact && f.bs isa SortedParticleList
         print(io, "|h ", M, ": ", join(Int.(f.bs.storage), ' '), "⟩")
+    elseif compact && ismissing(N)
+        print(io, "|", join(map(o -> o == 0 ? '∘' : '●', onr(f))), "⟩{}")
     elseif compact
         print(io, "|", join(map(o -> o == 0 ? '∘' : '●', onr(f))), "⟩")
     elseif f.bs isa SortedParticleList
@@ -119,13 +137,12 @@ function print_address(io::IO, f::HardcoreBoseFS{N,M}; compact=false) where {N,M
     end
 end
 
-function near_uniform(::Type{HardcoreBoseFS{N,M}}) where {N,M}
-    return HardcoreBoseFS([fill(1, N); fill(0, M - N)])
-end
-
-function excitation(a::HardcoreBoseFS{N,M,S}, creations, destructions) where {N,M,S}
+function excitation(
+    a::HardcoreBoseFS{N,M,S}, creations::NTuple{NC}, destructions::NTuple{ND}
+) where {N,M,S,NC,ND}
     new_bs, value = fermi_excitation(a.bs, creations, destructions)
-    return HardcoreBoseFS{N,M,S}(new_bs), abs(value) # different from FermiFS, no sign
+    NN = ismissing(N) ? missing : N + NC - ND # done at compile time
+    return HardcoreBoseFS{NN,M,S}(new_bs), abs(value) # different from FermiFS, no sign
 end
 
 # See "fermifs.jl" for other function definitions for HardcoreBoseFS.

--- a/src/BitStringAddresses/hardcorebosefs.jl
+++ b/src/BitStringAddresses/hardcorebosefs.jl
@@ -140,9 +140,11 @@ end
 function excitation(
     a::HardcoreBoseFS{N,M,S}, creations::NTuple{NC}, destructions::NTuple{ND}
 ) where {N,M,S,NC,ND}
+    if NC != ND && !ismissing(N)
+        throw(ArgumentError("number of creations and destructions must be equal, got $NC and $ND"))
+    end
     new_bs, value = fermi_excitation(a.bs, creations, destructions)
-    NN = ismissing(N) ? missing : N + NC - ND # done at compile time
-    return HardcoreBoseFS{NN,M,S}(new_bs), abs(value) # different from FermiFS, no sign
+    return HardcoreBoseFS{N,M,S}(new_bs), abs(value) # different from FermiFS, no sign
 end
 
 # See "fermifs.jl" for other function definitions for HardcoreBoseFS.

--- a/src/BitStringAddresses/hardcorebosefs.jl
+++ b/src/BitStringAddresses/hardcorebosefs.jl
@@ -5,7 +5,7 @@ Address type that represents a Fock state of `N` hardcore bosons in `M` modes, w
 occupancies restricted to 0 or 1 per mode, by wrapping a [`BitString`](@ref) or a
 [`SortedParticleList`](@ref). Which is wrapped is chosen automatically based on the
 properties of the address. Set `N` to `missing` if the number of particles is not known at
-compile time.
+compile time and can be changed by excitations.
 
 # Constructors
 
@@ -33,7 +33,7 @@ See the examples below.
 # Examples
 
 ```jldoctest
-julia> HardcoreBoseFS{3,5}(1, 1, 1, 0, 0)
+julia> HardcoreBoseFS(1, 1, 1, 0, 0)
 HardcoreBoseFS{3,5}(1, 1, 1, 0, 0)
 
 julia> HardcoreBoseFS([abs(i - 2) ≤ 1 for i in 1:5])
@@ -47,6 +47,9 @@ HardcoreBoseFS{3,5}(1, 1, 1, 0, 0)
 
 julia> fs"|●●●∘∘⟩" # \\mdlgblkcircle(tab) -> ●, \\circ(tab) -> ∘, \\rangle(tab) -> ⟩
 HardcoreBoseFS{3,5}(1, 1, 1, 0, 0)
+
+julia> HardcoreBoseFS{missing}(1, 1, 1, 0, 0) == fs"|●●●∘∘⟩{}" # missing particle number
+true
 
 julia> fs"|h 5: 1 2 3⟩"
 HardcoreBoseFS{3,5}(1, 1, 1, 0, 0)

--- a/src/BitStringAddresses/multicomponent.jl
+++ b/src/BitStringAddresses/multicomponent.jl
@@ -20,13 +20,20 @@ end
 
 # Slow constructor - not to be used internallly
 function CompositeFS(adds::Vararg{SingleComponentFockAddress})
-    N = sum(a -> num_particles(typeof(a)), adds)
+    if any(a -> num_particles(typeof(a)) === Missing, adds)
+        N = Missing
+    else
+        N = sum(a -> num_particles(typeof(a)), adds)
+    end
     M1, M2 = extrema(num_modes, adds)
     if M1 ≠ M2
         throw(ArgumentError("all addresses must have the same number of modes"))
     end
     return CompositeFS{length(adds),N,M1,typeof(adds)}(adds)
 end
+function Interfaces.num_particles(cfs::CompositeFS{<:Any,missing})
+    sum(num_particles, cfs.components)
+end # only required for missing, as the fallback for others is defined in the abstract type
 
 Interfaces.num_components(::Type{<:CompositeFS{C}}) where {C} = C
 Base.hash(c::CompositeFS, u::UInt) = hash(c.components, u)

--- a/src/BitStringAddresses/multicomponent.jl
+++ b/src/BitStringAddresses/multicomponent.jl
@@ -20,11 +20,7 @@ end
 
 # Slow constructor - not to be used internallly
 function CompositeFS(adds::Vararg{SingleComponentFockAddress})
-    if any(a -> num_particles(typeof(a)) === Missing, adds)
-        N = Missing
-    else
-        N = sum(a -> num_particles(typeof(a)), adds)
-    end
+    N = sum(a -> num_particles(typeof(a)), adds)
     M1, M2 = extrema(num_modes, adds)
     if M1 ≠ M2
         throw(ArgumentError("all addresses must have the same number of modes"))
@@ -93,12 +89,17 @@ end
 """
     FermiFS2C <: AbstractFockAddress
     FermiFS2C(onr_a, onr_b)
+    FermiFS2C{missing}(onr_a, onr_b)
 
 Fock state address with two fermionic (spin) components. Alias for [`CompositeFS`](@ref)
-with two [`FermiFS`](@ref) components. Construct by specifying either two compatible
-[`FermiFS`](@ref)s, two [`onr`](@ref)s, or the number of modes followed by `mode =>
-occupation_number` pairs, where `occupation_number=1` will put a particle in the first
-component and `occupation_number=-1` will put a particle in the second component.
+with two [`FermiFS`](@ref) components. If the type parameter `missing` is specified, the
+number of particles is not known at compile time. This is useful for spinful fermionic
+systems where the number of particles in each spin channel may vary.
+
+Construct by specifying either two compatible [`FermiFS`](@ref)s, two [`onr`](@ref)s, or
+the number of modes followed by `mode => occupation_number` pairs, where
+`occupation_number = 1` will put a particle in the first
+component and `occupation_number = -1` will put a particle in the second component.
 See examples below.
 
 # Examples
@@ -116,16 +117,28 @@ CompositeFS(
   FermiFS{2,3}(0, 1, 1),
 )
 
-julia> FermiFS2C(3, 1 => 1, 2 => -1, 3 => -1)
+julia> FermiFS2C{missing}((1,0,0), (0,1,1)) # number non-conserving, spin flips allowed
 CompositeFS(
-  FermiFS{1,3}(1, 0, 0),
-  FermiFS{2,3}(0, 1, 1),
+  FermiFS{missing,3}(1, 0, 0),
+  FermiFS{missing,3}(0, 1, 1),
+)
+
+julia> FermiFS2C{missing}(3, 1 => 1, 2 => -1, 3 => -1)
+CompositeFS(
+  FermiFS{missing,3}(1, 0, 0),
+  FermiFS{missing,3}(0, 1, 1),
 )
 
 julia> fs"|↑↓↓⟩" # \\uparrow(tab) -> ↑, \\downarrow(tab) -> ↓, \\rangle(tab) -> ⟩
 CompositeFS(
   FermiFS{1,3}(1, 0, 0),
   FermiFS{2,3}(0, 1, 1),
+)
+
+julia> fs"|↑↓↓⇅⟩{}" # \\dblarrowupdown(tab) -> ⇅
+CompositeFS(
+  FermiFS{missing,4}(1, 0, 0, 1),
+  FermiFS{missing,4}(0, 1, 1, 1),
 )
 ```
 
@@ -136,11 +149,18 @@ const FermiFS2C{N1,N2,M,N,F1,F2} =
 
 FermiFS2C(f1::FermiFS{<:Any,M}, f2::FermiFS{<:Any,M}) where {M} = CompositeFS(f1, f2)
 FermiFS2C(onr_a, onr_b) = FermiFS2C(FermiFS(onr_a), FermiFS(onr_b))
+FermiFS2C{missing}(onr_a, onr_b) = FermiFS2C(FermiFS{missing}(onr_a), FermiFS{missing}(onr_b))
 FermiFS2C(M::Integer, pairs::Pair...) = FermiFS2C(M, pairs)
+FermiFS2C{missing}(M::Integer, pairs::Pair...) = FermiFS2C{missing}(M, pairs)
 function FermiFS2C(M::Integer, pairs)
     up_pairs = filter(p -> p[2] > 0, pairs)
     down_pairs = map(p -> p[1] => -p[2], filter(p -> p[2] < 0, pairs))
     return FermiFS2C(FermiFS(M, up_pairs), FermiFS(M, down_pairs))
+end
+function FermiFS2C{missing}(M::Integer, pairs)
+    up_pairs = filter(p -> p[2] > 0, pairs)
+    down_pairs = map(p -> p[1] => -p[2], filter(p -> p[2] < 0, pairs))
+    return FermiFS2C(FermiFS{missing}(M, up_pairs), FermiFS{missing}(M, down_pairs))
 end
 
 function print_address(io::IO, f::FermiFS2C; compact=false)
@@ -149,7 +169,11 @@ function print_address(io::IO, f::FermiFS2C; compact=false)
         str = join(
             [i && j ? '⇅' : i ? '↑' : j ? '↓' : '⋅' for (i, j) in zip(Bool.(o1), Bool.(o2))]
         )
-        print(io, "|", str, "⟩")
+        if ismissing(num_particles(typeof(f)))
+            print(io, "|", str, "⟩{}")
+        else
+            print(io, "|", str, "⟩")
+        end
     else
         # Show as normal CompositeFS
         invoke(print_address, Tuple{typeof(io),CompositeFS}, io, f)

--- a/src/BitStringAddresses/occupationnumberfs.jl
+++ b/src/BitStringAddresses/occupationnumberfs.jl
@@ -172,32 +172,6 @@ See also: [`destroy`](@ref), [`excitation`](@ref).
     return (ofs, val)
 end
 
-"""
-    excitation(addr::OccupationNumberFS, c::NTuple, d::NTuple)
-    → (nadd, α)
-Generate an excitation on an [`OccupationNumberFS`](@ref) by applying the creation and
-destruction operators specified by the tuples of mode numbers `c` and `d` to the Fock state
-`addr`. The modes are indexed by integers (starting at 1), or by indices of type
-`BoseFSIndex`. The value of `α` is given by the square root of the product of mode
-occupations before destruction and after creation.
-
-The number of particles may change by this type of excitation.
-
-# Example
-```jl_doctest
-julia> s = fs"|1 2 3⟩{8}"
-OccupationNumberFS{3, UInt8}(1, 2, 3)
-
-julia> num_particles(s)
-6
-
-julia> es, α = excitation(s, (1,1), (3,))
-(OccupationNumberFS{3, UInt8}(3, 2, 2), 4.242640687119285)
-
-julia> num_particles(es)
-7
-```
-"""
 function excitation(
     fs::OccupationNumberFS{<:Any,T},
     c::NTuple{<:Any,Int},

--- a/src/ExactDiagonalization/ExactDiagonalization.jl
+++ b/src/ExactDiagonalization/ExactDiagonalization.jl
@@ -32,9 +32,10 @@ import Folds
 using Rimu: Rimu, DictVectors, Hamiltonians, Interfaces, BitStringAddresses, replace_keys,
     clean_and_warn_if_others_present, split_keys
 using ..Interfaces: AbstractDVec, AbstractHamiltonian, AbstractOperator, AdjointUnknown,
-    diagonal_element, offdiagonals, starting_address, LOStructure, IsHermitian, operator_column
-using ..BitStringAddresses: AbstractFockAddress, BoseFS, FermiFS, CompositeFS,
-    OccupationNumberFS, near_uniform
+    diagonal_element, offdiagonals, starting_address, LOStructure, IsHermitian,
+    operator_column
+using ..BitStringAddresses: AbstractFockAddress, BoseFS, FermiFS, HardcoreBoseFS,
+    CompositeFS, OccupationNumberFS, near_uniform, BitString
 using ..DictVectors: FrozenDVec, PDVec, DVec
 using ..Hamiltonians: allows_address_type, check_address_type, dimension,
     ParitySymmetry, TimeReversalSymmetry, AbstractOperator
@@ -47,6 +48,7 @@ export LinearMap
 
 export sparse # from SparseArrays
 
+const FermiOrHardcoreBoseFS{N,M,S} = Union{FermiFS{N,M,S},HardcoreBoseFS{N,M,S}}
 
 include("basis_breadth_first_search.jl")
 include("basis_fock.jl")

--- a/src/ExactDiagonalization/basis_fock.jl
+++ b/src/ExactDiagonalization/basis_fock.jl
@@ -90,15 +90,15 @@ end
 end
 
 ###
-### FermiFS
+### FermiFS or HardcoreBoseFS
 ###
 # The algorithm is similar to the BoseFS one.
 
 # this is equivalent to `dimension(FermiFS{n,m})`, but does not return a `BigInt`.
 _fermi_dimension(n, m) = binomial(m, n)
 
-function build_basis(::Type{<:FermiFS{N,M}}) where {N,M}
-    T = typeof(near_uniform(FermiFS{N,M}))
+function build_basis(::Type{AT}) where {N, M, AT<:FermiOrHardcoreBoseFS{N,M}}
+    T = typeof(near_uniform(AT))
     result = Vector{T}(undef, _fermi_dimension(N, M))
     _fermi_basis!(result, (), 1, N, Val(M), 2 * Threads.nthreads())
     return result
@@ -141,6 +141,15 @@ end
         _fermi_basis!(result, (1, postfix...), index, remaining_n - 1, Val(M - 1))
     end
     return nothing
+end
+
+###
+### FermiFS or HardcoreBoseFS with missing N
+###
+function build_basis(::Type{AT}) where {M, AT<:FermiOrHardcoreBoseFS{missing,M}}
+    M > 63 && throw(ArgumentError("Cannot build basis for type $AT with M=$M > 63"))
+    T = typeof(near_uniform(AT, 0, M))
+    return [T(BitString{M}(i)) for i in 0 : (UInt(1) << M) - 1]
 end
 
 ###

--- a/src/Hamiltonians/Hamiltonians.jl
+++ b/src/Hamiltonians/Hamiltonians.jl
@@ -113,6 +113,8 @@ if VERSION < v"1.10"
     end
 end
 
+const FermiOrHardcoreBoseFS{N,M,S} = Union{FermiFS{N,M,S},HardcoreBoseFS{N,M,S}}
+
 include("abstract.jl")
 include("offdiagonals.jl")
 include("geometry.jl")

--- a/src/Hamiltonians/abstract.jl
+++ b/src/Hamiltonians/abstract.jl
@@ -77,11 +77,11 @@ function dimension(::Type{<:OccupationNumberFS{M,T}}) where {M,T}
     n = typemax(T)
     return BigInt(n + 1)^BigInt(M)
 end
-function dimension(::Type{<:FermiFS{N,M}}) where {N,M}
+function dimension(::Type{<:FermiOrHardcoreBoseFS{N,M}}) where {N,M}
     return number_conserving_fermi_dimension(N, M)
 end
-function dimension(::Type{<:HardcoreBoseFS{N,M}}) where {N,M}
-    return number_conserving_fermi_dimension(N, M)
+function dimension(::Type{<:FermiOrHardcoreBoseFS{missing,M}}) where {M}
+    return BigInt(2)^BigInt(M)
 end
 function dimension(::Type{<:CompositeFS{<:Any,<:Any,<:Any,T}}) where {T}
     return prod(dimension, T.parameters)

--- a/test/BitStringAddresses.jl
+++ b/test/BitStringAddresses.jl
@@ -319,6 +319,10 @@ end
         @test FermiFS(1) == fs"|↑⟩" # single occupation number
         @test_throws ArgumentError FermiFS(2)
         @test FermiFS(5, 1 => 0) == fs"|⋅⋅⋅⋅⋅⟩" # vacuum with 5 modes
+        @test FermiFS{missing}(t...) == FermiFS{missing}(t) # pass occupation numbers or tuple
+        @test FermiFS{missing}(1) == fs"|↑⟩{}" # single occupation number
+        @test_throws ArgumentError FermiFS{2}(1)
+        @test FermiFS{missing}(5, 1 => 0) == fs"|⋅⋅⋅⋅⋅⟩{}" # vacuum with 5 modes
     end
 
     small = SVector(1, 0, 0, 0, 0, 1, 1, 1, 0, 0)
@@ -330,8 +334,10 @@ end
     @testset "onr, constructors" begin
         for o in (small, big, giant, giant_sparse, giant_dense)
             f = FermiFS(o)
-            @test onr(f) == o
+            fm = FermiFS{missing}(o)
+            @test onr(f) == o == onr(fm)
             @test typeof(f)(onr(f)) == f
+            @test typeof(fm)(onr(fm)) == fm
         end
 
         @test FermiFS(small).bs isa BitString
@@ -339,12 +345,23 @@ end
         @test FermiFS(giant_sparse).bs isa SortedParticleList
         @test FermiFS(giant_dense).bs isa BitString
 
+        @test FermiFS{missing}(small).bs isa BitString
+        @test FermiFS{missing}(big).bs isa BitString
+        @test FermiFS{missing}(giant_sparse).bs isa BitString
+        @test FermiFS{missing}(giant_dense).bs isa BitString
+
         sp_10 = FermiFS(10, 1 => 1, 5 => 1)
         @test num_modes(sp_10) == 10
         @test num_particles(sp_10) == 2
+        sp_15 = FermiFS{missing}(15, 1 => 1, 5 => 1)
+        @test num_modes(sp_15) == 15
+        @test num_particles(sp_15) == 2
         sp_20 = FermiFS{4,20}(1 => 1, 3 => 1, 5 => 1, 7 => 1)
         @test num_modes(sp_20) == 20
         @test num_particles(sp_20) == 4
+        sp_30 = FermiFS{missing,30}(1 => 1, 3 => 1, 5 => 1, 7 => 1)
+        @test num_modes(sp_30) == 30
+        @test num_particles(sp_30) == 4
 
         @test_throws ArgumentError FermiFS(3, 4 => 1)
         @test_throws ArgumentError FermiFS(3, 2 => -1)
@@ -359,6 +376,10 @@ end
             sites = collect(occupied_modes(f))
             @test occupied_mode_map(f) == sites
             @test getproperty.(sites, :mode) == findall(≠(0), onr(f))
+            fm = FermiFS{missing}(o)
+            sites = collect(occupied_modes(fm))
+            @test occupied_mode_map(fm) == sites
+            @test getproperty.(sites, :mode) == findall(≠(0), onr(fm))
         end
     end
     @testset "unoccupied_modes" begin
@@ -367,6 +388,10 @@ end
             sites = collect(unoccupied_modes(f))
             @test unoccupied_mode_map(f) == sites
             @test getproperty.(sites, :mode) == findall(==(0), onr(f))
+            fm = FermiFS{missing}(o)
+            sites = collect(unoccupied_modes(fm))
+            @test unoccupied_mode_map(fm) == sites
+            @test getproperty.(sites, :mode) == findall(==(0), onr(fm))
         end
     end
     @testset "each_mode" begin
@@ -374,6 +399,9 @@ end
             f = FermiFS(o)
             @test map(i -> i.occnum, each_mode(f)) == o
             @test map(i -> i.mode, each_mode(f)) == eachindex(o)
+            fm = FermiFS{missing}(o)
+            @test map(i -> i.occnum, each_mode(fm)) == o
+            @test map(i -> i.mode, each_mode(fm)) == eachindex(o)
         end
     end
     @testset "Randomized Tests" begin
@@ -385,22 +413,33 @@ end
                 for _ in 1:10
                     input = rand_onr_fermi(N, M)
                     fermi = FermiFS(input)
+                    mfermi = FermiFS{missing}(input)
                     @test FermiFS{N,M,typeof(fermi.bs)}(fermi.bs) === fermi
+                    @test FermiFS{missing,M,typeof(mfermi.bs)}(mfermi.bs) === mfermi
 
-                    @test num_particles(fermi) == N
-                    @test num_modes(fermi) == M
-                    @test onr(fermi) == input
+                    @test num_particles(fermi) == N == num_particles(mfermi)
+                    @test num_modes(fermi) == M == num_modes(mfermi)
+                    @test onr(fermi) == input == onr(mfermi)
 
                     check_single_excitations(fermi, 64)
                     check_double_excitations(fermi, 8)
                     check_triple_excitations(fermi, 4)
+
+                    check_single_excitations(mfermi, 64)
+                    check_double_excitations(mfermi, 8)
+                    check_triple_excitations(mfermi, 4)
 
                     @test map(i -> i.mode, occupied_modes(fermi)) == findall(≠(0), input)
                     @test map(i -> i.mode, unoccupied_modes(fermi)) == findall(==(0), input)
                     @test map(i -> i.occnum, each_mode(fermi)) == input
                     @test map(i -> i.mode, each_mode(fermi)) == eachindex(input)
 
-                    @test onr(reverse(fermi)) == reverse(input)
+                    @test map(i -> i.mode, occupied_modes(mfermi)) == findall(≠(0), input)
+                    @test map(i -> i.mode, unoccupied_modes(mfermi)) == findall(==(0), input)
+                    @test map(i -> i.occnum, each_mode(mfermi)) == input
+                    @test map(i -> i.mode, each_mode(mfermi)) == eachindex(input)
+
+                    @test onr(reverse(fermi)) == reverse(input) == onr(reverse(mfermi))
 
                     # Check that the result of show can be pasted into the REPL
                     @test eval(Meta.parse(repr(fermi))) == fermi
@@ -408,9 +447,9 @@ end
                     @test parse_address(sprint(show, fermi; context=:compact => true)) == fermi
 
                     # Check that the result of show can be pasted into the REPL
-                    @test eval(Meta.parse(repr(fermi))) == fermi
+                    @test eval(Meta.parse(repr(mfermi))) == mfermi
                     # Check that compact string can be parsed.
-                    @test parse_address(sprint(show, fermi; context=:compact => true)) == fermi
+                    @test parse_address(sprint(show, mfermi; context=:compact => true)) == mfermi
                 end
             end
         end
@@ -420,34 +459,34 @@ end
 @testset "Multicomponent" begin
     @testset "CompositeFS" begin
         fs1 = CompositeFS(
-            FermiFS((1,1,0,0,0,0)), FermiFS((1,1,1,0,0,0)), BoseFS((5,0,0,0,0,0))
+            FermiFS((1,1,0,0,0,0)), FermiFS{missing}((1,1,1,0,0,0)), BoseFS((5,0,0,0,0,0))
         )
         @test num_modes(fs1) == 6
         @test num_components(fs1) == 3
         @test num_particles(fs1) == 10
         @test fs1.components[1] == FermiFS((1,1,0,0,0,0))
-        @test fs1.components[2] == FermiFS((1,1,1,0,0,0))
+        @test fs1.components[2] == FermiFS{missing}((1,1,1,0,0,0))
         @test fs1.components[3] == BoseFS((5,0,0,0,0,0))
         @test eval(Meta.parse(repr(fs1))) == fs1
         str = sprint(show, fs1; context=:compact => true)
         @test parse_address(str) == fs1
 
         fs2 = CompositeFS(
-            FermiFS((0,1,1,0,0,0)), FermiFS((1,0,1,0,1,0)), BoseFS((1,1,1,1,1,0))
+            FermiFS((0,1,1,0,0,0)), FermiFS{missing}((1,0,1,0,1,0)), BoseFS((1,1,1,1,1,0))
         )
         @test fs1 < fs2
 
         @test_throws ArgumentError CompositeFS(BoseFS((1,1)), BoseFS((1,1,1)))
 
         @inferred update_component(fs1, FermiFS((0,0,0,1,1,0)), Val(1))
-        @inferred update_component(fs1, FermiFS((0,0,1,1,1,0)), Val(2))
+        @inferred update_component(fs1, FermiFS{missing}((0,0,1,1,1,0)), Val(2))
         @inferred update_component(fs1, BoseFS((1,1,1,1,1,0)), Val(3))
         @test_throws MethodError update_component(fs1, BoseFS((1,1,1,1,1,0)), Val(1))
         @test_throws MethodError update_component(fs1, FermiFS((1,1,1,1,1,0)), Val(1))
 
-        fs3 = Rimu.BitStringAddresses.update_component(fs1, FermiFS((0,0,1,1,1,0)), Val(2))
+        fs3 = update_component(fs1, FermiFS{missing}((0,0,1,1,1,0)), Val(2))
         @test fs3 == CompositeFS(
-            FermiFS((1,1,0,0,0,0)), FermiFS((0,0,1,1,1,0)), BoseFS((5,0,0,0,0,0)),
+            FermiFS((1,1,0,0,0,0)), FermiFS{missing}((0,0,1,1,1,0)), BoseFS((5,0,0,0,0,0)),
         )
         @test onr(fs3) == ([1,1,0,0,0,0], [0,0,1,1,1,0], [5,0,0,0,0,0])
         @test onr(fs3, LadderBoundaries(2, 3)) == (
@@ -609,26 +648,36 @@ end
 
 @testset "HardcoreBoseFS" begin
     add_hb = HardcoreBoseFS(1, 0, 1, 0, 0)
+    add_hb_m = HardcoreBoseFS{missing}(1, 0, 1, 0, 0)
     @test add_hb isa Rimu.BitStringAddresses.SingleComponentFockAddress
 
     add_f = FermiFS(1, 0, 1, 0, 0)
+    add_f_m = FermiFS{missing}(1, 0, 1, 0, 0)
 
-    @test bitstring(add_f) == bitstring(add_hb)
-    @test find_mode(add_hb, 1) == find_mode(add_f, 1)
+    @test bitstring(add_f) == bitstring(add_hb) == bitstring(add_f_m) == bitstring(add_hb_m)
+    @test find_mode(add_hb, 1) == find_mode(add_f, 1) == find_mode(add_hb_m, 1)
 
     src = find_mode(add_hb, 1)
     dst = find_mode(add_hb, 4)
+    @test src == find_mode(add_hb_m, 1) == find_mode(add_f, 1) == find_mode(add_f_m, 1)
     @test src == FermiFSIndex(occnum=1, mode=1, offset=0)
 
     n_add_f, val_f = excitation(add_f, (dst,), (src,))
     n_add_hb, val_hb = excitation(add_hb, (dst,), (src,))
-    
+
     @test n_add_hb isa HardcoreBoseFS
     @test bitstring(n_add_f) == bitstring(n_add_hb)
     @test val_f == -val_hb
 
+    n_add_f_m, val_f_m = excitation(add_f_m, (), (src,))
+    n_add_hb_m, val_hb_m = excitation(add_hb_m, (), (src,))
+    @test bitstring(n_add_f_m) == bitstring(n_add_hb_m)
+    @test val_f_m == val_hb_m
+    @test num_particles(n_add_hb_m) == num_particles(add_hb_m) - 1 == num_particles(n_add_f_m)
+
     @test dimension(n_add_f) == dimension(n_add_hb)
     @test near_uniform(HardcoreBoseFS{2,5}) == HardcoreBoseFS{2,5}(1, 1, 0, 0, 0)
+    @test near_uniform(HardcoreBoseFS{missing}, 2, 5) == HardcoreBoseFS{missing,5}(1, 1, 0, 0, 0)
 
     S = typeof(BitString{6}(big"0x07")) # corresponds to the occupation pattern (1, 1, 1, 0, 0, 0)
     @test_throws ArgumentError HardcoreBoseFS{2,5,S}(onr(add_hb))
@@ -636,8 +685,8 @@ end
     @test_throws ArgumentError HardcoreBoseFS{2,5,S}(onr(add_hb))
     S = typeof(BitString{5}(big"0x05")) # corresponds to the occupation pattern (1, 0, 1, 0, 0)
     @test HardcoreBoseFS{2,5,S}(onr(add_hb)) == HardcoreBoseFS{2,5}(1 => 1, 3 => 1)
-    @test_throws ArgumentError HardcoreBoseFS(1 => 1, 3 => 1)    
-    
+    @test_throws ArgumentError HardcoreBoseFS(1 => 1, 3 => 1)
+
     @testset "Randomized Tests" begin
         function rand_onr_fermi(N, M)
             return SVector{M}(shuffle([ones(Int,N); zeros(Int,M - N)]))
@@ -647,22 +696,34 @@ end
                 for _ in 1:10
                     input = rand_onr_fermi(N, M)
                     hcbose = HardcoreBoseFS(input)
+                    hcbosem = HardcoreBoseFS{missing}(input)
                     @test HardcoreBoseFS{N,M,typeof(hcbose.bs)}(hcbose.bs) === hcbose
+                    @test HardcoreBoseFS{missing,M,typeof(hcbosem.bs)}(hcbosem.bs) === hcbosem
 
-                    @test num_particles(hcbose) == N
-                    @test num_modes(hcbose) == M
-                    @test onr(hcbose) == input
+                    @test num_particles(hcbose) == N == num_particles(hcbosem)
+                    @test num_modes(hcbose) == M == num_modes(hcbosem)
+                    @test onr(hcbose) == input == onr(hcbosem)
 
                     check_single_excitations(hcbose, 64)
                     check_double_excitations(hcbose, 8)
                     check_triple_excitations(hcbose, 4)
+
+                    check_single_excitations(hcbosem, 64)
+                    check_double_excitations(hcbosem, 8)
+                    check_triple_excitations(hcbosem, 4)
 
                     @test map(i -> i.mode, occupied_modes(hcbose)) == findall(≠(0), input)
                     @test map(i -> i.mode, unoccupied_modes(hcbose)) == findall(==(0), input)
                     @test map(i -> i.occnum, each_mode(hcbose)) == input
                     @test map(i -> i.mode, each_mode(hcbose)) == eachindex(input)
 
+                    @test map(i -> i.mode, occupied_modes(hcbosem)) == findall(≠(0), input)
+                    @test map(i -> i.mode, unoccupied_modes(hcbosem)) == findall(==(0), input)
+                    @test map(i -> i.occnum, each_mode(hcbosem)) == input
+                    @test map(i -> i.mode, each_mode(hcbosem)) == eachindex(input)
+
                     @test onr(reverse(hcbose)) == reverse(input)
+                    @test onr(reverse(hcbosem)) == reverse(input)
 
                     # Check that the result of show can be pasted into the REPL
                     @test eval(Meta.parse(repr(hcbose))) == hcbose
@@ -670,9 +731,9 @@ end
                     @test parse_address(sprint(show, hcbose; context=:compact => true)) == hcbose
 
                     # Check that the result of show can be pasted into the REPL
-                    @test eval(Meta.parse(repr(hcbose))) == hcbose
+                    @test eval(Meta.parse(repr(hcbosem))) == hcbosem
                     # Check that compact string can be parsed.
-                    @test parse_address(sprint(show, hcbose; context=:compact => true)) == hcbose
+                    @test parse_address(sprint(show, hcbosem; context=:compact => true)) == hcbosem
                 end
             end
         end
@@ -683,7 +744,9 @@ end
         @test HardcoreBoseFS(1) == fs"|●⟩" # single occupation number
         @test_throws ArgumentError HardcoreBoseFS(2)
         @test HardcoreBoseFS(5, 1 => 0) == fs"|∘∘∘∘∘⟩" # vacuum with 5 modes
+        @test HardcoreBoseFS{missing}(t...) == HardcoreBoseFS{missing}(t) # pass occupation numbers or tuple
+        @test HardcoreBoseFS{missing}(1) == fs"|●⟩{}" # single occupation number
+        @test_throws ArgumentError HardcoreBoseFS{missing}(2)
+        @test HardcoreBoseFS{missing}(5, 1 => 0) == fs"|∘∘∘∘∘⟩{}" # vacuum with 5 modes
     end
 end
-   
-    

--- a/test/BitStringAddresses.jl
+++ b/test/BitStringAddresses.jl
@@ -698,6 +698,10 @@ end
     @test HardcoreBoseFS{2,5,S}(onr(add_hb)) == HardcoreBoseFS{2,5}(1 => 1, 3 => 1)
     @test_throws ArgumentError HardcoreBoseFS(1 => 1, 3 => 1)
 
+    @test HardcoreBoseFS{missing}(1, 0, 1) == HardcoreBoseFS(1, 0, 1)
+    @test HardcoreBoseFS(1, 0, 1) != FermiFS(1, 0, 1)
+    @test HardcoreBoseFS(1, 0, 1).bs == FermiFS(1, 0, 1).bs
+
     @testset "Randomized Tests" begin
         function rand_onr_fermi(N, M)
             return SVector{M}(shuffle([ones(Int,N); zeros(Int,M - N)]))

--- a/test/BitStringAddresses.jl
+++ b/test/BitStringAddresses.jl
@@ -785,4 +785,14 @@ end
     @test ismissing(num_particles(typeof(fs)))
     @test length(occupied_modes(fs)) == num_particles(fs) == 4
     @test length(unoccupied_modes(fs)) == num_modes(fs) - num_particles(fs) == 2
+
+    f = FermiFS(1, 1, 0, 0, 1, 1, 1, 1)
+    i, j, k, l = find_mode(f, (3, 4, 2, 5))
+    @test_throws ArgumentError excitation(f, (i,), (k, l)) # number non-conserving excitation
+    h = HardcoreBoseFS(1, 1, 0, 0, 1, 1, 1, 1)
+    i, j, k, l = find_mode(h, (3, 4, 2, 5))
+    @test_throws ArgumentError excitation(h, (i,), (k, l)) # number non-conserving excitation
+    b = BoseFS(1, 1, 0, 0, 1, 1, 1, 1)
+    i, j, k, l = find_mode(b, (3, 4, 2, 5))
+    @test_throws ArgumentError excitation(b, (i,), (k, l)) # number non-conserving excitation
 end

--- a/test/BitStringAddresses.jl
+++ b/test/BitStringAddresses.jl
@@ -461,9 +461,10 @@ end
         fs1 = CompositeFS(
             FermiFS((1,1,0,0,0,0)), FermiFS{missing}((1,1,1,0,0,0)), BoseFS((5,0,0,0,0,0))
         )
+        @test num_particles(typeof(fs1)) === missing
+        @test num_particles(fs1) == 10
         @test num_modes(fs1) == 6
         @test num_components(fs1) == 3
-        @test num_particles(fs1) == 10
         @test fs1.components[1] == FermiFS((1,1,0,0,0,0))
         @test fs1.components[2] == FermiFS{missing}((1,1,1,0,0,0))
         @test fs1.components[3] == BoseFS((5,0,0,0,0,0))
@@ -500,6 +501,16 @@ end
         @test fs"|↑⋅⇅⋅↓⟩" == CompositeFS(FermiFS((1,0,1,0,0)), FermiFS((0,0,1,0,1)))
         @test fs"|↑⋅⟩ ⊗ |0 2⟩ ⊗ |b 2: 1 1⟩ ⊗ |f 2: 1 2⟩" == CompositeFS(
             FermiFS((1, 0)), BoseFS((0, 2)), BoseFS((2, 0)), FermiFS((1, 1))
+        )
+
+        fermim = FermiFS2C{missing}((0, 0, 1, 1, 0, 0), (0, 1, 0, 0, 1, 0))
+        @test parse_address(sprint(show, fermim; context=:compact => true)) == fermim
+
+        @test fs"|↑⋅⇅⋅↓⟩{}" == CompositeFS(FermiFS{missing}((1, 0, 1, 0, 0)),
+                FermiFS{missing}((0, 0, 1, 0, 1))
+        )
+        @test fs"|↑⋅⟩{} ⊗ |0 2⟩ ⊗ |b 2: 1 1⟩ ⊗ |f 2: 1 2⟩{}" == CompositeFS(
+            FermiFS{missing}((1, 0)), BoseFS((0, 2)), BoseFS((2, 0)), FermiFS{missing}((1, 1))
         )
         @test_throws ArgumentError parse_address("|2 3⟩ ⊗ |↓↑⟩")
         @test_throws ArgumentError parse_address("|⋅↓⟩ ⊗ |2 3⟩")
@@ -749,4 +760,25 @@ end
         @test_throws ArgumentError HardcoreBoseFS{missing}(2)
         @test HardcoreBoseFS{missing}(5, 1 => 0) == fs"|∘∘∘∘∘⟩{}" # vacuum with 5 modes
     end
+end
+
+@testset "missing particle number" begin
+    @test_throws ArgumentError parse_address("|2 3⟩{x}")
+    @test_throws ArgumentError parse_address("|⋅↑⟩{3}")
+    @test_throws ArgumentError parse_address("|●∘⟩{8}")
+    @test_throws ArgumentError parse_address("|↓↑⟩{3}")
+    @test_throws ArgumentError parse_address("|b 2: 1 2⟩{7}")
+    @test fs"|b 2: 1 2⟩{}" == OccupationNumberFS(1,1)
+    @test_throws ArgumentError parse_address("|h 2: 1 2⟩{7}")
+    @test fs"|h 2: 1 2⟩{}" == HardcoreBoseFS{missing}(1, 1)
+    @test_throws ArgumentError parse_address("|f 3: 1 2⟩{7}")
+    @test fs"|f 3: 1 2⟩{}" == FermiFS{missing}(1, 1, 0)
+    @test near_uniform(FermiFS{missing}(1, 0, 0)) == FermiFS{missing}(1, 0, 0)
+    @test near_uniform(HardcoreBoseFS{missing}(1, 0, 0)) == HardcoreBoseFS{missing}(1, 0, 0)
+    @test near_uniform(OccupationNumberFS(10, 0, 0)) == OccupationNumberFS(4, 3, 3)
+
+    fs = FermiFS{missing}(1, 0, 1, 1, 1, 0)
+    @test ismissing(num_particles(typeof(fs)))
+    @test length(occupied_modes(fs)) == num_particles(fs) == 4
+    @test length(unoccupied_modes(fs)) == num_modes(fs) - num_particles(fs) == 2
 end

--- a/test/ExactDiagonalization.jl
+++ b/test/ExactDiagonalization.jl
@@ -155,6 +155,24 @@ using SparseArrays
         bsr = BasisSetRepresentation(ham, add; cutoff)
         basis = build_basis(ham, add; cutoff)
         @test basis == bsr.basis
+
+        # build_basis for HardcoreBoseFS and FermiFS
+        hbas = build_basis(HardcoreBoseFS{2, 4})
+        @test length(hbas) == dimension(HardcoreBoseFS{2, 4})
+        fbas = build_basis(FermiFS{2, 4})
+        @test all(f.bs == h.bs for (f, h) in zip(fbas, hbas))
+
+
+        # build_basis with missing N for FermiFS and HardcoreBoseFS
+        fbasis = build_basis(FermiFS{missing}(1, 0, 1))
+        @test fbasis == build_basis(FermiFS{missing,3})
+        @test eltype(fbasis) <: FermiFS{missing,3}
+        @test length(fbasis) == 8 == dimension(FermiFS{missing}(1, 0, 1))
+        hbasis = build_basis(HardcoreBoseFS{missing}(1, 0, 1))
+        @test eltype(hbasis) <: HardcoreBoseFS{missing,3}
+        @test length(hbasis) == 8 == dimension(HardcoreBoseFS{missing}(1, 0, 1))
+        @test all(f.bs == h.bs for (f, h) in zip(fbasis, hbasis))
+        @test_throws ArgumentError build_basis(FermiFS{missing, 64})
     end
 
     @testset "fock build basis" begin

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -1656,10 +1656,22 @@ end
 end
 
 @testset "dimension and multi-component addresses" begin
-    addresses = [CompositeFS(FermiFS((1,0,1)), FermiFS((0,1,0))), BoseFS((1,0,1)),
-                FermiFS2C((1,0,1), (0,1,0))
+    addresses = [
+        CompositeFS(FermiFS((1,0,1)), FermiFS((0,1,0))), BoseFS((1,0,1)),
+        FermiFS2C((1,0,1), (0,1,0)), OccupationNumberFS(3, 0, 1), HardcoreBoseFS(1,0,1),
+        HardcoreBoseFS{missing}(1, 0, 1), FermiFS{missing}(1, 0, 1),
+        FermiFS2C{missing}((1, 0, 1), (0, 1, 0))
     ]
     [@test dimension(addr) == dimension(typeof(addr)) for addr in addresses]
+    @test dimension(CompositeFS(FermiFS((1,0,1)), FermiFS((0,1,0)))) == 9
+    @test dimension(CompositeFS(FermiFS((1,0,1)), FermiFS((0,1,0)), BoseFS((1,0,0)))) == 27
+    @test dimension(FermiFS2C{missing}((1, 0, 1), (0, 1, 0))) == 64
+    @test dimension(HardcoreBoseFS{missing}(1, 0, 1)) == 8
+    @test dimension(FermiFS{missing}(1, 0, 1)) == 8
+
+    h = ExtendedHubbardReal1D(HardcoreBoseFS{missing}(1, 1, 0))
+    @test dimension(h) == 3
+    @test dimension(starting_address(h)) == 8
 end
 
 @testset "ExtendedHubbardReal1D" begin
@@ -1793,11 +1805,11 @@ end
     rdm = ReducedDensityMatrix{ComplexF64}(1)
     m = dot(gs, rdm, gs)
     @test all(x -> abs(x) < √eps(Float64), m - m') # hermitian up to floating point noise
-    
+
     # a global relative phase in the vectors results in a global phase in the RDM
     m_phase = dot(im * gs, rdm, gs)
     @test all(x -> abs(x) < √eps(Float64), m_phase + im * m)
-    
+
     # complex non-hermitian Hamiltonian still produces approx hermitian RDM
     Hc = HubbardReal1D(BoseFS(0,1,2,0); u = 1+im)
     resc = solve(ExactDiagonalizationProblem(Hc))


### PR DESCRIPTION
This PR enable variable (non-conserved) particle number for `FermiFS` and `HardcoreBoseFS` address types and thereby enables `excitation`s to change the particle number without changing the address type. This enables the definition of number non-conserving Hamiltonians with fermions or hard core bosons.

## New features
- Add `N = missing` support to `FermiFS` / `HardcoreBoseFS` constructors, printing/parsing, and excitations.
- Extend parsing of compact address strings to recognize the `…⟩{}` form for missing-`N` fermionic / hardcore-bosonic addresses.
- Generalize `near_uniform` to accept `(N, M)` arguments and work across `SingleComponentFockAddress` subtypes; expand tests accordingly.
- `excitation` is allowed to change particle number if `N==missing`.
- `build_basis` and `dimension` work on the new address types.

## Bug fixed
- `build_basis` was not implemented for `HardcoreBoseFS{N,M}`. Now it is.

## Questions for reviewers: *(Not to be implemented here. See issue [#387](https://github.com/RimuQMC/Rimu.jl/issues/387))*
- Should we stop printing redundant type parameters, i.e. print `FermiFS(1, 0, 1)` for a number-conserving type and `FermiFS{missing}(1, 0, 1)`?
- Should we make `N=missing` the default for constructors when the type parameter is not explicitly requested?
  - If we do so and stop printing redundant parameters we would need to print the above examples as `FermiFS{3}(1, 0, 1)` and `FermiFS(1, 0, 1)`, respectively.
- Should we make `BoseFS{missing}(1, 2, 3)` a valid constructor for `OccupationNumberFS(1, 2, 3)`?
- Should we make `OccupationNumberFS(1, 2, 3)` print out as `BoseFS{missing}(1, 2, 3)` (and `OccupationNumberFS{UInt16}(1, 2, 3)` as `BoseFS{missing,UInt16}(1, 2, 3)`? Together with the previous suggestion it would hide the implementation detail of a non-converving boson type from the user and restore symmetry between bosons and fermions. 