### PR TITLE
Remove deprecation warning for Tuple{Vararg} type signature

### DIFF
--- a/src/strategies_and_params/replicastrategy.jl
+++ b/src/strategies_and_params/replicastrategy.jl
@@ -153,7 +153,7 @@ function AllOverlaps(
 end
 
 function replica_stats(
-    rs::AllOverlaps{N,<:Any,<:Any,B,S}, spectral_states::Tuple{Vararg{<:Any,N}}
+    rs::AllOverlaps{N,<:Any,<:Any,B,S}, spectral_states::Tuple{Vararg{Any,N}}
 ) where {N,B,S}
     n_spectral = num_spectral_states(spectral_states[1])
     vecs = SMatrix{N,n_spectral}(


### PR DESCRIPTION
This PR removes a deprecation warning by adjusting the argument type signature in a method definition for `replica_stats`.

It fixes the error encountered previously during precompilation.

Previously, when running `julia --depwarn=error`, it gave an error:
```
julia> using Rimu
[ Info: Precompiling Rimu [c53c40cc-bd84-11e9-2cf4-a9fde2b9386e](cache misses: include_dependency fsize change (1), wrong source (4), incompatible header (2), dep missing source (3))
Info Given Rimu was explicitly requested, output will be shown live 
ERROR: LoadError: Wrapping `Vararg` directly in UnionAll is deprecated (wrap the tuple instead).
You may need to write `f(x::Vararg{T})` rather than `f(x::Vararg{<:T})` or `f(x::Vararg{T}) where T` instead of `f(x::Vararg{T} where T)`.
Stacktrace:
  [1] UnionAll(v::Any, t::Any)
    @ Core ./boot.jl:338
  [2] top-level scope
    @ ~/git/code/Rimu/src/strategies_and_params/replicastrategy.jl:155
  [3] include(mapexpr::Function, mod::Module, _path::String)
    @ Base ./Base.jl:307
  [4] top-level scope
    @ ~/git/code/Rimu/src/Rimu.jl:91
  [5] include(mod::Module, _path::String)
    @ Base ./Base.jl:306
  [6] include_package_for_output(pkg::Base.PkgId, input::String, depot_path::Vector{String}, dl_load_path::Vector{String}, load_path::Vector{String}, concrete_deps::Vector{Pair{Base.PkgId, UInt128}}, source::Nothing)
    @ Base ./loading.jl:3028
  [7] top-level scope
    @ stdin:5
  [8] eval(m::Module, e::Any)
    @ Core ./boot.jl:489
  [9] include_string(mapexpr::typeof(identity), mod::Module, code::String, filename::String)
    @ Base ./loading.jl:2874
 [10] include_string
    @ ./loading.jl:2884 [inlined]
 [11] exec_options(opts::Base.JLOptions)
    @ Base ./client.jl:315
 [12] _start()
    @ Base ./client.jl:550
in expression starting at /Users/brand/git/code/Rimu/src/strategies_and_params/replicastrategy.jl:155
in expression starting at /Users/brand/git/code/Rimu/src/Rimu.jl:1
in expression starting at stdin:5
  ✗ Rimu
```
