### PR TITLE
ScaledOrShiftedHamiltonian

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Rimu"
 uuid = "c53c40cc-bd84-11e9-2cf4-a9fde2b9386e"
-version = "0.17.0"
+version = "0.18.0"
 authors = ["Joachim Brand <j.brand@massey.ac.nz>"]
 
 [deps]

--- a/docs/src/hamiltonians.md
+++ b/docs/src/hamiltonians.md
@@ -65,8 +65,7 @@ TimeReversalSymmetry
 Stoquastic
 Hamiltonians.TransformUndoer
 HamiltonianProduct
-ScaledHamiltonian
-ShiftedHamiltonian
+ScaledOrShiftedHamiltonian
 HamiltonianSum
 ```
 

--- a/docs/src/hamiltonians.md
+++ b/docs/src/hamiltonians.md
@@ -65,8 +65,17 @@ TimeReversalSymmetry
 Stoquastic
 Hamiltonians.TransformUndoer
 HamiltonianProduct
-ScaledOrShiftedHamiltonian
 HamiltonianSum
+```
+
+## Linear combination helpers
+These public functions construct scaled and shifted Hamiltonians without exposing the
+underlying wrapper type directly:
+```@docs
+VectorInterface.add
+Base.:+
+VectorInterface.scale
+Base.:*
 ```
 
 ## Observables
@@ -115,6 +124,7 @@ LadderBoundaries
 The following internal functions and types are documented here for completeness, 
 but are not part of the public API and may change any time. Use at your own risk.
 ```@docs
+Hamiltonians.ScaledOrShiftedHamiltonian
 Hamiltonians.one_electron_diagonal
 Hamiltonians.two_electron_diagonal
 Hamiltonians.MolecularHamiltonianOffDiagonals

--- a/docs/src/hamiltonians.md
+++ b/docs/src/hamiltonians.md
@@ -66,6 +66,7 @@ Stoquastic
 Hamiltonians.TransformUndoer
 HamiltonianProduct
 ScaledHamiltonian
+ShiftedHamiltonian
 HamiltonianSum
 ```
 

--- a/docs/src/hamiltonians.md
+++ b/docs/src/hamiltonians.md
@@ -72,10 +72,9 @@ HamiltonianSum
 These public functions construct scaled and shifted Hamiltonians without exposing the
 underlying wrapper type directly:
 ```@docs
-VectorInterface.add
-Base.:+
-VectorInterface.scale
-Base.:*
+VectorInterface.add(::UniformScaling, ::AbstractHamiltonian, ::Number, ::Number)
+Base.:+(::AbstractHamiltonian, ::UniformScaling)
+VectorInterface.scale(::AbstractHamiltonian, ::Number)
 ```
 
 ## Observables

--- a/src/Hamiltonians/Hamiltonians.jl
+++ b/src/Hamiltonians/Hamiltonians.jl
@@ -32,7 +32,7 @@ Other
 - [`TimeReversalSymmetry`](@ref)
 - [`Stoquastic`](@ref)
 - [`HamiltonianProduct`](@ref)
-- [`ScaledHamiltonian`](@ref)
+- [`ScaledOrShiftedHamiltonian`](@ref)
 - [`HamiltonianSum`](@ref)
 
 ## [Observables](#Observables)
@@ -103,7 +103,7 @@ export AxialAngularMomentumHO
 export get_all_blocks, fock_to_cart
 
 export ModifiedHamiltonian
-export HamiltonianProduct, ScaledHamiltonian, ShiftedHamiltonian, HamiltonianSum
+export HamiltonianProduct, HamiltonianSum, ScaledOrShiftedHamiltonian
 
 if VERSION < v"1.10"
     # used for ReducedDensityMatrix

--- a/src/Hamiltonians/Hamiltonians.jl
+++ b/src/Hamiltonians/Hamiltonians.jl
@@ -102,8 +102,8 @@ export HOCartesianContactInteractions, HOCartesianEnergyConservedPerDim, HOCarte
 export AxialAngularMomentumHO
 export get_all_blocks, fock_to_cart
 
-export HamiltonianProduct, ScaledHamiltonian
-export HamiltonianSum
+export ModifiedHamiltonian
+export HamiltonianProduct, ScaledHamiltonian, ShiftedHamiltonian, HamiltonianSum
 
 if VERSION < v"1.10"
     # used for ReducedDensityMatrix

--- a/src/Hamiltonians/Hamiltonians.jl
+++ b/src/Hamiltonians/Hamiltonians.jl
@@ -38,7 +38,6 @@ Other
 - [`add`](@ref)
 - [`+`](@ref)
 - [`scale`](@ref)
-- [`*`](@ref)
 
 ## [Observables](#Observables)
 - [`ParticleNumberOperator`](@ref)

--- a/src/Hamiltonians/Hamiltonians.jl
+++ b/src/Hamiltonians/Hamiltonians.jl
@@ -32,8 +32,13 @@ Other
 - [`TimeReversalSymmetry`](@ref)
 - [`Stoquastic`](@ref)
 - [`HamiltonianProduct`](@ref)
-- [`ScaledOrShiftedHamiltonian`](@ref)
 - [`HamiltonianSum`](@ref)
+
+## [Linear combination helpers](#Linear-combination-helpers)
+- [`add`](@ref)
+- [`+`](@ref)
+- [`scale`](@ref)
+- [`*`](@ref)
 
 ## [Observables](#Observables)
 - [`ParticleNumberOperator`](@ref)
@@ -103,7 +108,7 @@ export AxialAngularMomentumHO
 export get_all_blocks, fock_to_cart
 
 export ModifiedHamiltonian
-export HamiltonianProduct, HamiltonianSum, ScaledOrShiftedHamiltonian
+export HamiltonianProduct, HamiltonianSum
 
 if VERSION < v"1.10"
     # used for ReducedDensityMatrix

--- a/src/Hamiltonians/ModifiedHamiltonian.jl
+++ b/src/Hamiltonians/ModifiedHamiltonian.jl
@@ -28,8 +28,7 @@ The following are provided:
 * [`dimension(op, address)`](@ref)
 
 For examples of how to implement a `ModifiedHamiltonian`, see, e.g.,
-[`ScaledHamiltonian`](@ref), [`ShiftedHamiltonian`](@ref), or [`ParitySymmetry`](@ref) and
-read the source code.
+[`ScaledOrShiftedHamiltonian`](@ref) or [`ParitySymmetry`](@ref) and read the source code.
 """
 abstract type ModifiedHamiltonian{T} <: AbstractHamiltonian{T} end
 

--- a/src/Hamiltonians/ModifiedHamiltonian.jl
+++ b/src/Hamiltonians/ModifiedHamiltonian.jl
@@ -27,6 +27,9 @@ The following are provided:
 * [`random_offdiagonal(column)`](@ref)
 * [`dimension(op, address)`](@ref)
 
+For examples of how to implement a `ModifiedHamiltonian`, see, e.g.,
+[`ScaledHamiltonian`](@ref), [`ShiftedHamiltonian`](@ref), or [`ParitySymmetry`](@ref) and
+read the source code.
 """
 abstract type ModifiedHamiltonian{T} <: AbstractHamiltonian{T} end
 

--- a/src/Hamiltonians/ModifiedHamiltonian.jl
+++ b/src/Hamiltonians/ModifiedHamiltonian.jl
@@ -28,7 +28,7 @@ The following are provided:
 * [`dimension(op, address)`](@ref)
 
 For examples of how to implement a `ModifiedHamiltonian`, see, e.g.,
-[`ScaledOrShiftedHamiltonian`](@ref) or [`ParitySymmetry`](@ref) and read the source code.
+[`ParitySymmetry`](@ref) and read the source code.
 """
 abstract type ModifiedHamiltonian{T} <: AbstractHamiltonian{T} end
 

--- a/src/Hamiltonians/Product.jl
+++ b/src/Hamiltonians/Product.jl
@@ -256,12 +256,12 @@ parent_operator(h::ScaledHamiltonian) = h.hamiltonian
 modify_diagonal(h::ScaledHamiltonian, _, value) = value*h.α
 modify_offdiagonal(h::ScaledHamiltonian, _, addr, value) = addr => value*h.α
 
-@doc (@doc ScaledHamiltonian)
-function VectorInterface.scale(h::AbstractHamiltonian, α::T) where {T<:Number}
-    if α == 1
-        return h
-    end
-    return ScaledHamiltonian(h, α)
-end
+# @doc (@doc ScaledHamiltonian)
+# function VectorInterface.scale(h::AbstractHamiltonian, α::T) where {T<:Number}
+#     if α == 1
+#         return h
+#     end
+#     return ScaledHamiltonian(h, α)
+# end
 
-Base.:*(α::Number, h::AbstractHamiltonian) = scale(h, α)
+# Base.:*(α::Number, h::AbstractHamiltonian) = scale(h, α)

--- a/src/Hamiltonians/Product.jl
+++ b/src/Hamiltonians/Product.jl
@@ -5,7 +5,7 @@
 The product of two [`AbstractHamiltonian`](@ref)s, acting from right to left. The two Hamiltonians
 must act on the same address space. Set `commuting` to `true` if `A` and `B` commute.
 
-See also [`ScaledHamiltonian`](@ref), [`HamiltonianSum`](@ref), [`AbstractHamiltonian`](@ref).
+See also [`ScaledOrShiftedHamiltonian`](@ref), [`HamiltonianSum`](@ref), [`AbstractHamiltonian`](@ref).
 """
 struct HamiltonianProduct{T, O1<:AbstractHamiltonian, O2<:AbstractHamiltonian, C} <: AbstractHamiltonian{T}
     op1::O1
@@ -198,70 +198,3 @@ function Base.iterate(o::ProductOffdiagonals, state::ProductIterState{S1,S2,OD1,
         end
     end
 end
-
-"""
-    ScaledHamiltonian(H::AbstractHamiltonian, α) <: ModifiedHamiltonian
-    scale(H, α) -> ScaledHamiltonian
-    α * H
-
-The product of the Hamiltonian `H` with the scalar `α`.
-
-See also [`ShiftedHamiltonian`](@ref), [`HamiltonianSum`](@ref),
-[`HamiltonianProduct`](@ref), [`AbstractHamiltonian`](@ref), [`ModifiedHamiltonian`](@ref).
-"""
-struct ScaledHamiltonian{T,H} <: ModifiedHamiltonian{T}
-    hamiltonian::H
-    α::T
-end
-
-function ScaledHamiltonian(h::AbstractHamiltonian{T1}, α::T2) where {T1,T2}
-    T = promote_type(T1,T2)
-    ScaledHamiltonian{T, typeof(h)}(h, T(α))
-end
-
-function ScaledHamiltonian(h::ScaledHamiltonian, β::Number)
-    return ScaledHamiltonian(h.hamiltonian, h.α*β)
-end
-
-function Base.show(io::IO, h::ScaledHamiltonian{T}) where {T}
-    if T <: Real
-        print(io, h.α, " * ")
-    else
-        print(io, "(", h.α, ") * ")
-    end
-    if h.hamiltonian isa ShiftedHamiltonian
-        print(io, "(", h.hamiltonian, ")")
-    else
-        print(io, h.hamiltonian)
-    end
-end
-
-function LOStructure(::Type{<:ScaledHamiltonian{T,H}}) where {T,H}
-    if LOStructure(H) == IsHermitian()
-        if T <: Real
-            return IsHermitian()
-        else
-            return AdjointKnown()
-        end
-    else
-        return LOStructure(H)
-    end
-end
-
-function LinearAlgebra.adjoint(h::ScaledHamiltonian)
-    return ScaledHamiltonian(h.hamiltonian', conj(h.α))
-end
-
-parent_operator(h::ScaledHamiltonian) = h.hamiltonian
-modify_diagonal(h::ScaledHamiltonian, _, value) = value*h.α
-modify_offdiagonal(h::ScaledHamiltonian, _, addr, value) = addr => value*h.α
-
-# @doc (@doc ScaledHamiltonian)
-# function VectorInterface.scale(h::AbstractHamiltonian, α::T) where {T<:Number}
-#     if α == 1
-#         return h
-#     end
-#     return ScaledHamiltonian(h, α)
-# end
-
-# Base.:*(α::Number, h::AbstractHamiltonian) = scale(h, α)

--- a/src/Hamiltonians/Product.jl
+++ b/src/Hamiltonians/Product.jl
@@ -200,13 +200,14 @@ function Base.iterate(o::ProductOffdiagonals, state::ProductIterState{S1,S2,OD1,
 end
 
 """
-    ScaledHamiltonian(H::AbstractHamiltonian, α) <: AbstractHamiltonian
-    scale(H, α)
+    ScaledHamiltonian(H::AbstractHamiltonian, α) <: ModifiedHamiltonian
+    scale(H, α) -> ScaledHamiltonian
     α * H
 
 The product of the Hamiltonian `H` with the scalar `α`.
 
-See also [`HamiltonianSum`](@ref), [`HamiltonianProduct`](@ref), [`AbstractHamiltonian`](@ref).
+See also [`ShiftedHamiltonian`](@ref), [`HamiltonianSum`](@ref),
+[`HamiltonianProduct`](@ref), [`AbstractHamiltonian`](@ref), [`ModifiedHamiltonian`](@ref).
 """
 struct ScaledHamiltonian{T,H} <: ModifiedHamiltonian{T}
     hamiltonian::H
@@ -224,9 +225,14 @@ end
 
 function Base.show(io::IO, h::ScaledHamiltonian{T}) where {T}
     if T <: Real
-        print(io, h.α, " * ", h.hamiltonian)
+        print(io, h.α, " * ")
     else
-        print(io, "(", h.α, ") * ", h.hamiltonian)
+        print(io, "(", h.α, ") * ")
+    end
+    if h.hamiltonian isa ShiftedHamiltonian
+        print(io, "(", h.hamiltonian, ")")
+    else
+        print(io, h.hamiltonian)
     end
 end
 

--- a/src/Hamiltonians/Product.jl
+++ b/src/Hamiltonians/Product.jl
@@ -5,7 +5,7 @@
 The product of two [`AbstractHamiltonian`](@ref)s, acting from right to left. The two Hamiltonians
 must act on the same address space. Set `commuting` to `true` if `A` and `B` commute.
 
-See also [`ScaledOrShiftedHamiltonian`](@ref), [`HamiltonianSum`](@ref), [`AbstractHamiltonian`](@ref).
+See also [`HamiltonianSum`](@ref), [`AbstractHamiltonian`](@ref).
 """
 struct HamiltonianProduct{T, O1<:AbstractHamiltonian, O2<:AbstractHamiltonian, C} <: AbstractHamiltonian{T}
     op1::O1

--- a/src/Hamiltonians/Sum.jl
+++ b/src/Hamiltonians/Sum.jl
@@ -246,24 +246,165 @@ parent_operator(s::ShiftedHamiltonian) = s.hamiltonian
 modify_diagonal(s::ShiftedHamiltonian, _, value) = value + s.shift
 modify_offdiagonal(s::ShiftedHamiltonian, _, addr, value) = addr => value
 
-@doc (@doc ShiftedHamiltonian)
-function VectorInterface.add(
-    h::AbstractHamiltonian, shift::UniformScaling{T}, alpha::Number, beta::Number
-) where {T<:Number}
-    return ShiftedHamiltonian(beta * h, alpha * shift.λ)
+# @doc (@doc ShiftedHamiltonian)
+# function VectorInterface.add(
+#     h::AbstractHamiltonian, shift::UniformScaling{T}, alpha::Number, beta::Number
+# ) where {T<:Number}
+#     return ShiftedHamiltonian(beta * h, alpha * shift.λ)
+# end
+# function VectorInterface.add(
+#     shift::UniformScaling{T}, h::AbstractHamiltonian, alpha::Number, beta::Number
+# ) where {T<:Number}
+#     return add(h, shift, beta, alpha)
+# end
+
+# @doc (@doc ShiftedHamiltonian)
+# function Base.:+(h::AbstractHamiltonian, shift::UniformScaling{T}) where {T<:Number}
+#     return ShiftedHamiltonian(h, shift.λ)
+# end
+# Base.:+(shift::UniformScaling{T}, h::AbstractHamiltonian) where {T<:Number} = h + shift
+# Base.:-(h::AbstractHamiltonian, shift::UniformScaling{T}) where {T<:Number} = h + (-shift)
+# function Base.:-(shift::UniformScaling{T}, h::AbstractHamiltonian) where {T<:Number}
+#     scale(h, -1) + shift
+# end
+
+"""
+    ScaledOrShiftedHamiltonian(H::AbstractHamiltonian, alpha, beta) <: ModifiedHamiltonian
+    +(H::AbstractHamiltonian, shift::UniformScaling)
+    add(shift::UniformScaling, H::AbstractHamiltonian, [alpha, beta])
+    *(alpha::Number, H::AbstractHamiltonian)
+    scale(H, alpha)
+    alpha * H + beta * I -> ScaledOrShiftedHamiltonian(H, alpha, beta)
+
+A Hamiltonian that has been scaled by a scalar, `alpha * H`, or shifted by a scalar,
+`H + beta * I`, or both, `alpha * H + beta * I`. Note that scaling and shifting a
+Hamiltonian by a scalar using `add` or `+` requires a `UniformScaling` object, which is
+created by multiplying a scalar with `LinearAlgebra.I`, representing a unit matrix.
+
+Scaling is applied to all matrix elements of the Hamiltonian, while shifting only affects
+the diagonal elements. As a consequence the eigenvalues of the Hamiltonian are scaled and
+shifted, while the eigenvectors remain unchanged. Composite Hamiltonians constructed in this
+way are efficient for usage with deterministic and stochastic operations. Nested and
+consecutive scaling and shifting operations are automatically combined into a single
+`ScaledOrShiftedHamiltonian` object.
+
+## Example
+```jldoctest
+julia> H = HubbardReal1D(BoseFS(1,1));
+
+julia> ssh = 3*H + 2*I
+3*HubbardReal1D(fs"|1 1⟩"; u=1.0, t=1.0) + 2*I
+
+julia> using Rimu.Hamiltonians: ScaledOrShiftedHamiltonian
+
+julia> ssh == add(2*I, H, 3) == ScaledOrShiftedHamiltonian(H, 3, 2)
+true
+
+julia> Matrix(H)
+3×3 Matrix{Float64}:
+  0.0      -2.82843  -2.82843
+ -2.82843   1.0       0.0
+ -2.82843   0.0       1.0
+
+julia> Matrix(3*H + 2*I)
+3×3 Matrix{Float64}:
+  2.0      -8.48528  -8.48528
+ -8.48528   5.0       0.0
+ -8.48528   0.0       5.0
+```
+
+See also [`HamiltonianSum`](@ref), [`HamiltonianProduct`](@ref),
+[`ModifiedHamiltonian`](@ref), and [`AbstractHamiltonian`](@ref).
+"""
+struct ScaledOrShiftedHamiltonian{T, TA, TB, H} <: ModifiedHamiltonian{T}
+    hamiltonian::H
+    alpha::TA
+    beta::TB
 end
+
+function ScaledOrShiftedHamiltonian(
+    h::AbstractHamiltonian{TH}, alpha::TA, beta::TB
+) where {TH,TA<:Number,TB<:Number}
+    T = promote_type(TA, TB, TH)
+    ScaledOrShiftedHamiltonian{T, TA, TB, typeof(h)}(h, alpha, beta)
+end
+ScaledOrShiftedHamiltonian(h, ::One, ::Zero) = h
+
+function ScaledOrShiftedHamiltonian(
+    h::ScaledOrShiftedHamiltonian, alpha::Number, beta::Number
+)
+    return ScaledOrShiftedHamiltonian(h.hamiltonian, alpha * h.alpha, alpha * h.beta + beta)
+end
+
+function Base.show(io::IO, s::ScaledOrShiftedHamiltonian{T, TA, TB}) where {T, TA, TB}
+    if TA <: One
+        print(io, s.hamiltonian)
+    elseif TA <: Real
+        print(io, s.alpha, "*", s.hamiltonian)
+    else
+        print(io, "(", s.alpha, ")*", s.hamiltonian)
+    end
+    if TB <: Zero
+        return
+    elseif TB <: Real
+        print(io, " + ", s.beta, "*I")
+    else
+        print(io, " + (", s.beta, ")*I")
+    end
+end
+
+function LinearAlgebra.adjoint(s::ScaledOrShiftedHamiltonian)
+    return ScaledOrShiftedHamiltonian(s.hamiltonian', conj(s.alpha), conj(s.beta))
+end
+
+function LOStructure(::Type{<:ScaledOrShiftedHamiltonian{T,TA,TB,H}}) where {T,TA,TB,H}
+    if LOStructure(H) == IsHermitian()
+        if TA <: Real && TB <: Real
+            return IsHermitian()
+        else
+            return AdjointKnown()
+        end
+    else
+        return LOStructure(H)
+    end
+end
+
+parent_operator(s::ScaledOrShiftedHamiltonian) = s.hamiltonian
+function modify_diagonal(s::ScaledOrShiftedHamiltonian{T}, _, value) where {T}
+    return T(s.alpha * value + s.beta)
+end
+function modify_offdiagonal(s::ScaledOrShiftedHamiltonian{T}, _, addr, value) where {T}
+    return addr => T(s.alpha * value)
+end
+
+@doc (@doc ScaledOrShiftedHamiltonian)
 function VectorInterface.add(
     shift::UniformScaling{T}, h::AbstractHamiltonian, alpha::Number, beta::Number
 ) where {T<:Number}
-    return add(h, shift, beta, alpha)
+    return ScaledOrShiftedHamiltonian(h, alpha, shift.λ * beta)
+end
+function VectorInterface.add(
+    h::AbstractHamiltonian, shift::UniformScaling{T}, beta::Number, alpha::Number
+) where {T<:Number}
+    return add(shift, h, alpha, beta)
 end
 
-@doc (@doc ShiftedHamiltonian)
+@doc (@doc ScaledOrShiftedHamiltonian)
 function Base.:+(h::AbstractHamiltonian, shift::UniformScaling{T}) where {T<:Number}
-    return ShiftedHamiltonian(h, shift.λ)
+    return ScaledOrShiftedHamiltonian(h, One(), shift.λ)
 end
 Base.:+(shift::UniformScaling{T}, h::AbstractHamiltonian) where {T<:Number} = h + shift
+
 Base.:-(h::AbstractHamiltonian, shift::UniformScaling{T}) where {T<:Number} = h + (-shift)
 function Base.:-(shift::UniformScaling{T}, h::AbstractHamiltonian) where {T<:Number}
-    scale(h, -1) + shift
+    return ScaledOrShiftedHamiltonian(h, -1, shift.λ)
 end
+Base.:-(h::AbstractHamiltonian) = ScaledOrShiftedHamiltonian(h, -1, Zero())
+
+@doc (@doc ScaledOrShiftedHamiltonian)
+function VectorInterface.scale(h::AbstractHamiltonian, alpha::T) where {T<:Number}
+    return ScaledOrShiftedHamiltonian(h, alpha, Zero())
+end
+
+@doc (@doc ScaledOrShiftedHamiltonian)
+Base.:*(alpha::Number, h::AbstractHamiltonian) = scale(h, alpha)

--- a/src/Hamiltonians/Sum.jl
+++ b/src/Hamiltonians/Sum.jl
@@ -155,12 +155,12 @@ end
 
 """
     ShiftedHamiltonian(h::AbstractHamiltonian, shift::Number) <: ModifiedHamiltonian
-    add(h::AbstractHamiltonian, shift::UniformScaling) -> ShiftedHamiltonian
+    add(h::AbstractHamiltonian, shift_op::UniformScaling, [α, β]) -> ShiftedHamiltonian
     h + shift * I
 
 A Hamiltonian that has been shifted by a scalar value. In combination with
 [`ScaledHamiltonian`](@ref), this can be used to represent a Hamiltonian of the form
-``αH + βI``. Composite Hamiltonians constructed in this way are efficient for usage with
+``β*H + α*I``. Composite Hamiltonians constructed in this way are efficient for usage with
 deterministic and stochastic operations.
 
 Note that shifting a Hamiltonian by a scalar using `add` or `+` requires a
@@ -187,7 +187,7 @@ julia> Matrix(hamiltonian - 2I)
  -2.82843   0.0      -1.0
 
 julia> transition_operator  = I - im * 0.1 * hamiltonian
-(1.0 + 0.0im)I + (-0.0 - 0.1im) * HubbardRealSpace(
+(1.0 + 0.0im)*I + (-0.0 - 0.1im) * HubbardRealSpace(
   fs"|1 1⟩";
   geometry = CubicGrid((2,), (true,)),
   t = [1.0;;],
@@ -220,9 +220,9 @@ end
 
 function Base.show(io::IO, s::ShiftedHamiltonian{T}) where {T}
     if T <: Real
-        print(io, s.shift, "I + ", s.hamiltonian)
+        print(io, s.shift, "*I + ", s.hamiltonian)
     else
-        print(io, "(", s.shift, ")", "I + ", s.hamiltonian)
+        print(io, "(", s.shift, ")*I + ", s.hamiltonian)
     end
 end
 
@@ -250,7 +250,7 @@ modify_offdiagonal(s::ShiftedHamiltonian, _, addr, value) = addr => value
 function VectorInterface.add(
     h::AbstractHamiltonian, shift::UniformScaling{T}, alpha::Number, beta::Number
 ) where {T<:Number}
-    return ShiftedHamiltonian(alpha * h, beta * shift.λ)
+    return ShiftedHamiltonian(beta * h, alpha * shift.λ)
 end
 function VectorInterface.add(
     shift::UniformScaling{T}, h::AbstractHamiltonian, alpha::Number, beta::Number

--- a/src/Hamiltonians/Sum.jl
+++ b/src/Hamiltonians/Sum.jl
@@ -163,6 +163,10 @@ A Hamiltonian that has been shifted by a scalar value. In combination with
 ``αH + βI``. Composite Hamiltonians constructed in this way are efficient for usage with
 deterministic and stochastic operations.
 
+Note that shifting a Hamiltonian by a scalar using `add` or `+` requires a
+`UniformScaling` object, which is created by multiplying a scalar with
+`I` (from the `LinearAlgebra` standard library).
+
 ## Example
 ```jldoctest
 julia> hamiltonian = HubbardRealSpace(BoseFS(1,1));

--- a/src/Hamiltonians/Sum.jl
+++ b/src/Hamiltonians/Sum.jl
@@ -8,11 +8,11 @@ on the same address space. The keyword argument `weight` affects random spawning
 with [`random_offdiagonal`](@ref) and determines the probability of random spawns
 from `A`, with `1 - weight` the probability of spawning from `B`.
 
-If coefficients `a` and `b` are given, the Hamiltonians are scaled with [`ScaledHamiltonian`](@ref),
-to represent ``aA + bB``.
+If coefficients `a` and `b` are given, the Hamiltonians are scaled with
+[`ScaledOrShiftedHamiltonian`](@ref), to represent ``aA + bB``.
 
-See also [`ShiftedHamiltonian`](@ref), [`ScaledHamiltonian`](@ref),
-[`HamiltonianProduct`](@ref), [`AbstractHamiltonian`](@ref).
+See also [`ScaledOrShiftedHamiltonian`](@ref), [`HamiltonianProduct`](@ref),
+[`AbstractHamiltonian`](@ref).
 """
 struct HamiltonianSum{T, H1<:AbstractHamiltonian, H2<:AbstractHamiltonian} <: AbstractHamiltonian{T}
     h1::H1
@@ -37,7 +37,7 @@ end
 
 @doc (@doc HamiltonianSum)
 function VectorInterface.add(
-    h1::AbstractHamiltonian, h2::AbstractHamiltonian, a::Number=1, b::Number=1; weight=0.5
+    h1::AbstractHamiltonian, h2::AbstractHamiltonian, a::Number=One(), b::Number=One(); weight=0.5
 )
     return HamiltonianSum(a*h1, b*h2; weight)
 end
@@ -154,121 +154,6 @@ function Base.iterate(o::SumOffdiagonals, state)
 end
 
 """
-    ShiftedHamiltonian(h::AbstractHamiltonian, shift::Number) <: ModifiedHamiltonian
-    add(h::AbstractHamiltonian, shift_op::UniformScaling, [α, β]) -> ShiftedHamiltonian
-    h + shift * I
-
-A Hamiltonian that has been shifted by a scalar value. In combination with
-[`ScaledHamiltonian`](@ref), this can be used to represent a Hamiltonian of the form
-``β*H + α*I``. Composite Hamiltonians constructed in this way are efficient for usage with
-deterministic and stochastic operations.
-
-Note that shifting a Hamiltonian by a scalar using `add` or `+` requires a
-`UniformScaling` object, which is created by multiplying a scalar with
-`I` (from the `LinearAlgebra` standard library).
-
-## Example
-```jldoctest
-julia> hamiltonian = HubbardRealSpace(BoseFS(1,1));
-
-julia> hamiltonian - 2I == ShiftedHamiltonian(hamiltonian, -2) == add(hamiltonian, -2I)
-true
-
-julia> Matrix(hamiltonian)
-3×3 Matrix{Float64}:
-  0.0      -2.82843  -2.82843
- -2.82843   1.0       0.0
- -2.82843   0.0       1.0
-
-julia> Matrix(hamiltonian - 2I)
-3×3 Matrix{Float64}:
- -2.0      -2.82843  -2.82843
- -2.82843  -1.0       0.0
- -2.82843   0.0      -1.0
-
-julia> transition_operator  = I - im * 0.1 * hamiltonian
-(1.0 + 0.0im)*I + (-0.0 - 0.1im) * HubbardRealSpace(
-  fs"|1 1⟩";
-  geometry = CubicGrid((2,), (true,)),
-  t = [1.0;;],
-  u = [1.0;;],
-)
-
-julia> Matrix(transition_operator)
-3×3 Matrix{ComplexF64}:
- 1.0+0.0im       0.0+0.282843im  0.0+0.282843im
- 0.0+0.282843im  1.0-0.1im       0.0+0.0im
- 0.0+0.282843im  0.0+0.0im       1.0-0.1im
-```
-
-See also [`HamiltonianSum`](@ref), [`ScaledHamiltonian`](@ref),
-[`ModifiedHamiltonian`](@ref), and [`AbstractHamiltonian`](@ref).
-"""
-struct ShiftedHamiltonian{T<:Number,H} <: ModifiedHamiltonian{T}
-    hamiltonian::H
-    shift::T
-end
-
-function ShiftedHamiltonian(h::AbstractHamiltonian{T1}, shift::T2) where {T1,T2<:Number}
-    T = promote_type(T1,T2)
-    return ShiftedHamiltonian{T, typeof(h)}(h, T(shift))
-end
-
-function ShiftedHamiltonian(h::ShiftedHamiltonian, shift::Number)
-    return ShiftedHamiltonian(h.hamiltonian, h.shift + shift)
-end
-
-function Base.show(io::IO, s::ShiftedHamiltonian{T}) where {T}
-    if T <: Real
-        print(io, s.shift, "*I + ", s.hamiltonian)
-    else
-        print(io, "(", s.shift, ")*I + ", s.hamiltonian)
-    end
-end
-
-function LinearAlgebra.adjoint(s::ShiftedHamiltonian)
-    return ShiftedHamiltonian(s.hamiltonian', conj(s.shift))
-end
-
-function LOStructure(::Type{<:ShiftedHamiltonian{T,H}}) where {T,H}
-    if LOStructure(H) == IsHermitian()
-        if T <: Real
-            return IsHermitian()
-        else
-            return AdjointKnown()
-        end
-    else
-        return LOStructure(H)
-    end
-end
-
-parent_operator(s::ShiftedHamiltonian) = s.hamiltonian
-modify_diagonal(s::ShiftedHamiltonian, _, value) = value + s.shift
-modify_offdiagonal(s::ShiftedHamiltonian, _, addr, value) = addr => value
-
-# @doc (@doc ShiftedHamiltonian)
-# function VectorInterface.add(
-#     h::AbstractHamiltonian, shift::UniformScaling{T}, alpha::Number, beta::Number
-# ) where {T<:Number}
-#     return ShiftedHamiltonian(beta * h, alpha * shift.λ)
-# end
-# function VectorInterface.add(
-#     shift::UniformScaling{T}, h::AbstractHamiltonian, alpha::Number, beta::Number
-# ) where {T<:Number}
-#     return add(h, shift, beta, alpha)
-# end
-
-# @doc (@doc ShiftedHamiltonian)
-# function Base.:+(h::AbstractHamiltonian, shift::UniformScaling{T}) where {T<:Number}
-#     return ShiftedHamiltonian(h, shift.λ)
-# end
-# Base.:+(shift::UniformScaling{T}, h::AbstractHamiltonian) where {T<:Number} = h + shift
-# Base.:-(h::AbstractHamiltonian, shift::UniformScaling{T}) where {T<:Number} = h + (-shift)
-# function Base.:-(shift::UniformScaling{T}, h::AbstractHamiltonian) where {T<:Number}
-#     scale(h, -1) + shift
-# end
-
-"""
     ScaledOrShiftedHamiltonian(H::AbstractHamiltonian, alpha, beta) <: ModifiedHamiltonian
     +(H::AbstractHamiltonian, shift::UniformScaling)
     add(shift::UniformScaling, H::AbstractHamiltonian, [alpha, beta])
@@ -326,9 +211,9 @@ function ScaledOrShiftedHamiltonian(
     h::AbstractHamiltonian{TH}, alpha::TA, beta::TB
 ) where {TH,TA<:Number,TB<:Number}
     T = promote_type(TA, TB, TH)
-    ScaledOrShiftedHamiltonian{T, TA, TB, typeof(h)}(h, alpha, beta)
+    return ScaledOrShiftedHamiltonian{T, TA, TB, typeof(h)}(h, alpha, beta)
 end
-ScaledOrShiftedHamiltonian(h, ::One, ::Zero) = h
+ScaledOrShiftedHamiltonian(h::AbstractHamiltonian, ::One, ::Zero) = h
 
 function ScaledOrShiftedHamiltonian(
     h::ScaledOrShiftedHamiltonian, alpha::Number, beta::Number
@@ -359,7 +244,7 @@ end
 
 function LOStructure(::Type{<:ScaledOrShiftedHamiltonian{T,TA,TB,H}}) where {T,TA,TB,H}
     if LOStructure(H) == IsHermitian()
-        if TA <: Real && TB <: Real
+        if (TA <: Real || TA <: One) && (TB <: Real || TB <: Zero)
             return IsHermitian()
         else
             return AdjointKnown()

--- a/src/Hamiltonians/Sum.jl
+++ b/src/Hamiltonians/Sum.jl
@@ -269,7 +269,7 @@ end
     add(shift::UniformScaling, H::AbstractHamiltonian, [alpha, beta])
     add(H::AbstractHamiltonian, shift::UniformScaling, [beta, alpha])
 
-Construct the linear combination ``alpha * H + beta * I`` where `I` is the identity
+Construct the linear combination `alpha * H + beta * I` where `I` is the identity
 operator represented by a `UniformScaling`. This is the public entry point for applying
 a scalar shift to a Hamiltonian while preserving the underlying modified-operator
 implementation.

--- a/src/Hamiltonians/Sum.jl
+++ b/src/Hamiltonians/Sum.jl
@@ -3,15 +3,16 @@
     add(A::AbstractHamiltonian, B::AbstractHamiltonian, [a=1, b=1]; weight=0.5) -> HamiltonianSum
     +(A::AbstractHamiltonian, B::AbstractHamiltonian)
 
-The sum of two [`AbstractHamiltonian`](@ref)s, ``A + B``. The two Hamiltonians must act 
+The sum of two [`AbstractHamiltonian`](@ref)s, ``A + B``. The two Hamiltonians must act
 on the same address space. The keyword argument `weight` affects random spawning
-with [`random_offdiagonal`](@ref) and determines the probability of random spawns 
+with [`random_offdiagonal`](@ref) and determines the probability of random spawns
 from `A`, with `1 - weight` the probability of spawning from `B`.
 
 If coefficients `a` and `b` are given, the Hamiltonians are scaled with [`ScaledHamiltonian`](@ref),
 to represent ``aA + bB``.
 
-See also [`ScaledHamiltonian`](@ref), [`HamiltonianProduct`](@ref), [`AbstractHamiltonian`](@ref).
+See also [`ShiftedHamiltonian`](@ref), [`ScaledHamiltonian`](@ref),
+[`HamiltonianProduct`](@ref), [`AbstractHamiltonian`](@ref).
 """
 struct HamiltonianSum{T, H1<:AbstractHamiltonian, H2<:AbstractHamiltonian} <: AbstractHamiltonian{T}
     h1::H1
@@ -150,4 +151,115 @@ function Base.iterate(o::SumOffdiagonals, state)
         (add, val), state = next2
         return add => val, (state, false)
     end
+end
+
+"""
+    ShiftedHamiltonian(h::AbstractHamiltonian, shift::Number) <: ModifiedHamiltonian
+    add(h::AbstractHamiltonian, shift::UniformScaling) -> ShiftedHamiltonian
+    h + shift * I
+
+A Hamiltonian that has been shifted by a scalar value. In combination with
+[`ScaledHamiltonian`](@ref), this can be used to represent a Hamiltonian of the form
+``αH + βI``. Composite Hamiltonians constructed in this way are efficient for usage with
+deterministic and stochastic operations.
+
+## Example
+```jldoctest
+julia> hamiltonian = HubbardRealSpace(BoseFS(1,1));
+
+julia> hamiltonian - 2I == ShiftedHamiltonian(hamiltonian, -2) == add(hamiltonian, -2I)
+true
+
+julia> Matrix(hamiltonian)
+3×3 Matrix{Float64}:
+  0.0      -2.82843  -2.82843
+ -2.82843   1.0       0.0
+ -2.82843   0.0       1.0
+
+julia> Matrix(hamiltonian - 2I)
+3×3 Matrix{Float64}:
+ -2.0      -2.82843  -2.82843
+ -2.82843  -1.0       0.0
+ -2.82843   0.0      -1.0
+
+julia> transition_operator  = I - im * 0.1 * hamiltonian
+(1.0 + 0.0im)I + (-0.0 - 0.1im) * HubbardRealSpace(
+  fs"|1 1⟩";
+  geometry = CubicGrid((2,), (true,)),
+  t = [1.0;;],
+  u = [1.0;;],
+)
+
+julia> Matrix(transition_operator)
+3×3 Matrix{ComplexF64}:
+ 1.0+0.0im       0.0+0.282843im  0.0+0.282843im
+ 0.0+0.282843im  1.0-0.1im       0.0+0.0im
+ 0.0+0.282843im  0.0+0.0im       1.0-0.1im
+```
+
+See also [`HamiltonianSum`](@ref), [`ScaledHamiltonian`](@ref),
+[`ModifiedHamiltonian`](@ref), and [`AbstractHamiltonian`](@ref).
+"""
+struct ShiftedHamiltonian{T<:Number,H} <: ModifiedHamiltonian{T}
+    hamiltonian::H
+    shift::T
+end
+
+function ShiftedHamiltonian(h::AbstractHamiltonian{T1}, shift::T2) where {T1,T2<:Number}
+    T = promote_type(T1,T2)
+    return ShiftedHamiltonian{T, typeof(h)}(h, T(shift))
+end
+
+function ShiftedHamiltonian(h::ShiftedHamiltonian, shift::Number)
+    return ShiftedHamiltonian(h.hamiltonian, h.shift + shift)
+end
+
+function Base.show(io::IO, s::ShiftedHamiltonian{T}) where {T}
+    if T <: Real
+        print(io, s.shift, "I + ", s.hamiltonian)
+    else
+        print(io, "(", s.shift, ")", "I + ", s.hamiltonian)
+    end
+end
+
+function LinearAlgebra.adjoint(s::ShiftedHamiltonian)
+    return ShiftedHamiltonian(s.hamiltonian', conj(s.shift))
+end
+
+function LOStructure(::Type{<:ShiftedHamiltonian{T,H}}) where {T,H}
+    if LOStructure(H) == IsHermitian()
+        if T <: Real
+            return IsHermitian()
+        else
+            return AdjointKnown()
+        end
+    else
+        return LOStructure(H)
+    end
+end
+
+parent_operator(s::ShiftedHamiltonian) = s.hamiltonian
+modify_diagonal(s::ShiftedHamiltonian, _, value) = value + s.shift
+modify_offdiagonal(s::ShiftedHamiltonian, _, addr, value) = addr => value
+
+@doc (@doc ShiftedHamiltonian)
+function VectorInterface.add(
+    h::AbstractHamiltonian, shift::UniformScaling{T}, alpha::Number, beta::Number
+) where {T<:Number}
+    return ShiftedHamiltonian(alpha * h, beta * shift.λ)
+end
+function VectorInterface.add(
+    shift::UniformScaling{T}, h::AbstractHamiltonian, alpha::Number, beta::Number
+) where {T<:Number}
+    return add(h, shift, beta, alpha)
+end
+
+@doc (@doc ShiftedHamiltonian)
+function Base.:+(h::AbstractHamiltonian, shift::UniformScaling{T}) where {T<:Number}
+    return ShiftedHamiltonian(h, shift.λ)
+end
+Base.:+(shift::UniformScaling{T}, h::AbstractHamiltonian) where {T<:Number} = h + shift
+Base.:-(h::AbstractHamiltonian, shift::UniformScaling{T}) where {T<:Number} = h + (-shift)
+function Base.:-(shift::UniformScaling{T}, h::AbstractHamiltonian) where {T<:Number}
+    scale(h, -1) + shift
 end

--- a/src/Hamiltonians/Sum.jl
+++ b/src/Hamiltonians/Sum.jl
@@ -8,11 +8,10 @@ on the same address space. The keyword argument `weight` affects random spawning
 with [`random_offdiagonal`](@ref) and determines the probability of random spawns
 from `A`, with `1 - weight` the probability of spawning from `B`.
 
-If coefficients `a` and `b` are given, the Hamiltonians are scaled with
-[`ScaledOrShiftedHamiltonian`](@ref), to represent ``aA + bB``.
+If coefficients `a` and `b` are given, the Hamiltonians are combined as
+``aA + bB`` with the same address compatibility checks as `A + B`.
 
-See also [`ScaledOrShiftedHamiltonian`](@ref), [`HamiltonianProduct`](@ref),
-[`AbstractHamiltonian`](@ref).
+See also [`HamiltonianProduct`](@ref), [`AbstractHamiltonian`](@ref).
 """
 struct HamiltonianSum{T, H1<:AbstractHamiltonian, H2<:AbstractHamiltonian} <: AbstractHamiltonian{T}
     h1::H1
@@ -197,6 +196,10 @@ julia> Matrix(3*H + 2*I)
  -8.48528   5.0       0.0
  -8.48528   0.0       5.0
 ```
+!!! warning "Warning"
+    The `ScaledOrShiftedHamiltonian` type is an implementation detail and may change in future
+    versions of Rimu. Use the public interface functions [`add`](@ref), [`+`](@ref), [`scale`](@ref),
+    and [`*`](@ref) to construct scaled and shifted Hamiltonians.
 
 See also [`HamiltonianSum`](@ref), [`HamiltonianProduct`](@ref),
 [`ModifiedHamiltonian`](@ref), and [`AbstractHamiltonian`](@ref).
@@ -262,7 +265,20 @@ function modify_offdiagonal(s::ScaledOrShiftedHamiltonian{T}, _, addr, value) wh
     return addr => T(s.alpha * value)
 end
 
-@doc (@doc ScaledOrShiftedHamiltonian)
+"""
+    add(shift::UniformScaling, H::AbstractHamiltonian, [alpha, beta])
+    add(H::AbstractHamiltonian, shift::UniformScaling, [beta, alpha])
+
+Construct the linear combination ``alpha * H + beta * I`` where `I` is the identity
+operator represented by a `UniformScaling`. This is the public entry point for applying
+a scalar shift to a Hamiltonian while preserving the underlying modified-operator
+implementation.
+
+The coefficient order matches the `add(y, x, α, β)` convention used throughout
+`VectorInterface`.
+
+See also [`+`](@ref), [`scale`](@ref), [`*`](@ref), and [`HamiltonianSum`](@ref).
+"""
 function VectorInterface.add(
     shift::UniformScaling{T}, h::AbstractHamiltonian, alpha::Number, beta::Number
 ) where {T<:Number}
@@ -274,7 +290,14 @@ function VectorInterface.add(
     return add(shift, h, alpha, beta)
 end
 
-@doc (@doc ScaledOrShiftedHamiltonian)
+"""
+    +(H::AbstractHamiltonian, shift::UniformScaling)
+
+Return a Hamiltonian shifted by a scalar multiple of the identity operator.
+This is equivalent to `H + shift.λ * I` and returns a modified Hamiltonian wrapper.
+
+See also [`add`](@ref), [`scale`](@ref), [`*`](@ref).
+"""
 function Base.:+(h::AbstractHamiltonian, shift::UniformScaling{T}) where {T<:Number}
     return ScaledOrShiftedHamiltonian(h, One(), shift.λ)
 end
@@ -286,10 +309,24 @@ function Base.:-(shift::UniformScaling{T}, h::AbstractHamiltonian) where {T<:Num
 end
 Base.:-(h::AbstractHamiltonian) = ScaledOrShiftedHamiltonian(h, -1, Zero())
 
-@doc (@doc ScaledOrShiftedHamiltonian)
+"""
+    scale(H::AbstractHamiltonian, alpha)
+
+Return the scalar multiple `alpha * H` as a modified Hamiltonian wrapper.
+This is the canonical helper for scaling Hamiltonians by a numeric factor.
+
+See also [`add`](@ref), [`+`](@ref), [`*`](@ref).
+"""
 function VectorInterface.scale(h::AbstractHamiltonian, alpha::T) where {T<:Number}
     return ScaledOrShiftedHamiltonian(h, alpha, Zero())
 end
 
-@doc (@doc ScaledOrShiftedHamiltonian)
+"""
+    *(alpha::Number, H::AbstractHamiltonian)
+
+Return the scalar multiple `alpha * H`.
+This is an alias for [`scale`](@ref).
+
+See also [`add`](@ref), [`+`](@ref), [`scale`](@ref).
+"""
 Base.:*(alpha::Number, h::AbstractHamiltonian) = scale(h, alpha)

--- a/src/Hamiltonians/Sum.jl
+++ b/src/Hamiltonians/Sum.jl
@@ -197,9 +197,9 @@ julia> Matrix(3*H + 2*I)
  -8.48528   0.0       5.0
 ```
 !!! warning "Warning"
-    The `ScaledOrShiftedHamiltonian` type is an implementation detail and may change in future
-    versions of Rimu. Use the public interface functions [`add`](@ref), [`+`](@ref), [`scale`](@ref),
-    and [`*`](@ref) to construct scaled and shifted Hamiltonians.
+    The `ScaledOrShiftedHamiltonian` type is an implementation detail and may change in
+    future versions of Rimu. Use the public interface functions [`add`](@ref), [`+`](@ref)
+    and [`scale`](@ref) to construct scaled and shifted Hamiltonians.
 
 See also [`HamiltonianSum`](@ref), [`HamiltonianProduct`](@ref),
 [`ModifiedHamiltonian`](@ref), and [`AbstractHamiltonian`](@ref).
@@ -270,14 +270,14 @@ end
     add(H::AbstractHamiltonian, shift::UniformScaling, [beta, alpha])
 
 Construct the linear combination `alpha * H + beta * I` where `I` is the identity
-operator represented by a `UniformScaling`. This is the public entry point for applying
-a scalar shift to a Hamiltonian while preserving the underlying modified-operator
-implementation.
+operator represented by a `UniformScaling`. This returns a modified operator representing
+the Hamiltonian with all matrix elements scaled by `alpha` and all diagonal elements shifted
+by `beta`. The coefficients `alpha` and `beta` default to `One()` if not specified.
 
 The coefficient order matches the `add(y, x, α, β)` convention used throughout
 `VectorInterface`.
 
-See also [`+`](@ref), [`scale`](@ref), [`*`](@ref), and [`HamiltonianSum`](@ref).
+See also [`+`](@ref), [`scale`](@ref), and [`HamiltonianSum`](@ref).
 """
 function VectorInterface.add(
     shift::UniformScaling{T}, h::AbstractHamiltonian, alpha::Number, beta::Number
@@ -292,11 +292,13 @@ end
 
 """
     +(H::AbstractHamiltonian, shift::UniformScaling)
+    H + beta * I
 
-Return a Hamiltonian shifted by a scalar multiple of the identity operator.
-This is equivalent to `H + shift.λ * I` and returns a modified Hamiltonian wrapper.
+Return a modified Hamiltonian where all diagonal elements are uniformly shifted by a scalar
+`beta`. Use the identity operator `I` from `LinearAlgebra` to construct the shift.
+The resulting Hamiltonian is equivalent to `add(H, beta * I)`.
 
-See also [`add`](@ref), [`scale`](@ref), [`*`](@ref).
+See also [`add`](@ref), [`scale`](@ref).
 """
 function Base.:+(h::AbstractHamiltonian, shift::UniformScaling{T}) where {T<:Number}
     return ScaledOrShiftedHamiltonian(h, One(), shift.λ)
@@ -311,22 +313,16 @@ Base.:-(h::AbstractHamiltonian) = ScaledOrShiftedHamiltonian(h, -1, Zero())
 
 """
     scale(H::AbstractHamiltonian, alpha)
+    *(alpha::Number, H::AbstractHamiltonian)
 
 Return the scalar multiple `alpha * H` as a modified Hamiltonian wrapper.
-This is the canonical helper for scaling Hamiltonians by a numeric factor.
+All matrix elements are scaled by the factor `alpha`.
 
-See also [`add`](@ref), [`+`](@ref), [`*`](@ref).
+See also [`add`](@ref), [`+`](@ref).
 """
 function VectorInterface.scale(h::AbstractHamiltonian, alpha::T) where {T<:Number}
     return ScaledOrShiftedHamiltonian(h, alpha, Zero())
 end
 
-"""
-    *(alpha::Number, H::AbstractHamiltonian)
-
-Return the scalar multiple `alpha * H`.
-This is an alias for [`scale`](@ref).
-
-See also [`add`](@ref), [`+`](@ref), [`scale`](@ref).
-"""
+@doc (@doc scale)
 Base.:*(alpha::Number, h::AbstractHamiltonian) = scale(h, alpha)

--- a/src/fciqmc.jl
+++ b/src/fciqmc.jl
@@ -61,52 +61,6 @@ function _determine_initial_shift(hamiltonian, starting_vectors)
 end
 
 """
-    FirstOrderTransitionOperator(hamiltonian, shift, time_step) <: AbstractHamiltonian
-    FirstOrderTransitionOperator(sp::DefaultShiftParameters, hamiltonian)
-
-First order transition operator
-```math
-𝐓 = 1 + dτ(S - 𝐇)
-```
-where ``𝐇`` is the `hamiltonian`, ``dτ`` the `time_step` and ``S`` is the `shift`.
-
-``𝐓`` represents the first order expansion of the exponential evolution operator
-of the imaginary-time Schrödinger equation (Euler step) and repeated application
-will project out the ground state eigenvector of the `hamiltonian`.  It is the
-transition operator used in [`FCIQMC`](@ref).
-"""
-struct FirstOrderTransitionOperator{
-    T,S,H<:AbstractHamiltonian{T}
-} <: Hamiltonians.ModifiedHamiltonian{T}
-    hamiltonian::H
-    shift::S
-    time_step::Float64
-end
-function FirstOrderTransitionOperator(hamiltonian::H, shift::S, time_step) where {H,S}
-    T = eltype(H)
-    return FirstOrderTransitionOperator{T,S,H}(hamiltonian, shift, Float64(time_step))
-end
-function FirstOrderTransitionOperator(sp::DefaultShiftParameters, hamiltonian)
-    return FirstOrderTransitionOperator(hamiltonian, sp.shift, sp.time_step)
-end
-
-function Hamiltonians.parent_operator(op::FirstOrderTransitionOperator)
-    return op.hamiltonian
-end
-function Hamiltonians.modify_offdiagonal(op::FirstOrderTransitionOperator, _, addr, value)
-    return addr => -op.time_step * value
-end
-function Hamiltonians.modify_diagonal(op::FirstOrderTransitionOperator, _, value)
-    return 1 - op.time_step * (value - op.shift)
-end
-function Hamiltonians.LOStructure(op::FirstOrderTransitionOperator)
-    return LOStructure(op.hamiltonian)
-end
-function Base.adjoint(op::FirstOrderTransitionOperator)
-    return FirstOrderTransitionOperator(adjoint(op.hamiltonian), op.shift, op.time_step)
-end
-
-"""
     advance!(algorithm::PMCAlgorithm, report::Report, state::ReplicaState, s_state::SingleState)
 
 Advance the `s_state` by one step according to the `algorithm`. The `state` is used only to
@@ -128,7 +82,7 @@ function advance!(algorithm::FCIQMC, report, state::ReplicaState, s_state::Singl
 
     ### PROPAGATOR ACTS
     ### FROM HERE
-    transition_op = FirstOrderTransitionOperator(shift_parameters, hamiltonian)
+    transition_op = I + time_step * (shift*I - hamiltonian)
 
     # Step
     step_stat_names, step_stat_values, wm, pv = apply_operator!(wm, pv, v, transition_op)

--- a/src/strategies_and_params/poststepstrategy.jl
+++ b/src/strategies_and_params/poststepstrategy.jl
@@ -153,7 +153,7 @@ function coherence(::Type{<:Complex}, reference, vector)
             Int(!iszero(ref))
         )
     end
-    return iszero(overlap) ? 0.0 : accumulator / overlap
+    return iszero(overlap) ? 0.0 + 0im : accumulator / overlap
 end
 
 """

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -73,7 +73,7 @@ end
         FroehlichPolaron(BoseFS{missing}(1, 1, 1)),
         FroehlichPolaron(BoseFS{missing}(1, 1, 1); momentum_cutoff=10.0),
         momentum(HubbardMom1D(BoseFS(0, 1, 5, 1, 0))),
-        Rimu.FirstOrderTransitionOperator(HubbardRealSpace(BoseFS(1,1,1,1)), -5.0, 0.01),
+        I + 0.01 * (-5.0 * HubbardRealSpace(BoseFS(1,1,1,1))), # FCIQMC transition operator
         # HamiltonianProduct
         HubbardReal1D(BoseFS(2,0,0); u=1.0im) * ExtendedHubbardReal1D(BoseFS(2,0,0)),
         # HamiltonianSum

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -1962,9 +1962,9 @@ end
         @test Matrix(H - 2I, basis) ≈ Matrix(H, basis) - 2I
         @test Matrix(H + 3I, basis) ≈ Matrix(H, basis) + 3I
 
-        # `add` should construct alpha * H + beta * I via ShiftedHamiltonian.
-        @test add(H, 2I, 3, -4) == ShiftedHamiltonian(3 * H, -8)
-        @test add(2I, H, -4, 3) == ShiftedHamiltonian(3 * H, -8)
+        # `add` should construct beta * H + alpha * I via ShiftedHamiltonian.
+        @test add(H, 2I, -4, 3) == ShiftedHamiltonian(3 * H, -8)
+        @test add(2I, H, 3, -4) == ShiftedHamiltonian(3 * H, -8)
     end
 
     @testset "structure and adjoint" begin

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -82,7 +82,10 @@ end
         2 * HubbardReal1D(BoseFS(2, 0, 0)), # ScaledOrShiftedHamiltonian with real factor
         HubbardReal1D(BoseFS(2, 0, 0); u=1.0im) + 2I, # ScaledOrShiftedHamiltonian
         2 * (HubbardReal1D(BoseFS(2, 0, 0)) + 3.0I), # scaled and shifted
-    ]
+        3.0I - HubbardReal1D(BoseFS(2, 0, 0)), # subtract a Hamiltonian
+        - HubbardReal1D(BoseFS(2, 0, 0)), # unary minus
+        (2 + 2im) * (HubbardReal1D(BoseFS(2, 0, 0)) + (3.0 + 1.0im)I), # complex
+        ]
         test_hamiltonian_interface(H)
         # Check that the result of show can be pasted into the REPL. Does not work with
         # GuidingVectorSampling because it includes a DVec.

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -78,8 +78,10 @@ end
         HubbardReal1D(BoseFS(2,0,0); u=1.0im) * ExtendedHubbardReal1D(BoseFS(2,0,0)),
         # HamiltonianProduct
         HubbardReal1D(BoseFS(2,0,0); u=1.0im) + ExtendedHubbardReal1D(BoseFS(2,0,0)),
-        2*HubbardReal1D(BoseFS(2,0,0); u=1.0im), # ScaledHamiltonian
-        HubbardReal1D(BoseFS(2, 0, 0); u=1.0im) + 2I # ShiftedHamiltonian
+        2 * HubbardReal1D(BoseFS(2,0,0); u=1.0im), # ScaledHamiltonian
+        2 * HubbardReal1D(BoseFS(2, 0, 0)), # ScaledHamiltonian with real factor
+        HubbardReal1D(BoseFS(2, 0, 0); u=1.0im) + 2I, # ShiftedHamiltonian
+        2 * (HubbardReal1D(BoseFS(2, 0, 0)) + 3.0I), # scaled and shifted
     ]
         test_hamiltonian_interface(H)
         # Check that the result of show can be pasted into the REPL. Does not work with

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -74,9 +74,12 @@ end
         FroehlichPolaron(BoseFS{missing}(1, 1, 1); momentum_cutoff=10.0),
         momentum(HubbardMom1D(BoseFS(0, 1, 5, 1, 0))),
         Rimu.FirstOrderTransitionOperator(HubbardRealSpace(BoseFS(1,1,1,1)), -5.0, 0.01),
+        # HamiltonianProduct
         HubbardReal1D(BoseFS(2,0,0); u=1.0im) * ExtendedHubbardReal1D(BoseFS(2,0,0)),
+        # HamiltonianProduct
         HubbardReal1D(BoseFS(2,0,0); u=1.0im) + ExtendedHubbardReal1D(BoseFS(2,0,0)),
-        2*HubbardReal1D(BoseFS(2,0,0); u=1.0im)
+        2*HubbardReal1D(BoseFS(2,0,0); u=1.0im), # ScaledHamiltonian
+        HubbardReal1D(BoseFS(2, 0, 0); u=1.0im) + 2I # ShiftedHamiltonian
     ]
         test_hamiltonian_interface(H)
         # Check that the result of show can be pasted into the REPL. Does not work with
@@ -1939,6 +1942,51 @@ end
     addr = FermiFS(1,0,0)
     H4 = HubbardReal1D(addr)
     @test_throws ArgumentError H1 + H4
+end
+
+@testset "ShiftedHamiltonian" begin
+    addr = BoseFS(1,1)
+    H = HubbardRealSpace(addr)
+    basis = build_basis(addr)
+
+    @testset "construction and arithmetic" begin
+        S = ShiftedHamiltonian(H, -2)
+        @test S.shift === -2.0
+        @test parent_operator(S) == H
+
+        # `h +/- I` should dispatch to ShiftedHamiltonian and preserve matrix action.
+        @test H - 2I == ShiftedHamiltonian(H, -2)
+        @test H + 3I == ShiftedHamiltonian(H, 3)
+        @test Matrix(H - 2I, basis) ≈ Matrix(H, basis) - 2I
+        @test Matrix(H + 3I, basis) ≈ Matrix(H, basis) + 3I
+
+        # `add` should construct alpha * H + beta * I via ShiftedHamiltonian.
+        @test add(H, 2I, 3, -4) == ShiftedHamiltonian(3 * H, -8)
+        @test add(2I, H, -4, 3) == ShiftedHamiltonian(3 * H, -8)
+    end
+
+    @testset "structure and adjoint" begin
+        Sreal = ShiftedHamiltonian(H, -1.5)
+        Scomplex = ShiftedHamiltonian(H, 1im)
+        @test LOStructure(Sreal) == IsHermitian()
+        @test LOStructure(Scomplex) == AdjointKnown()
+
+        Sadj = Scomplex'
+        @test Sadj == ShiftedHamiltonian(H', -1im)
+        @test Matrix(Sadj, basis) ≈ Matrix(Scomplex, basis)'
+
+        # If base structure is not Hermitian, shifting should preserve base structure.
+        Hnh = HubbardReal1D(BoseFS(1,2,3,4); u=1.0im)
+        @test LOStructure(ShiftedHamiltonian(Hnh, 2.0)) == LOStructure(Hnh)
+    end
+
+    @testset "nested shifts and repr" begin
+        S0 = ShiftedHamiltonian(H, -2)
+        S1 = ShiftedHamiltonian(S0, 5)
+        @test S1 == ShiftedHamiltonian(H, 3)
+        @test Matrix(S1, basis) ≈ Matrix(H, basis) + 3I
+        @test eval(Meta.parse(repr(S1))) == S1
+    end
 end
 
 @testset "Operator Traits" begin

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -76,7 +76,7 @@ end
         Rimu.FirstOrderTransitionOperator(HubbardRealSpace(BoseFS(1,1,1,1)), -5.0, 0.01),
         # HamiltonianProduct
         HubbardReal1D(BoseFS(2,0,0); u=1.0im) * ExtendedHubbardReal1D(BoseFS(2,0,0)),
-        # HamiltonianProduct
+        # HamiltonianSum
         HubbardReal1D(BoseFS(2,0,0); u=1.0im) + ExtendedHubbardReal1D(BoseFS(2,0,0)),
         2 * HubbardReal1D(BoseFS(2,0,0); u=1.0im), # ScaledHamiltonian
         2 * HubbardReal1D(BoseFS(2, 0, 0)), # ScaledHamiltonian with real factor

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -73,13 +73,14 @@ end
         FroehlichPolaron(BoseFS{missing}(1, 1, 1)),
         FroehlichPolaron(BoseFS{missing}(1, 1, 1); momentum_cutoff=10.0),
         momentum(HubbardMom1D(BoseFS(0, 1, 5, 1, 0))),
-        I + 0.01 * (-5.0 * HubbardRealSpace(BoseFS(1,1,1,1))), # FCIQMC transition operator
         # HamiltonianProduct
         HubbardReal1D(BoseFS(2,0,0); u=1.0im) * ExtendedHubbardReal1D(BoseFS(2,0,0)),
         # HamiltonianSum
         HubbardReal1D(BoseFS(2,0,0); u=1.0im) + ExtendedHubbardReal1D(BoseFS(2,0,0)),
-        2 * HubbardReal1D(BoseFS(2, 0, 0); u=1.0im), # ScaledOrShiftedHamiltonian
-        2 * HubbardReal1D(BoseFS(2, 0, 0)), # ScaledOrShiftedHamiltonian with real factor
+        # FCIQMC transition operator
+        (@inferred I + 0.01 * (-5.0*I + HubbardRealSpace(BoseFS(1,1,1,1)))),
+        2 * HubbardReal1D(BoseFS(2, 0, 0); u=1.0im), # scale
+        2 * HubbardReal1D(BoseFS(2, 0, 0)), # scale with real factor
         HubbardReal1D(BoseFS(2, 0, 0); u=1.0im) + 2I, # ScaledOrShiftedHamiltonian
         2 * (HubbardReal1D(BoseFS(2, 0, 0)) + 3.0I), # scaled and shifted
         3.0I - HubbardReal1D(BoseFS(2, 0, 0)), # subtract a Hamiltonian
@@ -1894,7 +1895,7 @@ end
         basis = build_basis(addr)
         H = HubbardReal1D(addr)
 
-        H1 = 2*H
+        H1 = @inferred 2*H
         @test Matrix(H1) == 2*Matrix(H)
         @test LOStructure(H1) == LOStructure(H)
         H1_twice = 2 * H1
@@ -1958,29 +1959,26 @@ end
     H = HubbardRealSpace(addr)
     basis = build_basis(addr)
 
-    @test !isdefined(Rimu.Hamiltonians, :ScaledHamiltonian)
-    @test !isdefined(Rimu.Hamiltonians, :ShiftedHamiltonian)
-
     @testset "construction and arithmetic" begin
         S = ScaledOrShiftedHamiltonian(H, 2, -3)
         @test S.alpha == 2
         @test S.beta == -3
         @test parent_operator(S) == H
 
-        Sidentity = ScaledOrShiftedHamiltonian(H, 1, 0)
+        Sidentity = @inferred ScaledOrShiftedHamiltonian(H, 1, 0)
         @test Sidentity isa ScaledOrShiftedHamiltonian
         @test Sidentity.alpha == 1
         @test Sidentity.beta == 0
         @test Matrix(Sidentity, basis) ≈ Matrix(H, basis)
 
-        @test H - 2I == ScaledOrShiftedHamiltonian(H, One(), -2)
-        @test H + 3I == ScaledOrShiftedHamiltonian(H, One(), 3)
+        @test (@inferred H - 2I) == ScaledOrShiftedHamiltonian(H, One(), -2)
+        @test (@inferred H + 3I) == ScaledOrShiftedHamiltonian(H, One(), 3)
         @test 2 * H == ScaledOrShiftedHamiltonian(H, 2, Zero())
         @test Matrix(H - 2I, basis) ≈ Matrix(H, basis) - 2I
         @test Matrix(2 * H + 3I, basis) ≈ 2 * Matrix(H, basis) + 3I
 
-        @test add(H, 2I, -4, 3) == ScaledOrShiftedHamiltonian(H, 3, -8)
-        @test add(2I, H, 3, -4) == ScaledOrShiftedHamiltonian(H, 3, -8)
+        @test (@inferred add(H, 2I, -4, 3)) == ScaledOrShiftedHamiltonian(H, 3, -8)
+        @test (@inferred add(2I, H, 3, -4)) == ScaledOrShiftedHamiltonian(H, 3, -8)
     end
 
     @testset "structure and adjoint" begin

--- a/test/Hamiltonians.jl
+++ b/test/Hamiltonians.jl
@@ -6,7 +6,7 @@ using Test
 using DataFrames
 using Suppressor
 using StaticArrays
-using Rimu.Hamiltonians: TransformUndoer, AbstractOffdiagonals
+using Rimu.Hamiltonians: TransformUndoer, AbstractOffdiagonals, ScaledOrShiftedHamiltonian
 using Rimu.InterfaceTests: test_observable_interface, test_operator_interface,
     test_hamiltonian_interface, test_hamiltonian_structure
 using Rimu.Interfaces: LOStructure, IsHermitian, IsDiagonal, AdjointKnown,
@@ -78,9 +78,9 @@ end
         HubbardReal1D(BoseFS(2,0,0); u=1.0im) * ExtendedHubbardReal1D(BoseFS(2,0,0)),
         # HamiltonianSum
         HubbardReal1D(BoseFS(2,0,0); u=1.0im) + ExtendedHubbardReal1D(BoseFS(2,0,0)),
-        2 * HubbardReal1D(BoseFS(2,0,0); u=1.0im), # ScaledHamiltonian
-        2 * HubbardReal1D(BoseFS(2, 0, 0)), # ScaledHamiltonian with real factor
-        HubbardReal1D(BoseFS(2, 0, 0); u=1.0im) + 2I, # ShiftedHamiltonian
+        2 * HubbardReal1D(BoseFS(2, 0, 0); u=1.0im), # ScaledOrShiftedHamiltonian
+        2 * HubbardReal1D(BoseFS(2, 0, 0)), # ScaledOrShiftedHamiltonian with real factor
+        HubbardReal1D(BoseFS(2, 0, 0); u=1.0im) + 2I, # ScaledOrShiftedHamiltonian
         2 * (HubbardReal1D(BoseFS(2, 0, 0)) + 3.0I), # scaled and shifted
     ]
         test_hamiltonian_interface(H)
@@ -1886,7 +1886,7 @@ end
     c = operator_column(P, addr)
     @test iszero(last.(collect(offdiagonals(c))))
 
-    @testset "ScaledHamiltonian" begin
+    @testset "ScaledOrShifted scaling" begin
         addr = BoseFS(2,0,0)
         basis = build_basis(addr)
         H = HubbardReal1D(addr)
@@ -1894,8 +1894,12 @@ end
         H1 = 2*H
         @test Matrix(H1) == 2*Matrix(H)
         @test LOStructure(H1) == LOStructure(H)
-        @test 2*H1 == 4*H
-        @test 1*H1 == H1
+        H1_twice = 2 * H1
+        @test H1_twice isa ScaledOrShiftedHamiltonian
+        @test Matrix(H1_twice, basis) ≈ 4 * Matrix(H, basis)
+        H1_same = 1 * H1
+        @test H1_same isa ScaledOrShiftedHamiltonian
+        @test Matrix(H1_same, basis) ≈ Matrix(H1, basis)
 
         H2 = 3im*H
         @test Matrix(H2) == 3im*Matrix(H)
@@ -1946,48 +1950,63 @@ end
     @test_throws ArgumentError H1 + H4
 end
 
-@testset "ShiftedHamiltonian" begin
+@testset "ScaledOrShiftedHamiltonian" begin
     addr = BoseFS(1,1)
     H = HubbardRealSpace(addr)
     basis = build_basis(addr)
 
+    @test !isdefined(Rimu.Hamiltonians, :ScaledHamiltonian)
+    @test !isdefined(Rimu.Hamiltonians, :ShiftedHamiltonian)
+
     @testset "construction and arithmetic" begin
-        S = ShiftedHamiltonian(H, -2)
-        @test S.shift === -2.0
+        S = ScaledOrShiftedHamiltonian(H, 2, -3)
+        @test S.alpha == 2
+        @test S.beta == -3
         @test parent_operator(S) == H
 
-        # `h +/- I` should dispatch to ShiftedHamiltonian and preserve matrix action.
-        @test H - 2I == ShiftedHamiltonian(H, -2)
-        @test H + 3I == ShiftedHamiltonian(H, 3)
-        @test Matrix(H - 2I, basis) ≈ Matrix(H, basis) - 2I
-        @test Matrix(H + 3I, basis) ≈ Matrix(H, basis) + 3I
+        Sidentity = ScaledOrShiftedHamiltonian(H, 1, 0)
+        @test Sidentity isa ScaledOrShiftedHamiltonian
+        @test Sidentity.alpha == 1
+        @test Sidentity.beta == 0
+        @test Matrix(Sidentity, basis) ≈ Matrix(H, basis)
 
-        # `add` should construct beta * H + alpha * I via ShiftedHamiltonian.
-        @test add(H, 2I, -4, 3) == ShiftedHamiltonian(3 * H, -8)
-        @test add(2I, H, 3, -4) == ShiftedHamiltonian(3 * H, -8)
+        @test H - 2I == ScaledOrShiftedHamiltonian(H, One(), -2)
+        @test H + 3I == ScaledOrShiftedHamiltonian(H, One(), 3)
+        @test 2 * H == ScaledOrShiftedHamiltonian(H, 2, Zero())
+        @test Matrix(H - 2I, basis) ≈ Matrix(H, basis) - 2I
+        @test Matrix(2 * H + 3I, basis) ≈ 2 * Matrix(H, basis) + 3I
+
+        @test add(H, 2I, -4, 3) == ScaledOrShiftedHamiltonian(H, 3, -8)
+        @test add(2I, H, 3, -4) == ScaledOrShiftedHamiltonian(H, 3, -8)
     end
 
     @testset "structure and adjoint" begin
-        Sreal = ShiftedHamiltonian(H, -1.5)
-        Scomplex = ShiftedHamiltonian(H, 1im)
+        Sreal = ScaledOrShiftedHamiltonian(H, 2.5, -1.5)
+        Scomplex = ScaledOrShiftedHamiltonian(H, 1im, 2.0)
         @test LOStructure(Sreal) == IsHermitian()
         @test LOStructure(Scomplex) == AdjointKnown()
 
         Sadj = Scomplex'
-        @test Sadj == ShiftedHamiltonian(H', -1im)
+        @test Sadj == ScaledOrShiftedHamiltonian(H', -1im, 2.0)
         @test Matrix(Sadj, basis) ≈ Matrix(Scomplex, basis)'
 
-        # If base structure is not Hermitian, shifting should preserve base structure.
         Hnh = HubbardReal1D(BoseFS(1,2,3,4); u=1.0im)
-        @test LOStructure(ShiftedHamiltonian(Hnh, 2.0)) == LOStructure(Hnh)
+        @test LOStructure(ScaledOrShiftedHamiltonian(Hnh, 2.0, 1.0)) == LOStructure(Hnh)
     end
 
-    @testset "nested shifts and repr" begin
-        S0 = ShiftedHamiltonian(H, -2)
-        S1 = ShiftedHamiltonian(S0, 5)
-        @test S1 == ShiftedHamiltonian(H, 3)
-        @test Matrix(S1, basis) ≈ Matrix(H, basis) + 3I
+    @testset "nested composition and repr" begin
+        S0 = ScaledOrShiftedHamiltonian(H, 2, -1) # 2H - I
+        S1 = ScaledOrShiftedHamiltonian(S0, -1, 3) # -(2H - I) + 3 = -2H + 4I
+        @test S1 == ScaledOrShiftedHamiltonian(H, -2, 4)
+        @test Matrix(S1, basis) ≈ -2 * Matrix(H, basis) + 4I
         @test eval(Meta.parse(repr(S1))) == S1
+
+        Sidentity = ScaledOrShiftedHamiltonian(H, 1, 0)
+        Snoop = ScaledOrShiftedHamiltonian(Sidentity, 1, 0)
+        @test Snoop isa ScaledOrShiftedHamiltonian
+        @test Snoop == Sidentity
+        @test eval(Meta.parse(repr(Snoop))) == Snoop
+        @test ScaledOrShiftedHamiltonian(H, One(), Zero()) == H
     end
 end
 

--- a/test/StochasticStyles.jl
+++ b/test/StochasticStyles.jl
@@ -99,6 +99,7 @@ end
     end
 end
 
+transition_op(H, shift, time_step) = I + time_step * (shift*I - H)
 @testset "diagonal_step!" begin
     add = BoseFS((1,1,1))
     H = HubbardReal1D(add)
@@ -111,7 +112,7 @@ end
         # clones
         for _ in 1:20
             dv = DVec(add => 0)
-            T = Rimu.FirstOrderTransitionOperator(H, 10, 0.5)
+            T = transition_op(H, 10, 0.5)
             st = diagonal_step!(dv, operator_column(T, BoseFS((2,0,1))), 1, 0)
             @test st[1] == 4 || st[1] == 5
             @test dv[BoseFS((2,0,1))] == st[1] + 1 # original value + clones
@@ -119,7 +120,7 @@ end
         # deaths
         for _ in 1:20
             dv = DVec(BoseFS((2,0,1)) => 0)
-            T = Rimu.FirstOrderTransitionOperator(H, -1.0, 0.125)
+            T = transition_op(H, -1.0, 0.125)
             st = diagonal_step!(dv, operator_column(T, BoseFS((2,0,1))), 2, 0)
             @test st[2] == 0 || st[2] == 1
             @test dv[BoseFS((2,0,1))] == 2 - st[2] # original value - deaths
@@ -127,7 +128,7 @@ end
         # zombies
         for _ in 1:20
             dv = DVec(BoseFS((2,0,1)) => 0)
-            T = Rimu.FirstOrderTransitionOperator(H, -10, 0.5)
+            T = transition_op(H, -10, 0.5)
             st = diagonal_step!(dv, operator_column(T, BoseFS((2,0,1))), 1, 0)
             @test st[2] == 1
             @test st[3] == 4 || st[3] == 5
@@ -137,24 +138,24 @@ end
     @testset "Exact" begin
         # nothing happens - one annihilation
         dv = DVec(add => -1.0)
-        T = Rimu.FirstOrderTransitionOperator(H, 0, 1)
+        T = transition_op(H, 0, 1)
         @test diagonal_step!(dv, operator_column(T, add), 1.0, 0) == (0, 0, 0)
         @test dv[add] == 0
         # clones
         dv = DVec(add => 0.0)
-        T = Rimu.FirstOrderTransitionOperator(H, 10, 1)
+        T = transition_op(H, 10, 1)
         st = diagonal_step!(dv, operator_column(T, BoseFS((2,0,1))), 2.5, 0)
         @test st[1] == 22.5
         @test dv[BoseFS((2,0,1))] == 25.0
         # deaths
         dv = DVec(add => 0.0)
-        T = Rimu.FirstOrderTransitionOperator(H, -0.5, 0.5)
+        T = transition_op(H, -0.5, 0.5)
         st = diagonal_step!(dv, operator_column(T, BoseFS((2,0,1))), 1.0, 0)
         @test st[2] == 0.75
         @test dv[BoseFS((2,0,1))] == 0.25
         # zombies
         dv = DVec(add => 0.0)
-        T = Rimu.FirstOrderTransitionOperator(H, -10, 0.5)
+        T = transition_op(H, -10, 0.5)
         st = diagonal_step!(dv, operator_column(T, BoseFS((2,0,1))), 1.0, 0)
         @test st[2] == 1
         @test st[3] == 4.5
@@ -171,21 +172,21 @@ end
 
         # clones - above projection threshold
         dv = DVec(add => 0.0)
-        T = Rimu.FirstOrderTransitionOperator(H, 10, 0.5)
+        T = transition_op(H, 10, 0.5)
         st = diagonal_step!(dv, operator_column(T, BoseFS((2,0,1))), 1, 1)
         @test st[1] == 4.5
         @test dv[BoseFS((2,0,1))] == 5.5
         # deaths - below threshold
         for _ in 1:20
             dv = DVec(add => 0.0)
-            T = Rimu.FirstOrderTransitionOperator(H, -0.5, 0.5)
+            T = transition_op(H, -0.5, 0.5)
             st = diagonal_step!(dv, operator_column(T, BoseFS((2,0,1))), 1.0, 1)
             @test st[2] == 0.0 || st[2] == 1.0
             @test dv[BoseFS((2,0,1))] == 1 - st[2]
         end
         # zombies
         dv = DVec(add => 0.0)
-        T = Rimu.FirstOrderTransitionOperator(H, -10, 0.5)
+        T = transition_op(H, -10, 0.5)
         st = diagonal_step!(dv, operator_column(T, BoseFS((2,0,1))), 1, 1)
         @test st[2] == 1
         @test st[3] == 4.5

--- a/test/allocation_tests.jl
+++ b/test/allocation_tests.jl
@@ -10,7 +10,9 @@ using BenchmarkTools
 Returning the vectors is tracked as an allocation. This wrapper takes care of that.
 """
 function apply_operator_wrap!(r::SingleState)
-    transition = Rimu.FirstOrderTransitionOperator(r.shift_parameters, r.hamiltonian)
+    time_step = r.shift_parameters.time_step
+    shift = r.shift_parameters.shift
+    transition = I + time_step * (shift * I - r.hamiltonian)
     apply_operator!(r.wm, r.pv, r.v, transition)
     return nothing
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -101,4 +101,4 @@ end
     include("KrylovKit.jl")
 end
 
-# Note: Running Rimu with several MPI ranks is tested seperately on GitHub CI and not here.
+# Note: Running Rimu with several MPI ranks is tested separately on GitHub CI and not here.

--- a/test/strategies.jl
+++ b/test/strategies.jl
@@ -209,6 +209,11 @@ end
         @test all(-1.0 .≤ df.coherence .≤ 1.0)
         @test all(in.(df.single_coherence, Ref((-1, 0, 1))))
 
+        # test type stability of `coherence` with complex vectors
+        v1 = rand(ComplexF64, 10) .- (0.5 + 0.5im)
+        v2 = rand(ComplexF64, 10) .- (0.5 + 0.5im)
+        @inferred Rimu.coherence(ComplexF64, v1, v2)
+
         cdv = DVec(address => 1 + im; style=StochasticStyles.IsStochastic2Pop())
         shift = float(valtype(cdv))(diagonal_element(H*address)) # need complex shift
         df = solve(ProjectorMonteCarloProblem(H; start_at=cdv, shift, post_step_strategy)).df


### PR DESCRIPTION
Adding a new private type `ScaledOrShiftedHamiltonian` allows the efficient shifting of operators by scalar values in addition to scaling and thus enables generating transition operators on the fly.

## New features
- Shifting and scaling and `AbstractHamiltonian` is now possible with through efficient wrapper type based on `ModifiedHamiltonian`. The wrapper is private but access is provided through public interface functions `add`, `scale`, `*`, `+`, and `-`.
- `VectorInterface.add` and `Base.+` and `Base.-` are overloaded to allow adding `AbstractHamiltonian`s with `UniformScaling` operators.

## Changed behaviour
- `ModifiedHamiltonian` is now exported.
- `Rimu.FirstOrderTransitionOperator` is removed and replaced by on-the-fly generation of a `ScaledOrShiftedHamiltonian` wrapper.

## Breaking changes
- `ScaledHamiltonian` is removed as it is no longer needed. Scaling of Hamiltonians by scalar values can be achieved by using `scale` and `*` and will dispatch into the new mechanism.

## Bug fixes
- Fixed a type stability bug in `Rimu.coherence`.