### PR TITLE
Feature to preserve `StochasticStyle` across `empty` calls

### DIFF
--- a/src/DictVectors/dvec.jl
+++ b/src/DictVectors/dvec.jl
@@ -79,7 +79,7 @@ function DVec(dv::AbstractDVec{K,V}; style=StochasticStyle(dv), capacity=0) wher
     return copyto!(dvec, dv)
 end
 
-function Base.empty(dvec::DVec{K,V}; style=dvec.style) where {K,V}   # was wrongly commented out
+function Base.empty(dvec::DVec{K,V}; style=dvec.style) where {K,V} 
     return DVec{K,V}(; style)
 end
 function Base.empty(dvec::DVec{K,V}, ::Type{V}; style=dvec.style) where {K,V}

--- a/src/DictVectors/dvec.jl
+++ b/src/DictVectors/dvec.jl
@@ -79,19 +79,18 @@ function DVec(dv::AbstractDVec{K,V}; style=StochasticStyle(dv), capacity=0) wher
     return copyto!(dvec, dv)
 end
 
-function Base.empty(dvec::DVec{K,V}; style=dvec.style) where {K,V}
+function Base.empty(dvec::DVec{K,V}; style=dvec.style) where {K,V}   # was wrongly commented out
     return DVec{K,V}(; style)
 end
 function Base.empty(dvec::DVec{K,V}, ::Type{V}; style=dvec.style) where {K,V}
     return empty(dvec; style)
 end
-function Base.empty(::DVec{K}, ::Type{V}; style=default_style(V)) where {K,V}
+function Base.empty(dvec::DVec{K}, ::Type{V}; style=dvec.style(V)) where {K,V}
     return DVec{K,V}(; style)
 end
-function Base.empty(::DVec, ::Type{K}, ::Type{V}; style=default_style(V)) where {K,V}
+function Base.empty(dvec::DVec, ::Type{K}, ::Type{V}; style=dvec.style(V)) where {K,V}
     return DVec{K,V}(; style)
 end
-
 ###
 ### Show
 ###

--- a/src/DictVectors/initiatordvec.jl
+++ b/src/DictVectors/initiatordvec.jl
@@ -119,14 +119,14 @@ end
 function Base.empty(dvec::InitiatorDVec{K,V}; style=dvec.style) where {K,V}
     return InitiatorDVec{K,V}(; style, initiator=dvec.initiator)
 end
+function Base.empty(dvec::InitiatorDVec{K}, ::Type{V}; style=dvec.style(V)) where {K,V}
+    return InitiatorDVec{K,V}(; style, initiator=dvec.initiator)
+end
+function Base.empty(dvec::InitiatorDVec, ::Type{K}, ::Type{V}; style=dvec.style(V)) where {K,V}
+    return InitiatorDVec{K,V}(; style, initiator=dvec.initiator)
+end
 function Base.empty(dvec::InitiatorDVec{K,V}, ::Type{V}; style=dvec.style) where {K,V}
     return empty(dvec; style)
-end
-function Base.empty(dvec::InitiatorDVec{K}, ::Type{V}; style=default_style(V)) where {K,V}
-    return InitiatorDVec{K,V}(; style, initiator=dvec.initiator)
-end
-function Base.empty(dvec::InitiatorDVec, ::Type{K}, ::Type{V}; style=default_style(V)) where {K,V}
-    return InitiatorDVec{K,V}(; style, initiator=dvec.initiator)
 end
 
 ###

--- a/src/DictVectors/pdvec.jl
+++ b/src/DictVectors/pdvec.jl
@@ -372,14 +372,16 @@ function Base.empty(t::PDVec{K,V}, ::Type{V}; kwargs...) where {K,V}
     return empty(t; kwargs...)
 end
 function Base.empty(
-    t::PDVec{K,<:Any,N}, ::Type{V}; style=default_style(V), kwargs...
+    t::PDVec{K,<:Any,N}, ::Type{V}; style=t.style(V), initiator=t.initiator,
+    communicator=t.communicator, kwargs...
 ) where {K,V,N}
-    return PDVec{K,V,N}(; style, kwargs...)
+    return PDVec{K,V,N}(; style, initiator, communicator, kwargs...)
 end
 function Base.empty(
-    t::PDVec{<:Any,<:Any,N}, ::Type{K}, ::Type{V}; style=default_style(V), kwargs...
+    t::PDVec{<:Any,<:Any,N}, ::Type{K}, ::Type{V}; style=t.style(V),
+    initiator=t.initiator, communicator=t.communicator, kwargs...
 ) where {K,V,N}
-    return PDVec{K,V,N}(; style, kwargs...)
+    return PDVec{K,V,N}(; style, initiator, communicator, kwargs...)
 end
 function Base.empty!(t::PDVec)
     Folds.foreach(empty!, t.segments, )

--- a/src/StochasticStyles/styles.jl
+++ b/src/StochasticStyles/styles.jl
@@ -216,3 +216,21 @@ default_style(::Type{T}) where {T<:Integer} = IsStochasticInteger{T}()
 default_style(::Type{T}) where {T<:AbstractFloat} = IsDeterministic{T}()
 default_style(::Type{T}) where {T<:Complex{<:AbstractFloat}} = IsDeterministic{T}()
 default_style(::Type{T}) where {T<:Complex{<:Integer}} = IsStochastic2Pop{T}()
+
+(::StochasticStyle)(::Type{V}) where {V} = default_style(V)
+
+(::IsStochasticInteger)(::Type{V}) where {V<:Integer} = IsStochasticInteger{V}()
+(::IsStochasticInteger)(::Type{V}) where {V} = default_style(V)
+
+(::IsStochastic2Pop)(::Type{V}) where {V<:Complex{<:Integer}} = IsStochastic2Pop{V}()
+(::IsStochastic2Pop)(::Type{V}) where {V} = default_style(V)
+
+(s::IsDeterministic)(::Type{V}) where {V<:FloatOrComplexFloat} = IsDeterministic{V}(s.compression)
+(s::IsDeterministic)(::Type{V}) where {V} = default_style(V)
+
+(s::IsStochasticWithThreshold)(::Type{V}) where {V<:AbstractFloat} = IsStochasticWithThreshold{V}(V(s.threshold))
+(s::IsStochasticWithThreshold)(::Type{V}) where {V} = default_style(V)
+
+(s::IsDynamicSemistochastic)(::Type{V}) where {V<:FloatOrComplexFloat} =
+    IsDynamicSemistochastic(V(s.proj_threshold), s.compression, s.spawning)
+(s::IsDynamicSemistochastic)(::Type{V}) where {V} = default_style(V)

--- a/test/DictVectors.jl
+++ b/test/DictVectors.jl
@@ -2,7 +2,7 @@ using LinearAlgebra
 using Random
 using Rimu
 using Rimu.DictVectors
-using Rimu.DictVectors: PDWorkingMemory
+using Rimu.DictVectors: PDWorkingMemory, NotDistributed, AllToAll, Initiator, NonInitiator, CommunicatorError
 using Rimu.StochasticStyles: IsStochastic2Pop, StochasticStyle
 using StaticArrays
 using Suppressor
@@ -106,7 +106,9 @@ function test_dvec_interface(type; kwargs...)
             @testset "zerovector(!)" begin
                 u = type(9 => 1 + im, 2 => 2 - im, 13 => im, 4 => -im; kwargs...)
                 e = type{Int,Complex{Int}}(; kwargs...)
-
+                u_style = type(:a => 1; style=IsDynamicSemistochastic(), kwargs...)
+                e_same = empty(u_style)
+                e_new = empty(u_style, Float32)
                 @test isempty(e)
                 @test e == zerovector(u) == empty(u) == similar(u)
                 @test e == zerovector!(copy(u)) == zerovector!(copy(u)) == empty!(copy(u))
@@ -125,6 +127,13 @@ function test_dvec_interface(type; kwargs...)
                 v = type(1 => 1; kwargs...)
                 @test zerovector!!(v, Int) ≡ v
                 @test zerovector!!(v, Float64) ≢ v
+
+                @test StochasticStyle(e_same) isa IsDynamicSemistochastic
+                @test StochasticStyle(e_new) isa IsDynamicSemistochastic{Float32}
+                @test valtype(e_new) === Float32
+                @test StochasticStyle(similar(u_style, Float32)) isa IsDynamicSemistochastic{Float32}
+
+
             end
             @testset "scale(!)" begin
                 u = type(1 => 1.0 + im, 2 => -2.0im; kwargs...)
@@ -468,6 +477,17 @@ using Rimu.DictVectors: num_segments, is_distributed, SegmentedBuffer, replace_c
 
                 @test dot(pv1, op, pv2, wm) ≈ dot(pv1, op, dv2)
             end
+        end
+
+        @testset "preserve initiator and communicator" begin
+            pv = PDVec(:a => 1; initiator=true)
+            e = empty(pv, Float64)
+            @test e.initiator isa Initiator 
+            @test e.communicator == pv.communicator  
+            pv2 = PDVec(:b => 1; communicator=NotDistributed(), initiator=NonInitiator())
+            e2 = empty(pv2, Float32)
+            @test e2.communicator isa NotDistributed
+            @test e2.initiator isa NonInitiator
         end
     end
 

--- a/test/StochasticStyles.jl
+++ b/test/StochasticStyles.jl
@@ -305,3 +305,9 @@ end
         @test exact[k] ≈ ds_exact[k]
     end
 end
+
+@testset "style(V) adapts type parameters" begin
+    @test IsDynamicSemistochastic()(Float32) == IsDynamicSemistochastic{Float32}()
+    @test IsStochasticInteger()(Int32) == IsStochasticInteger{Int32}()
+    @test IsDeterministic()(Float32) == IsDeterministic{Float32}()
+end


### PR DESCRIPTION
Previous calls to the `empty(dvec, NewValueType)` always fell back to `default_style(NewValueType)` while silently discarding whatever style had been set on the original vector. This meant `IsDynamicSemistochastic`, or `IsDeterministic` with a custom compression strategy, would be lost whenever a same shape empty vector with a different `valtype` was constructed.

### Changes

**`StochasticStyles.jl`**

- Added callable instances `(style::S)(::Type{V})` for every concrete `StochasticStyle`. Each adapts the style to the new value type where possible, and falls back to `default_style(V)` only when the combination is incompatible (for example: `IsStochasticInteger` with a `Float64`):

**`DVec.jl`** 
- updated the `Base.empty` overloads that previously used `default_style(V)`:
- `empty(dvec::DVec{K}, ::Type{V})` now uses `dvec.style(V)` instead of `default_style(V)`
- Likewise for `empty(dvec::DVec, ::Type{K}, ::Type{V})` 

**`InitiatorDVec.jl`** 
- Same fix applied to the corresponding overloads of `InitiatorDVec`.
- `empty(dvec::InitiatorDVec{K}, ::Type{V})` now uses `dvec.style(V)`
-  Likewise for `empty(dvec::InitiatorDVec, ::Type{K}, ::Type{V})` 
- `initiator` is preserved in all cases (now made explicit alongside the style fix)

**`PDVec.jl`** 
- same fix, with `initiator` and `communicator` now explicitly forwarded in the type-changing overloads.
- `empty(t::PDVec{K,<:Any,N}, ::Type{V})` now passes `style=t.style(V)`, `initiator=t.initiator`, `communicator=t.communicator`
- Likewise for `empty(t::PDVec{<:Any,<:Any,N}, ::Type{K}, ::Type{V})` 

### Tests

- `test_dvec_interface` extended to check that `empty(u_style)` and `empty(u_style, Float32)`, on a vector constructed with `IsDynamicSemistochastic`, return `IsDynamicSemistochastic` and `IsDynamicSemistochastic{Float32}` respectively, and that `similar(u_style, Float32)` follows the same rule.
- For `PDVec` block new `"preserve initiator and communicator"` testset verifying that `empty(pv, Float64)` retains both fields across the type change.
- `StochasticStyles.jl` new `"style(V) adapts type parameters"` testset.

### Behaviour after this PR
**`empty(dv, Float32)`** where `dv` has `IsDynamicSemistochastic`
- Before: `IsDeterministic{Float32}`
- After: `IsDynamicSemistochastic{Float32}` (thresholds preserved)

**`empty(dv_compressed, Float32)`**
- Before: `IsDeterministic{Float32}()` (compression dropped)
- After: `IsDeterministic{Float32}(compression)` (compression preserved)

**`empty(dv_int, Float64)`** where `dv_int` has `IsStochasticInteger`
- Before: `IsDeterministic{Float64}`
- After: `IsDeterministic{Float64}` (unchanged)

**`empty(pv, Float64)`** on `PDVec` with custom `initiator`/`communicator`
- Before: both dropped
- After: both preserved