### PR TITLE
Relax type constraint in replica_stats to allow heterogeneous spectral_states

### DIFF
--- a/src/strategies_and_params/replicastrategy.jl
+++ b/src/strategies_and_params/replicastrategy.jl
@@ -153,7 +153,7 @@ function AllOverlaps(
 end
 
 function replica_stats(
-    rs::AllOverlaps{N,<:Any,<:Any,B,S}, spectral_states::NTuple{N}
+    rs::AllOverlaps{N,<:Any,<:Any,B,S}, spectral_states::Tuple{Vararg{<:Any,N}}
 ) where {N,B,S}
     n_spectral = num_spectral_states(spectral_states[1])
     vecs = SMatrix{N,n_spectral}(


### PR DESCRIPTION
## Change
This changes the `spectral_states` signature from `NTuple{N`} to `Tuple{Vararg{<:Any,N}}` to resolve a `MethodError` when passing mixed evolution strategies like `(PEC(), RungeKutta())` from [`RimuRealTime.jl`](https://github.com/RimuQMC/RimuRealTime.jl)